### PR TITLE
implement a Rest interface for SILO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/build/")
 # ---------------------------------------------------------------------------
 
 find_package(Boost REQUIRED COMPONENTS system serialization iostreams)
-find_package(Poco REQUIRED COMPONENTS Net Util)
+find_package(Poco REQUIRED COMPONENTS Net Util JSON)
 find_package(LibLZMA REQUIRED)
 find_package(TBB REQUIRED)
 find_package(RapidJSON REQUIRED INTERFACE)
@@ -74,7 +74,7 @@ add_executable(silo src/main.cpp)
 target_link_libraries(silo PUBLIC siloapi)
 
 add_executable(siloWebApi src/api.cpp)
-target_link_libraries(siloWebApi PUBLIC siloapi Poco::Net Poco::Util)
+target_link_libraries(siloWebApi PUBLIC siloapi Poco::Net Poco::Util Poco::JSON)
 
 # ---------------------------------------------------------------------------
 # Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/build/")
 # ---------------------------------------------------------------------------
 
 find_package(Boost REQUIRED COMPONENTS system serialization iostreams)
+find_package(Poco REQUIRED COMPONENTS Net Util)
 find_package(LibLZMA REQUIRED)
 find_package(TBB REQUIRED)
 find_package(RapidJSON REQUIRED INTERFACE)
@@ -72,6 +73,8 @@ target_link_libraries(siloapi PUBLIC ${Boost_LIBRARIES} TBB::tbb ${readline_LIBR
 add_executable(silo src/main.cpp)
 target_link_libraries(silo PUBLIC siloapi)
 
+add_executable(siloWebApi src/api.cpp)
+target_link_libraries(siloWebApi PUBLIC siloapi Poco::Net Poco::Util)
 
 # ---------------------------------------------------------------------------
 # Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ RUN \
     --mount=type=cache,target=build/.cmake \
     cmake --build build
 
-RUN cp build/silo . && cp testBaseData/* .
+RUN cp build/siloWebApi . && cp testBaseData/* .
 
-CMD ["./siloWebApi", "api"]
+CMD ["./siloWebApi", "--api"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apk update && \
         libtbb-dev=2021.7.0-r0 \
         readline-dev=8.2.0-r0 \
         xz-dev=5.2.9-r0 \
-        rapidjson-dev=1.1.0-r4
+        rapidjson-dev=1.1.0-r4 \
+        poco-dev=1.12.2-r1
 
 WORKDIR /src
 COPY . .
@@ -24,4 +25,4 @@ RUN \
 
 RUN cp build/silo . && cp testBaseData/* .
 
-CMD ["./silo"]
+CMD ["./siloWebApi", "api"]

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -4,6 +4,7 @@ onetbb/2021.7.0
 readline/8.1.2
 xz_utils/5.4.0
 rapidjson/cci.20220822
+poco/1.12.4
 
 [generators]
 cmake_find_package
@@ -44,3 +45,23 @@ boost:without_thread=True
 boost:without_timer=True
 boost:without_type_erasure=True
 boost:without_wave=True
+
+poco:shared=False
+poco:enable_json=True
+poco:enable_net=True
+poco:enable_util=True
+
+poco:enable_crypto=False
+poco:enable_activerecord=False
+poco:enable_active_record=False
+poco:enable_data=False
+poco:enable_data_mysql=False
+poco:enable_data_postgresql=False
+poco:enable_data_sqlite=False
+poco:enable_encodings=False
+poco:enable_jwt=False
+poco:enable_mongodb=False
+poco:enable_netssl=False
+poco:enable_redis=False
+poco:enable_xml=False
+poco:enable_zip=False

--- a/include/silo/database.h
+++ b/include/silo/database.h
@@ -48,6 +48,12 @@ struct pango_descriptor_t {
    std::vector<pango_t> pangos;
 };
 
+struct db_info_t {
+   uint32_t sequence_count;
+   uint64_t total_size;
+   size_t N_bitmaps_size;
+};
+
 class DatabasePartition {
    friend class Database;
    friend class boost::serialization::access;
@@ -122,7 +128,7 @@ class Database {
 
    void build(const std::string& part_prefix, const std::string& meta_suffix, const std::string& seq_suffix, std::ostream& out);
    // void analyse();
-   int db_info(std::ostream& io);
+   silo::db_info_t get_db_info();
    int db_info_detailed(std::ostream& io);
    void print_flipped(std::ostream& io);
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1,8 +1,5 @@
 
-#include "../include/silo/database.h"
-#include "Poco/DateTimeFormat.h"
-#include "Poco/DateTimeFormatter.h"
-#include "Poco/Exception.h"
+#include "Poco/JSON/Object.h"
 #include "Poco/Net/HTTPRequestHandler.h"
 #include "Poco/Net/HTTPRequestHandlerFactory.h"
 #include "Poco/Net/HTTPServer.h"
@@ -10,55 +7,17 @@
 #include "Poco/Net/HTTPServerRequest.h"
 #include "Poco/Net/HTTPServerResponse.h"
 #include "Poco/Net/ServerSocket.h"
-#include "Poco/ThreadPool.h"
-#include "Poco/Timestamp.h"
+#include "Poco/StreamCopier.h"
 #include "Poco/Util/HelpFormatter.h"
 #include "Poco/Util/Option.h"
 #include "Poco/Util/OptionSet.h"
 #include "Poco/Util/ServerApplication.h"
+#include "silo/database.h"
+#include "silo/query_engine/query_engine.h"
 #include <iostream>
 #include <vector>
-#include <silo/database.h>
-#include <silo/query_engine/query_engine.h>
 
 using namespace silo;
-
-//int handle_command(Database& db, std::vector<std::string> args) {
-//   if ("info" == args[0]) {
-//      if (args.size() > 1) {
-//         std::ofstream out(args[1]);
-//         if (!out) {
-//            std::cout << "Could not open outfile " << args[1] << endl;
-//            return 0;
-//         }
-//         db.db_info(out);
-//      } else {
-//         db.db_info(std::cout);
-//      }
-//   } else if ("query" == args[0]) {
-//      if (args.size() < 2) {
-//         std::cout << "Expected syntax: \"query <JSON_QUERY> [query_dir]\"" << endl;
-//         return 0;
-//      }
-//      std::string test_name = args[1];
-//
-//      std::string query_dir_str = args.size() > 2 ? args[2] : default_query_dir;
-//
-//      std::ifstream query_file(query_dir_str + test_name);
-//      if (!query_file || !query_file.good()) {
-//         std::cerr << "query_file " << (query_dir_str + test_name) << " not found." << std::endl;
-//         return 0;
-//      }
-//
-//      std::stringstream buffer;
-//      buffer << query_file.rdbuf();
-//
-//      std::string query = "{\"action\": {\"type\": \"Aggregated\"" /*,\"groupByFields\": [\"date\",\"division\"]*/ "},\"filter\": " + buffer.str() + "}";
-//      execute_query(db, query, std::cout, std::cout, std::cout);
-//      query = "{\"action\": {\"type\": \"Mutations\"},\"filter\": " + buffer.str() + "}";
-//      execute_query(db, query, std::cout, std::cout, std::cout);
-//   }
-//}
 
 class QueryRequestHandler : public Poco::Net::HTTPRequestHandler {
    private:
@@ -68,9 +27,33 @@ class QueryRequestHandler : public Poco::Net::HTTPRequestHandler {
    explicit QueryRequestHandler(const std::shared_ptr<silo::Database>& database) : database(database) {
    }
 
-   void handleRequest(Poco::Net::HTTPServerRequest&, Poco::Net::HTTPServerResponse& response) override {
-      std::ostream& out_stream = response.send();
-      out_stream << "TODO query";
+   void handleRequest(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response) override {
+      std::string query;
+      std::istream& istream = request.stream();
+      Poco::StreamCopier::copyToString(istream, query);
+
+      response.setContentType("application/json");
+
+      try {
+         const result_s& query_result = silo::execute_query(*database, query, std::cout, std::cout, std::cout);
+
+         std::ostream& out_stream = response.send();
+         Poco::JSON::Object output;
+         output.set("result", query_result.return_message);
+         output.stringify(out_stream);
+      } catch (const silo::QueryParseException& ex) {
+         response.setStatus(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+         std::ostream& out_stream = response.send();
+         Poco::JSON::Object output;
+         output.set("error", ex.what());
+         output.stringify(out_stream);
+      } catch (const std::exception& ex) {
+         response.setStatus(Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR);
+         std::ostream& out_stream = response.send();
+         Poco::JSON::Object output;
+         output.set("error", ex.what());
+         output.stringify(out_stream);
+      }
    }
 };
 
@@ -83,9 +66,26 @@ class InfoHandler : public Poco::Net::HTTPRequestHandler {
    }
 
    void handleRequest(Poco::Net::HTTPServerRequest&, Poco::Net::HTTPServerResponse& response) override {
-      response.setContentType("text/text");
+      const auto db_info = database->get_db_info();
+
+      response.setContentType("application/json");
       std::ostream& out_stream = response.send();
-      out_stream << "TODO info";
+      Poco::JSON::Object output;
+      output.set("sequenceCount", db_info.sequence_count);
+      output.set("totalSize", db_info.total_size);
+      output.set("nBitmapsSize", db_info.N_bitmaps_size);
+      output.stringify(out_stream);
+   }
+};
+
+class NotFoundHandler : public Poco::Net::HTTPRequestHandler {
+   void handleRequest(Poco::Net::HTTPServerRequest&, Poco::Net::HTTPServerResponse& response) override {
+      response.setContentType("application/json");
+      response.setStatus(Poco::Net::HTTPResponse::HTTP_NOT_FOUND);
+      std::ostream& out_stream = response.send();
+      Poco::JSON::Object output;
+      output.set("error", "not found");
+      output.stringify(out_stream);
    }
 };
 
@@ -103,67 +103,79 @@ class SiloRequestHandlerFactory : public Poco::Net::HTTPRequestHandlerFactory {
       if (request.getURI() == "/query")
          return new QueryRequestHandler(database);
       else
-         return nullptr;
+         return new NotFoundHandler;
    }
 };
 
 class SiloServer : public Poco::Util::ServerApplication {
-   public:
    protected:
-   //   void initialize(Application& self) override {
-   //      loadConfiguration(); // load default configuration files, if present
-   //      ServerApplication::initialize(self);
-   //   }
-   //
-   //   void uninitialize() override {
-   //      ServerApplication::uninitialize();
-   //   }
+   void defineOptions(Poco::Util::OptionSet& options) override {
+      ServerApplication::defineOptions(options);
 
-   //   void defineOptions(OptionSet& options) {
-   //      ServerApplication::defineOptions(options);
-   //
-   //      options.addOption(
-   //         Option("help", "h", "display help information on command line arguments")
-   //            .required(false)
-   //            .repeatable(false));
-   //   }
-   //
-   //   void handleOption(const std::string& name, const std::string& value) {
-   //      ServerApplication::handleOption(name, value);
-   //
-   //      if (name == "help")
-   //         _helpRequested = true;
-   //   }
+      options.addOption(
+         Poco::Util::Option("help", "h", "display help information on command line arguments")
+            .required(false)
+            .repeatable(false)
+            .callback(Poco::Util::OptionCallback<SiloServer>(this, &SiloServer::displayHelp)));
 
-   void displayHelp() {
-      //      HelpFormatter helpFormatter(options());
-      //      helpFormatter.setCommand(commandName());
-      //      helpFormatter.setUsage("OPTIONS");
-      //      helpFormatter.setHeader("A web server that serves the current date and time.");
-      //      helpFormatter.format(std::cout);
+      options.addOption(
+         Poco::Util::Option("api", "a", "start the SILO web interface")
+            .required(false)
+            .repeatable(false)
+            .callback(Poco::Util::OptionCallback<SiloServer>(this, &SiloServer::handleApi)));
+
+      options.addOption(
+         Poco::Util::Option(
+            "processData",
+            "p",
+            "trigger the preprocessing pipeline to generate a partitioned dataset that can be read by the database")
+            .required(false)
+            .repeatable(false)
+            .callback(Poco::Util::OptionCallback<SiloServer>(this, &SiloServer::handleProcessData)));
    }
 
    int main(const std::vector<std::string>& args) override {
-      if (args.empty() || args.at(0) != "api") {
+      if (args.empty()) {
          return Application::EXIT_OK;
       }
+
+      std::cout << "Found unknown arguments:" << std::endl;
+      for (const auto& arg : args) {
+         std::cout << arg << std::endl;
+      }
+
+      displayHelp("", "");
+
+      return Application::EXIT_USAGE;
+   }
+
+   private:
+   void handleApi(const std::string&, const std::string&) {
+      int port = 8080;
+
       const char* working_directory = "./";
       auto database = std::make_shared<silo::Database>(working_directory);
 
-      //      int maxQueued = config().getInt("SiloServer.maxQueued", 100);
-      //      int maxThreads = config().getInt("SiloServer.maxThreads", 16);
-      //      Poco::ThreadPool::defaultPool().addCapacity(maxThreads);
+      Poco::Net::ServerSocket server_socket(port);
+      Poco::Net::HTTPServer server(new SiloRequestHandlerFactory(database), server_socket, new Poco::Net::HTTPServerParams);
 
-      auto* parameters = new Poco::Net::HTTPServerParams;
-      //      parameters->setMaxQueued(maxQueued);
-      //      parameters->setMaxThreads(maxThreads);
+      std::cout << "listening on port " << port << std::endl;
 
-      Poco::Net::ServerSocket server_socket(8080);
-      Poco::Net::HTTPServer server(new SiloRequestHandlerFactory(database), server_socket, parameters);
       server.start();
       waitForTerminationRequest();
       server.stop();
-      return Application::EXIT_OK;
+   };
+
+   void handleProcessData(const std::string&, const std::string&) {
+      std::cout << "handleProcessData is not implemented" << std::endl;
+   };
+
+   void displayHelp(const std::string&, const std::string&) {
+      Poco::Util::HelpFormatter helpFormatter(options());
+      helpFormatter.setCommand(commandName());
+      helpFormatter.setUsage("OPTIONS");
+      helpFormatter.setHeader("SILO - Sequence Indexing engine for Large Order of genomic data");
+      helpFormatter.format(std::cout);
    }
 };
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1,0 +1,173 @@
+
+#include "../include/silo/database.h"
+#include "Poco/DateTimeFormat.h"
+#include "Poco/DateTimeFormatter.h"
+#include "Poco/Exception.h"
+#include "Poco/Net/HTTPRequestHandler.h"
+#include "Poco/Net/HTTPRequestHandlerFactory.h"
+#include "Poco/Net/HTTPServer.h"
+#include "Poco/Net/HTTPServerParams.h"
+#include "Poco/Net/HTTPServerRequest.h"
+#include "Poco/Net/HTTPServerResponse.h"
+#include "Poco/Net/ServerSocket.h"
+#include "Poco/ThreadPool.h"
+#include "Poco/Timestamp.h"
+#include "Poco/Util/HelpFormatter.h"
+#include "Poco/Util/Option.h"
+#include "Poco/Util/OptionSet.h"
+#include "Poco/Util/ServerApplication.h"
+#include <iostream>
+#include <vector>
+#include <silo/database.h>
+#include <silo/query_engine/query_engine.h>
+
+using namespace silo;
+
+//int handle_command(Database& db, std::vector<std::string> args) {
+//   if ("info" == args[0]) {
+//      if (args.size() > 1) {
+//         std::ofstream out(args[1]);
+//         if (!out) {
+//            std::cout << "Could not open outfile " << args[1] << endl;
+//            return 0;
+//         }
+//         db.db_info(out);
+//      } else {
+//         db.db_info(std::cout);
+//      }
+//   } else if ("query" == args[0]) {
+//      if (args.size() < 2) {
+//         std::cout << "Expected syntax: \"query <JSON_QUERY> [query_dir]\"" << endl;
+//         return 0;
+//      }
+//      std::string test_name = args[1];
+//
+//      std::string query_dir_str = args.size() > 2 ? args[2] : default_query_dir;
+//
+//      std::ifstream query_file(query_dir_str + test_name);
+//      if (!query_file || !query_file.good()) {
+//         std::cerr << "query_file " << (query_dir_str + test_name) << " not found." << std::endl;
+//         return 0;
+//      }
+//
+//      std::stringstream buffer;
+//      buffer << query_file.rdbuf();
+//
+//      std::string query = "{\"action\": {\"type\": \"Aggregated\"" /*,\"groupByFields\": [\"date\",\"division\"]*/ "},\"filter\": " + buffer.str() + "}";
+//      execute_query(db, query, std::cout, std::cout, std::cout);
+//      query = "{\"action\": {\"type\": \"Mutations\"},\"filter\": " + buffer.str() + "}";
+//      execute_query(db, query, std::cout, std::cout, std::cout);
+//   }
+//}
+
+class QueryRequestHandler : public Poco::Net::HTTPRequestHandler {
+   private:
+   std::shared_ptr<silo::Database> database{};
+
+   public:
+   explicit QueryRequestHandler(const std::shared_ptr<silo::Database>& database) : database(database) {
+   }
+
+   void handleRequest(Poco::Net::HTTPServerRequest&, Poco::Net::HTTPServerResponse& response) override {
+      std::ostream& out_stream = response.send();
+      out_stream << "TODO query";
+   }
+};
+
+class InfoHandler : public Poco::Net::HTTPRequestHandler {
+   private:
+   std::shared_ptr<silo::Database> database{};
+
+   public:
+   explicit InfoHandler(const std::shared_ptr<silo::Database>& database) : database(database) {
+   }
+
+   void handleRequest(Poco::Net::HTTPServerRequest&, Poco::Net::HTTPServerResponse& response) override {
+      response.setContentType("text/text");
+      std::ostream& out_stream = response.send();
+      out_stream << "TODO info";
+   }
+};
+
+class SiloRequestHandlerFactory : public Poco::Net::HTTPRequestHandlerFactory {
+   private:
+   std::shared_ptr<silo::Database> database{};
+
+   public:
+   explicit SiloRequestHandlerFactory(const std::shared_ptr<silo::Database>& database) : database(database) {
+   }
+
+   Poco::Net::HTTPRequestHandler* createRequestHandler(const Poco::Net::HTTPServerRequest& request) override {
+      if (request.getURI() == "/info")
+         return new InfoHandler(database);
+      if (request.getURI() == "/query")
+         return new QueryRequestHandler(database);
+      else
+         return nullptr;
+   }
+};
+
+class SiloServer : public Poco::Util::ServerApplication {
+   public:
+   protected:
+   //   void initialize(Application& self) override {
+   //      loadConfiguration(); // load default configuration files, if present
+   //      ServerApplication::initialize(self);
+   //   }
+   //
+   //   void uninitialize() override {
+   //      ServerApplication::uninitialize();
+   //   }
+
+   //   void defineOptions(OptionSet& options) {
+   //      ServerApplication::defineOptions(options);
+   //
+   //      options.addOption(
+   //         Option("help", "h", "display help information on command line arguments")
+   //            .required(false)
+   //            .repeatable(false));
+   //   }
+   //
+   //   void handleOption(const std::string& name, const std::string& value) {
+   //      ServerApplication::handleOption(name, value);
+   //
+   //      if (name == "help")
+   //         _helpRequested = true;
+   //   }
+
+   void displayHelp() {
+      //      HelpFormatter helpFormatter(options());
+      //      helpFormatter.setCommand(commandName());
+      //      helpFormatter.setUsage("OPTIONS");
+      //      helpFormatter.setHeader("A web server that serves the current date and time.");
+      //      helpFormatter.format(std::cout);
+   }
+
+   int main(const std::vector<std::string>& args) override {
+      if (args.empty() || args.at(0) != "api") {
+         return Application::EXIT_OK;
+      }
+      const char* working_directory = "./";
+      auto database = std::make_shared<silo::Database>(working_directory);
+
+      //      int maxQueued = config().getInt("SiloServer.maxQueued", 100);
+      //      int maxThreads = config().getInt("SiloServer.maxThreads", 16);
+      //      Poco::ThreadPool::defaultPool().addCapacity(maxThreads);
+
+      auto* parameters = new Poco::Net::HTTPServerParams;
+      //      parameters->setMaxQueued(maxQueued);
+      //      parameters->setMaxThreads(maxThreads);
+
+      Poco::Net::ServerSocket server_socket(8080);
+      Poco::Net::HTTPServer server(new SiloRequestHandlerFactory(database), server_socket, parameters);
+      server.start();
+      waitForTerminationRequest();
+      server.stop();
+      return Application::EXIT_OK;
+   }
+};
+
+int main(int argc, char** argv) {
+   SiloServer app;
+   return app.run(argc, argv);
+}

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -56,7 +56,10 @@ void silo::Database::build(const std::string& part_prefix, const std::string& me
    }
    out << "Build took " << std::to_string(micros) << "seconds." << std::endl;
    out << "Info directly after build: " << std::endl;
-   db_info(out);
+   const auto info = get_db_info();
+   out << "Sequence count: " << info.sequence_count << std::endl;
+   out << "Total size: " << info.total_size << std::endl;
+   out << "N_bitmaps per sequence, total size: " << number_fmt(info.N_bitmaps_size) << std::endl;
    db_info_detailed(out);
    {
       BlockTimer timer(micros);
@@ -197,7 +200,7 @@ static inline void addStat(r_stat& r1, const r_stat& r2) {
    r1.sum_value += r2.sum_value;
 }
 
-int silo::Database::db_info(std::ostream& io) {
+silo::db_info_t silo::Database::get_db_info() {
    std::atomic<uint32_t> sequence_count = 0;
    std::atomic<uint64_t> total_size = 0;
    std::atomic<size_t> N_bitmaps_size = 0;
@@ -210,11 +213,7 @@ int silo::Database::db_info(std::ostream& io) {
       }
    });
 
-   std::osyncstream(io) << "sequence count: " << number_fmt(sequence_count) << std::endl;
-   std::osyncstream(io) << "total size: " << number_fmt(total_size) << std::endl;
-   std::osyncstream(io) << "N_bitmaps per sequence, total size: " << number_fmt(N_bitmaps_size) << std::endl;
-
-   return 0;
+   return silo::db_info_t{sequence_count, total_size, N_bitmaps_size};
 }
 
 void silo::Database::indexAllN() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,17 +97,6 @@ int handle_command(Database& db, std::vector<std::string> args) {
       }
       auto sequence_out = args.size() > 3 ? std::ofstream(args[3]) : std::ofstream(default_sequence_input + ".repair");
       prune_sequences(meta_input, sequence_input.get_is(), sequence_out);
-   } else if ("info" == args[0]) {
-      if (args.size() > 1) {
-         std::ofstream out(args[1]);
-         if (!out) {
-            std::cout << "Could not open outfile " << args[1] << endl;
-            return 0;
-         }
-         db.db_info(out);
-      } else {
-         db.db_info(std::cout);
-      }
    } else if ("info_d" == args[0]) {
       if (args.size() > 1) {
          std::ofstream out(args[1]);

--- a/src/query_engine/query_engine.cpp
+++ b/src/query_engine/query_engine.cpp
@@ -1,11 +1,13 @@
 
 
 #include "silo/query_engine/query_engine.h"
-#include "rapidjson/document.h"
 #include "tbb/parallel_for.h"
 #include "tbb/parallel_for_each.h"
 #include <silo/common/PerfEvent.hpp>
 #include <syncstream>
+
+#define RAPIDJSON_ASSERT(x) if (!(x)) throw silo::QueryParseException("The query was not a valid JSON: " + std::string(RAPIDJSON_STRINGIFY(x)))
+#include "rapidjson/document.h"
 
 namespace silo {
 


### PR DESCRIPTION
resolves #2 

This is more an MVP than a fully functional solution. It's possible to communicate with SILO via HTTP requests, but:
- handling JSON is quite exhausting in C++. We should think of something how to simplify serializing structs. I didn't find anything premade yet. One always has to build JSON objects by hand. Luckily Poco can serialize those objects into JSON then. #21 
- The interface needs to be hardened: /query should only accept POST requests. If something goes wrong, the application will terminate. #14
- We should not use `assert` as it terminates the application on failure #15
- The current `main.cpp` should be deleted and the relevant content should be migrated to `--processData` of the `api.cpp`. #16
- We should decide what we want to do with the "info_d" command #18 
- We should implement proper logging in a file instead of to stdout #19
- Poco offers quite some options to configure the App (including loading the configuration from a file). We should check whether we need to tweak the App a bit by using more threads and such as [in this example](https://github.com/pocoproject/poco/blob/feb1e24cfdfe0c1e1b636eee8b63f98d95c9f817/Net/samples/HTTPTimeServer/src/HTTPTimeServer.cpp#L189)

Also finding a suitable library for an HTTP interface was quite hard. We decided against boost, since it's too low level. There are a lot of outdated and unmaintained frameworks around, and there are some alternatives in C which also seem very low level. Poco seemed to be the only viable alternative