### PR TITLE
reduce size of Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,8 @@
 *
 !CMakeLists.txt
+!build_with_conan.sh
+!conanprofile.docker
+!conanfile.txt
 !src/
 !include/
 !testBaseData/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Docker metadata
+      -
+        uses: actions/checkout@v3
+      -
+        name: Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -22,49 +24,73 @@ jobs:
           tags: |
             type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-      - name: Set up Docker Buildx
+      -
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Login to GitHub Container Registry
+      -
+        name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
+      -
+        name: Build and push unit test image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false
+          target: builder
+          tags: unittests:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=docker,dest=/tmp/unitTestsImage.tar
+      -
+        name: Temporarily store unit test image
+        uses: actions/upload-artifact@v2
+        with:
+          name: unitTestsImage
+          path: /tmp/unitTestsImage.tar
+      -
+        name: Build and push production image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   unitTests:
     name: Run unit tests
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.DOCKER_IMAGE_NAME }}
-          tags: type=ref,event=branch
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Wait for Docker Image
+      -
+        uses: actions/checkout@v3
+      -
+        name: Wait for Docker Image
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ github.ref }}
           check-name: 'Build Docker Image'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run tests
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: unitTestsImage
+          path: /tmp
+      -
+        name: Load Docker image
+        run: |
+          docker load --input /tmp/unitTestsImage.tar
+          docker image ls -a
+      -
+        name: Run tests
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ steps.meta.outputs.tags }}
+          image: unittests
           run: ./silo_test
 
   endToEndTests:
@@ -72,32 +98,41 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
+      -
+        uses: actions/checkout@v3
+      -
+        name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - uses: actions/cache@v3
+      -
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-      - name: npm install
+      -
+        name: npm install
         run: cd endToEndTests && npm ci
-      - name: Check Format
+      -
+        name: Check Format
         run: cd endToEndTests && npm run check-format
-      - name: Docker Metadata
+      -
+        name: Docker Metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.DOCKER_IMAGE_NAME }}
           tags: type=ref,event=branch
-      - name: Wait for Docker Image
+      -
+        name: Wait for Docker Image
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ github.ref }}
           check-name: 'Build Docker Image'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Start Docker Container
+      -
+        name: Start Docker Container
         run: docker run -p 8080:8080 -d ${{ steps.meta.outputs.tags }}
-      - name: Run Tests
+      -
+        name: Run Tests
         run: cd endToEndTests && SILO_URL=localhost:8080 npm run test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 set(CMAKE_CXX_FLAGS "-Wall")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -static-libstdc++ -static-libgcc")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/build/")
@@ -25,15 +25,6 @@ find_package(LibLZMA REQUIRED)
 find_package(TBB REQUIRED)
 find_package(RapidJSON REQUIRED INTERFACE)
 find_package(nlohmann_json REQUIRED)
-
-# workaround: conans readline is different from apk readline
-# Remove when readline is no longer needed
-# TODO: #16 Implement reading database data in SILO API
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    find_package(readline REQUIRED)
-else ()
-    set(readline_LIBRARIES readline)
-endif ()
 
 # ---------------------------------------------------------------------------
 # Includes
@@ -73,10 +64,7 @@ file(GLOB SRC_API_CC "src/silo_api/*")
 list(REMOVE_ITEM SRC_API_CC ${SRC_TEST})
 
 add_library(siloapi ${SRC_CC})
-target_link_libraries(siloapi PUBLIC ${Boost_LIBRARIES} TBB::tbb ${readline_LIBRARIES})
-
-add_executable(silo src/main.cpp)
-target_link_libraries(silo PUBLIC siloapi)
+target_link_libraries(siloapi PUBLIC ${Boost_LIBRARIES} TBB::tbb)
 
 add_executable(siloWebApi src/api.cpp ${SRC_API_CC})
 target_link_libraries(siloWebApi PUBLIC siloapi Poco::Net Poco::Util Poco::JSON nlohmann_json::nlohmann_json)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,11 +63,11 @@ set(SRC_CC
 file(GLOB SRC_API_CC "src/silo_api/*")
 list(REMOVE_ITEM SRC_API_CC ${SRC_TEST})
 
-add_library(siloapi ${SRC_CC})
-target_link_libraries(siloapi PUBLIC ${Boost_LIBRARIES} TBB::tbb)
+add_library(silo ${SRC_CC})
+target_link_libraries(silo PUBLIC ${Boost_LIBRARIES} TBB::tbb)
 
-add_executable(siloWebApi src/api.cpp ${SRC_API_CC})
-target_link_libraries(siloWebApi PUBLIC siloapi Poco::Net Poco::Util Poco::JSON nlohmann_json::nlohmann_json)
+add_executable(siloApi src/api.cpp ${SRC_API_CC})
+target_link_libraries(siloApi PUBLIC silo Poco::Net Poco::Util Poco::JSON nlohmann_json::nlohmann_json)
 
 # ---------------------------------------------------------------------------
 # Tests
@@ -82,4 +82,4 @@ add_executable(silo_test ${SRC_TEST} ${SRC_API_CC})
 if(NOT GTest_LIBRARIES)
     set(GTest_LIBRARIES gtest gmock)
 endif()
-target_link_libraries(silo_test ${GTest_LIBRARIES} siloapi Poco::Net Poco::Util Poco::JSON nlohmann_json::nlohmann_json)
+target_link_libraries(silo_test ${GTest_LIBRARIES} silo Poco::Net Poco::Util Poco::JSON nlohmann_json::nlohmann_json)

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,6 @@ RUN apk update && apk add libtbb=2021.7.0-r0
 
 WORKDIR /app
 COPY testBaseData .
-COPY --from=build /src/build/siloWebApi .
+COPY --from=build /src/build/siloApi .
 
-CMD ["./siloWebApi", "--api"]
+CMD ["./siloApi", "--api"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM alpine:3.17.0 AS build
+FROM alpine:3.17.0 AS builder
 
 RUN apk update && apk add --no-cache py3-pip \
     build-base=0.5-r3 \
     cmake=3.24.3-r0 \
     linux-headers=5.19.5-r0 \
-    boost-build=1.79.0-r0
+    boost-build=1.79.0-r0 \
+    libtbb=2021.7.0-r0
 
 RUN pip install conan==1.59.0
 
@@ -16,9 +17,11 @@ RUN --mount=type=cache,target=/root/.conan conan install . --build=missing --pro
 
 RUN  \
     --mount=type=cache,target=/root/.conan \
-    --mount=type=cache,target=build/CMakeFiles \
-    --mount=type=cache,target=build/.cmake \
-    ash ./build_with_conan.sh release
+    --mount=type=cache,target=build \
+    --mount=type=cache,target=build \
+    ash ./build_with_conan.sh release \
+    && cp build/silo_test . \
+    && cp build/siloApi .
 
 
 FROM alpine:3.17.0 AS server
@@ -27,6 +30,6 @@ RUN apk update && apk add libtbb=2021.7.0-r0
 
 WORKDIR /app
 COPY testBaseData .
-COPY --from=build /src/build/siloApi .
+COPY --from=builder /src/siloApi .
 
 CMD ["./siloApi", "--api"]

--- a/README.md
+++ b/README.md
@@ -8,18 +8,10 @@ Original genome indexing logic with roaring bitmaps by Prof. Neumann: https://db
 # Building
 
 ## With Conan
-for local development (tested on Ubuntu 22.04.2 LTS):
-- requires: python3, pip3
+We use Conan to install dependencies for local development. See Dockerfile for how to set up Conan and its requirements.
+This has been tested on Ubuntu 22.04 and is not guaranteed to work on other systems.
 
-Install conan version 1.59.0. We use this version because TBB is not yet ported to version 2.0.   
-```shell
-pip3 install conan==1.59.0
-```
-Set path for pip (if not already set)
-```shell
-export PATH="$HOME/.local/bin:$PATH"
-```
-Get default profile (myProfile) of own system and write to `~/.conan/profiles/myProfile`
+The Conan profile (myProfile) on your system might differ: Create a new profile `~/.conan/profiles/myProfile`
 ```shell
 conan profile new myProfile --detect
 ```
@@ -29,10 +21,7 @@ Build silo in `./build`. This build will load and build the required libraries t
 ```shell
 ./build_with_conan
 ```
-Run silo
-```shell
-./build/silo
-```
+Executables are located in `build/` upon a successful build.
 
 ## With Docker:
 (for CI and release)

--- a/build_with_conan.sh
+++ b/build_with_conan.sh
@@ -2,8 +2,9 @@
 
 set -e
 
-if [ "$1" == "clean" ]
+if [[ "$*" == *"clean"* ]]
 then
+  echo "cleaning build directory..."
   rm -rf build
 fi
 mkdir -p build
@@ -18,7 +19,15 @@ echo "----------------------------------"
 echo "cmake -B build"
 echo "----------------------------------"
 
-cmake -B build
+
+if [[ "$*" == *"release"* ]]
+then
+  echo "triggered RELEASE build"
+  cmake -D CMAKE_BUILD_TYPE=Release -B build
+else
+  echo "triggered DEBUG build"
+  cmake -B build
+fi
 
 echo "----------------------------------"
 echo "cmake --build build"

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,6 @@
 [requires]
 boost/1.80.0
 onetbb/2021.7.0
-readline/8.1.2
 xz_utils/5.4.0
 rapidjson/cci.20220822
 poco/1.12.4

--- a/conanprofile.docker
+++ b/conanprofile.docker
@@ -1,0 +1,12 @@
+[settings]
+os=Linux
+os_build=Linux
+arch=x86_64
+arch_build=x86_64
+compiler=gcc
+compiler.libcxx=libstdc++11
+compiler.version=9.3
+build_type=Release
+[options]
+[build_requires]
+[env]

--- a/endToEndTests/test/queries/invalidAction.json
+++ b/endToEndTests/test/queries/invalidAction.json
@@ -1,5 +1,5 @@
 {
-  "testCaseName": "N-Of query requesting 2 of 3 mutations",
+  "testCaseName": "query with invalid action",
   "query": {
     "action": {
       "type": "invalid action"

--- a/endToEndTests/test/queries/invalidMutationsMinProportion.json
+++ b/endToEndTests/test/queries/invalidMutationsMinProportion.json
@@ -1,5 +1,5 @@
 {
-  "testCaseName": "N-Of query requesting 2 of 3 mutations",
+  "testCaseName": "query with unvalid minProportions in Mutations action",
   "query": {
     "action": {
       "type": "Mutations",

--- a/endToEndTests/test/queries/nOf_2of3_aggregated.json
+++ b/endToEndTests/test/queries/nOf_2of3_aggregated.json
@@ -1,5 +1,5 @@
 {
-  "testCaseName": "N-Of query requesting 2 of 3 mutations",
+  "testCaseName": "N-Of query requesting 2 of 3 mutations with aggregated action",
   "query": {
     "action": {
       "type": "Aggregated"

--- a/endToEndTests/test/queries/nOf_2of3_mutations.json
+++ b/endToEndTests/test/queries/nOf_2of3_mutations.json
@@ -1,5 +1,5 @@
 {
-  "testCaseName": "N-Of query requesting 2 of 3 mutations",
+  "testCaseName": "N-Of query requesting 2 of 3 mutations with mutations action",
   "query": {
     "action": {
       "type": "Mutations"


### PR DESCRIPTION
resolves #12 

previously: ~500 MB, now ~40MB
Also use Conan in the build stage of the Dockerfile and statically link libraries as far as possible. Only TBB strongly advices against statically linking it, so we kept the dynamic link there.