### PR TITLE
Use spdlog for logging

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,7 +19,7 @@ Checks: >
   -abseil-string-find-str-contains
 #  TODO(someone): clean up misc-non-private-member-variables-in-classes and add option back in
 # Not using google-readability-avoid-underscore-in-googletest-name because it also fails for test_name
-# Not using abseil-string-find-str-contains because we dont want to include more libraries
+# Not using abseil-string-find-str-contains because we don't want to include more libraries
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
   - { key: readability-identifier-naming.ClassCase,              value: CamelCase }

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 .DS_Store
 
+/logs/
+
 # Conan
 conanprofile
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,12 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/build/")
 
 # ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
+
+# ---------------------------------------------------------------------------
 # Dependencies
 # ---------------------------------------------------------------------------
 
@@ -25,6 +31,7 @@ find_package(TBB REQUIRED)
 find_package(RapidJSON REQUIRED INTERFACE)
 find_package(nlohmann_json REQUIRED)
 find_package(roaring REQUIRED)
+find_package(spdlog REQUIRED)
 
 # ---------------------------------------------------------------------------
 # Includes
@@ -69,10 +76,10 @@ endif ()
 # ---------------------------------------------------------------------------
 
 add_library(silo ${SRC_SILO_LIB})
-target_link_libraries(silo PUBLIC ${Boost_LIBRARIES} TBB::tbb ${roaring_LIBRARIES})
+target_link_libraries(silo PUBLIC ${Boost_LIBRARIES} TBB::tbb ${roaring_LIBRARIES} ${spdlog_LIBRARIES})
 
 add_executable(siloApi src/silo_api/api.cpp ${SRC_SILO_API})
-target_link_libraries(siloApi PUBLIC silo Poco::Net Poco::Util Poco::JSON nlohmann_json::nlohmann_json)
+target_link_libraries(siloApi PUBLIC silo Poco::Net Poco::Util Poco::JSON nlohmann_json::nlohmann_json ${spdlog_LIBRARIES})
 
 # ---------------------------------------------------------------------------
 # Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,5 @@ COPY --from=builder /src/siloApi .
 # call /info, extract "seqeunceCount" from the JSON and assert that the value is not 0. If any of those fails, "exit 1".
 HEALTHCHECK CMD curl --fail --silent localhost:8080/info | jq .sequenceCount | xargs test 0 -ne || exit 1
 
+ENV SPDLOG_LEVEL="off,file_logger=debug"
 CMD ["./siloApi", "--api"]

--- a/README.md
+++ b/README.md
@@ -64,14 +64,31 @@ build/silo_test
 ```
 
 For linting we use clang-tidy. The config is stored in `.clang-tidy`. It will run automatically with the build process
-and will throw errors accordingly. However it is rather slow. If you only want a fast build use
+and will throw errors accordingly. However, it is rather slow. If you only want a fast build use
 
 ```shell
 ./build_with_conan build_without_clang_tidy
 ```
 
-When pushing to github, a separate Docker image will be built, which runs the formatter. (This is a workaround, because
+When pushing to GitHub, a separate Docker image will be built, which runs the formatter. (This is a workaround, because
 building with clang-tidy under alpine was not possible yet.)
+
+# Logging
+
+We use [spdlog](https://github.com/gabime/spdlog) for logging. The log level and log target can be controlled via
+environment variables:
+
+* Start SILO with `SPDLOG_LEVEL=off,console_logger=debug` to log to stdout at debug level.
+* Start SILO with `SPDLOG_LEVEL=off,file_logger=trace` to log to daily rotating files in `log/` (relative from the
+  location where SILO is executed) at trace level.
+
+If `SPDLOG_LEVEL` is not set, SILO will log to the console at info level.
+
+We decided to use the macros provided by spdlog rather than the functions, because this lets us disable log statements
+at compile time by adjusting `add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)` to the desired log level
+via CMake. This might be desirable for benchmarking SILO. However, the default should be `SPDLOG_LEVEL_TRACE` to give
+the maintainer the possibility to adjust the log level to a log level that they prefer, without the need to recompile
+SILO.
 
 # Code Style Guidelines
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,8 @@ class SiloRecipe(ConanFile):
         "rapidjson/cci.20220822",
         "nlohmann_json/3.11.2",
         "gtest/cci.20210126",
-        "roaring/0.9.9"
+        "roaring/0.9.9",
+        "spdlog/1.11.0",
     ]
 
     default_options = {
@@ -89,4 +90,6 @@ class SiloRecipe(ConanFile):
         deps.set_property("gtest", "cmake_find_mode", "both")
         deps.set_property("pcre2", "cmake_find_mode", "both")
         deps.set_property("roaring", "cmake_find_mode", "both")
+        deps.set_property("spdlog", "cmake_find_mode", "both")
+        deps.set_property("fmt", "cmake_find_mode", "both")
         deps.generate()

--- a/include/silo/common/format_number.h
+++ b/include/silo/common/format_number.h
@@ -1,0 +1,12 @@
+#ifndef SILO_FORMAT_NUMBER_H
+#define SILO_FORMAT_NUMBER_H
+
+#include <string>
+
+namespace silo {
+
+std::string formatNumber(uint64_t number);
+
+}
+
+#endif  // SILO_FORMAT_NUMBER_H

--- a/include/silo/database.h
+++ b/include/silo/database.h
@@ -98,8 +98,7 @@ class Database {
    void build(
       const std::string& partition_name_prefix,
       const std::string& metadata_file_suffix,
-      const std::string& sequence_file_suffix,
-      std::ostream& out
+      const std::string& sequence_file_suffix
    );
 
    virtual silo::DatabaseInfo getDatabaseInfo();
@@ -124,7 +123,7 @@ class Database {
    std::unordered_map<std::string, std::string> alias_key;
 };
 
-unsigned fillSequenceStore(SequenceStore& seq_store, std::istream& input_file);
+unsigned fillSequenceStore(SequenceStore& sequence_store, std::istream& input_file);
 
 unsigned fillMetadataStore(
    MetadataStore& meta_store,
@@ -143,8 +142,6 @@ PangoLineageCounts loadPangoLineageCounts(std::istream& input_stream);
 void savePartitions(const Partitions& partitions, std::ostream& output_file);
 
 Partitions loadPartitions(std::istream& input_file);
-
-std::string formatNumber(uint64_t number);
 
 std::string resolvePangoLineageAlias(
    const std::unordered_map<std::string, std::string>& alias_key,

--- a/include/silo/prepare_dataset.h
+++ b/include/silo/prepare_dataset.h
@@ -11,15 +11,15 @@ struct Partitions;
 struct PangoLineageCounts;
 
 [[maybe_unused]] void pruneSequences(
-   std::istream& meta_in,
+   std::istream& metadata_in,
    std::istream& sequences_in,
    std::ostream& sequences_out
 );
 
 [[maybe_unused]] void pruneMetadata(
-   std::istream& meta_in,
+   std::istream& metadata_in,
    std::istream& sequences_in,
-   std::ostream& meta_out
+   std::ostream& metadata_out
 );
 
 PangoLineageCounts buildPangoLineageCounts(

--- a/include/silo/query_engine/query_engine.h
+++ b/include/silo/query_engine/query_engine.h
@@ -408,7 +408,6 @@ struct MutationProportion {
 response::QueryResult executeQuery(
    const Database& database,
    const std::string& query,
-   std::ostream& parse_out,
    std::ostream& perf_out
 );
 

--- a/include/silo/storage/sequence_store.h
+++ b/include/silo/storage/sequence_store.h
@@ -2,6 +2,7 @@
 #ifndef SILO_SEQUENCE_STORE_H
 #define SILO_SEQUENCE_STORE_H
 
+#include <spdlog/spdlog.h>
 #include <array>
 #include <boost/serialization/array.hpp>
 #include <roaring/roaring.hh>
@@ -27,6 +28,12 @@ struct Position {
    uint32_t flipped_bitmap = REFERENCE_BITMAP_IS_FLIPPED;
 
    bool nucleotide_symbol_n_indexed = false;
+};
+
+struct SequenceStoreInfo {
+   uint32_t sequence_count;
+   uint64_t size;
+   size_t n_bitmaps_size;
 };
 
 class SequenceStore {
@@ -68,7 +75,7 @@ class SequenceStore {
 
    void naiveIndexAllNucleotideSymbolN();
 
-   int databaseInfo(std::ostream& output_stream) const;
+   SequenceStoreInfo getInfo() const;
 };
 
 [[maybe_unused]] unsigned runOptimize(SequenceStore& sequence_store);
@@ -76,5 +83,13 @@ class SequenceStore {
 [[maybe_unused]] unsigned shrinkToFit(SequenceStore& sequence_store);
 
 }  // namespace silo
+
+template <>
+struct [[maybe_unused]] fmt::formatter<silo::SequenceStoreInfo> : fmt::formatter<std::string> {
+   [[maybe_unused]] static auto format(
+      silo::SequenceStoreInfo sequence_store_info,
+      format_context& ctx
+   ) -> decltype(ctx.out());
+};
 
 #endif  // SILO_SEQUENCE_STORE_H

--- a/include/silo_api/logging.h
+++ b/include/silo_api/logging.h
@@ -1,0 +1,6 @@
+#ifndef SILO_LOGGING_H
+#define SILO_LOGGING_H
+
+void setupLogger();
+
+#endif  // SILO_LOGGING_H

--- a/include/silo_api/request_handler.h
+++ b/include/silo_api/request_handler.h
@@ -1,0 +1,25 @@
+#ifndef SILO_REQUEST_HANDLER_H
+#define SILO_REQUEST_HANDLER_H
+
+#include <memory>
+
+#include <Poco/Net/HTTPRequestHandler.h>
+#include <Poco/Net/HTTPServerRequest.h>
+#include <Poco/Net/HTTPServerResponse.h>
+
+namespace silo_api {
+class LoggingRequestHandler : public Poco::Net::HTTPRequestHandler {
+  private:
+   std::unique_ptr<Poco::Net::HTTPRequestHandler> wrapped_handler;
+
+  public:
+   explicit LoggingRequestHandler(Poco::Net::HTTPRequestHandler* wrapped_handler);
+
+   void handleRequest(
+      Poco::Net::HTTPServerRequest& request,
+      Poco::Net::HTTPServerResponse& response
+   ) override;
+};
+}  // namespace silo_api
+
+#endif  // SILO_REQUEST_HANDLER_H

--- a/src/silo/common/format_number.cpp
+++ b/src/silo/common/format_number.cpp
@@ -1,0 +1,21 @@
+#include "silo/common/format_number.h"
+
+#include <filesystem>
+#include <string>
+
+namespace silo {
+
+struct ThousandSeparator : std::numpunct<char> {
+   [[nodiscard]] char_type do_thousands_sep() const override { return '\''; }
+   [[nodiscard]] string_type do_grouping() const override { return "\3"; }
+};
+
+std::string formatNumber(uint64_t number) {
+   std::ostringstream oss;
+   auto thousands = std::make_unique<ThousandSeparator>();
+   oss.imbue(std::locale(oss.getloc(), thousands.release()));
+   oss << number;
+   return oss.str();
+}
+
+}  // namespace silo

--- a/src/silo/query_engine/query_engine.cpp
+++ b/src/silo/query_engine/query_engine.cpp
@@ -18,6 +18,7 @@
       "The query was not a valid JSON: " + std::string(RAPIDJSON_STRINGIFY(x)) \
    )
 #include <rapidjson/document.h>
+#include <spdlog/spdlog.h>
 
 #include "external/PerfEvent.hpp"
 #include "silo/common/silo_symbols.h"
@@ -1181,7 +1182,6 @@ std::string NOfExpression::toString(const Database& database) {
 silo::response::QueryResult silo::executeQuery(
    const silo::Database& database,
    const std::string& query,
-   std::ostream& parse_out,
    std::ostream& perf_out
 ) {
    rapidjson::Document json_document;
@@ -1198,7 +1198,7 @@ silo::response::QueryResult silo::executeQuery(
    {
       BlockTimer const timer(query_result.parseTime);
       filter = parseExpression(database, json_document["filterExpression"], 0);
-      parse_out << "Parsed query: " << filter->toString(database) << std::endl;
+      SPDLOG_DEBUG("Parsed query: {}", filter->toString(database));
    }
 
    perf_out << "Parse: " << std::to_string(query_result.parseTime) << " microseconds\n";
@@ -1216,8 +1216,7 @@ silo::response::QueryResult silo::executeQuery(
       });
    }
    for (unsigned i = 0; i < database.partitions.size(); ++i) {
-      parse_out << "Simplified query for partition " << i << ": " << simplified_queries[i]
-                << std::endl;
+      SPDLOG_DEBUG("Simplified query for partition {}: {}", i, simplified_queries[i]);
    }
    perf_out << "Execution (filter): " << std::to_string(query_result.filterTime)
             << " microseconds\n";

--- a/src/silo/query_engine/query_simplification.cpp
+++ b/src/silo/query_engine/query_simplification.cpp
@@ -2,7 +2,6 @@
 
 #include <memory>
 #include <string>
-#include <syncstream>
 #include <vector>
 
 #include "silo/common/silo_symbols.h"

--- a/src/silo_api/api.cpp
+++ b/src/silo_api/api.cpp
@@ -12,12 +12,12 @@
 #include <Poco/Util/Option.h>
 #include <Poco/Util/OptionSet.h>
 #include <Poco/Util/ServerApplication.h>
-#include <spdlog/sinks/daily_file_sink.h>
 #include <spdlog/spdlog.h>
 
 #include "silo/database.h"
 #include "silo/preprocessing/preprocessing_config.h"
 #include "silo_api/info_handler.h"
+#include "silo_api/logging.h"
 #include "silo_api/not_found_handler.h"
 #include "silo_api/query_handler.h"
 #include "silo_api/request_handler.h"
@@ -137,26 +137,16 @@ class SiloServer : public Poco::Util::ServerApplication {
    }
 };
 
-static const int MAX_FILES_7 = 7;
-static const int AT_MIDNIGHT = 0;
-static const int AT_0_MINUTES = 0;
-static const std::chrono::duration<int64_t> FIVE_SECONDS = std::chrono::seconds(5);
-
-static const bool DONT_TRUNCATE = false;
-void setupLogger() {
-   auto daily_logger = spdlog::daily_logger_mt(
-      "daily_logger", "logs/silo.log", AT_MIDNIGHT, AT_0_MINUTES, DONT_TRUNCATE, MAX_FILES_7
-   );
-   daily_logger->set_level(spdlog::level::debug);
-   spdlog::flush_every(FIVE_SECONDS);
-   spdlog::set_default_logger(daily_logger);
-}
-
 int main(int argc, char** argv) {
    setupLogger();
 
    SPDLOG_INFO("Starting SILO");
 
    SiloServer app;
-   return app.run(argc, argv);
+   const auto return_code = app.run(argc, argv);
+
+   SPDLOG_INFO("Stopping SILO");
+   spdlog::default_logger()->flush();
+
+   return return_code;
 }

--- a/src/silo_api/logging.cpp
+++ b/src/silo_api/logging.cpp
@@ -1,0 +1,27 @@
+#include "silo_api/logging.h"
+
+#include <spdlog/cfg/env.h>
+#include <spdlog/sinks/daily_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+static const int MAX_FILES_7 = 7;
+static const int AT_MIDNIGHT = 0;
+static const int AT_0_MINUTES = 0;
+static const bool DONT_TRUNCATE = false;
+
+static const std::chrono::duration<int64_t> FIVE_SECONDS = std::chrono::seconds(5);
+
+void setupLogger() {
+   spdlog::cfg::load_env_levels();
+   spdlog::flush_every(FIVE_SECONDS);
+
+   auto file_logger = spdlog::daily_logger_mt(
+      "file_logger", "logs/silo.log", AT_MIDNIGHT, AT_0_MINUTES, DONT_TRUNCATE, MAX_FILES_7
+   );
+   auto console_logger = spdlog::stdout_color_mt("console_logger");
+
+   spdlog::set_default_logger(
+      file_logger->level() < console_logger->level() ? file_logger : console_logger
+   );
+}

--- a/src/silo_api/request_handler.cpp
+++ b/src/silo_api/request_handler.cpp
@@ -1,0 +1,24 @@
+#include "silo_api/request_handler.h"
+
+#include <Poco/Net/HTTPRequestHandler.h>
+#include <Poco/Net/HTTPServerRequest.h>
+#include <Poco/Net/HTTPServerResponse.h>
+#include <spdlog/spdlog.h>
+
+namespace silo_api {
+
+LoggingRequestHandler::LoggingRequestHandler(Poco::Net::HTTPRequestHandler* wrapped_handler)
+    : wrapped_handler(wrapped_handler){};
+
+void LoggingRequestHandler::handleRequest(
+   Poco::Net::HTTPServerRequest& request,
+   Poco::Net::HTTPServerResponse& response
+) {
+   SPDLOG_INFO("Handling {} {}", request.getMethod(), request.getURI());
+
+   wrapped_handler->handleRequest(request, response);
+
+   SPDLOG_INFO("Responding with status code {}", response.getStatus());
+}
+
+}  // namespace silo_api


### PR DESCRIPTION
This is a part of #19. The performance log statements are not yet migrated to spdlog, they are still written to std::cout. This will be done in a separate step. I would propose to log those log messages into a separate log file.