### PR TITLE
build: make healthcheck more robust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,13 @@ RUN apk update && apk add --no-cache py3-pip \
 RUN pip install conan==2.0.2
 
 WORKDIR /src
-COPY . .
-
+COPY conanfile.py conanprofile.docker .
 RUN mv conanprofile.docker conanprofile
+
 RUN --mount=type=cache,target=/root/.conan2 \
     conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build
+
+COPY . .
 
 RUN  \
     --mount=type=cache,target=/root/.conan2 \
@@ -33,7 +35,7 @@ COPY testBaseData .
 COPY --from=builder /src/siloApi .
 
 # call /info, extract "seqeunceCount" from the JSON and assert that the value is not 0. If any of those fails, "exit 1".
-HEALTHCHECK CMD curl --fail --silent localhost:8080/info | jq .sequenceCount | xargs test 0 -ne || exit 1
+HEALTHCHECK --start-period=20s CMD curl --fail --silent localhost:8080/info | jq .sequenceCount | xargs test 0 -ne || exit 1
 
 ENV SPDLOG_LEVEL="off,file_logger=debug"
 CMD ["./siloApi", "--api"]

--- a/Dockerfile_linter
+++ b/Dockerfile_linter
@@ -8,11 +8,13 @@ RUN apt update && apt install -y \
 RUN pip install conan==2.0.2
 
 WORKDIR /src
-COPY . .
-
+COPY conanfile.py conanprofile.docker .
 RUN mv conanprofile.docker conanprofile
+
 RUN --mount=type=cache,target=/root/.conan2 \
     conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build -s build_type=Debug
+
+COPY . .
 
 RUN  \
     --mount=type=cache,target=/root/.conan2 \


### PR DESCRIPTION
Apply a start period. Maybe this helps that starting the Container doesn't fail on the first try. Also improve caching of the Docker builds by introducing a separate layer that only contains Conan dependencies but none of our code.