### PR TITLE
test cases with camel case

### DIFF
--- a/src/silo/common/nucleotide_symbols.test.cpp
+++ b/src/silo/common/nucleotide_symbols.test.cpp
@@ -2,21 +2,21 @@
 
 #include <gtest/gtest.h>
 
-TEST(genome_symbol, enum_should_have_same_length_as_symbol_representation) {
+TEST(NucleotideSymbol, enumShouldHaveSameLengthAsSymbolRepresentation) {
    EXPECT_EQ(silo::SYMBOL_COUNT, silo::SYMBOL_REPRESENTATION.size());
 }
 
-TEST(genome_symbol, enum_should_have_same_length_as_array_of_symbols) {
+TEST(NucleotideSymbol, enumShouldHaveSameLengthAsArrayOfSymbols) {
    EXPECT_EQ(silo::SYMBOL_COUNT, silo::GENOME_SYMBOLS.size());
 }
 
-TEST(genome_symbol, genome_symbol_representation_works_as_intended) {
+TEST(NucleotideSymbol, genomeSymbolRepresentationAsString) {
    EXPECT_EQ(silo::genomeSymbolRepresentation(silo::NUCLEOTIDE_SYMBOL::GAP), "-");
    EXPECT_EQ(silo::genomeSymbolRepresentation(silo::NUCLEOTIDE_SYMBOL::A), "A");
    EXPECT_EQ(silo::genomeSymbolRepresentation(silo::NUCLEOTIDE_SYMBOL::N), "N");
 }
 
-TEST(genome_symbol, to_nucleotide_symbol_works_as_intended) {
+TEST(NucleotideSymbol, conversionFromCharacter) {
    EXPECT_EQ(silo::toNucleotideSymbol('.'), silo::NUCLEOTIDE_SYMBOL::GAP);
    EXPECT_EQ(silo::toNucleotideSymbol('-'), silo::NUCLEOTIDE_SYMBOL::GAP);
    EXPECT_EQ(silo::toNucleotideSymbol('A'), silo::NUCLEOTIDE_SYMBOL::A);

--- a/src/silo/common/resolve_alias.test.cpp
+++ b/src/silo/common/resolve_alias.test.cpp
@@ -14,7 +14,7 @@ class ResolveAliasTestFixture : public ::testing::TestWithParam<TestParameter> {
    const std::unordered_map<std::string, std::string> alias_map = {{"X", "A"}, {"XY", "A.1"}};
 };
 
-TEST_P(ResolveAliasTestFixture, should_return_expected_resolved_alias) {
+TEST_P(ResolveAliasTestFixture, shouldReturnExpectedResolvedAlias) {
    const auto test_parameter = GetParam();
 
    const auto result = silo::resolvePangoLineageAlias(alias_map, test_parameter.input);
@@ -24,7 +24,7 @@ TEST_P(ResolveAliasTestFixture, should_return_expected_resolved_alias) {
 
 // NOLINTNEXTLINE(readability-identifier-length)
 INSTANTIATE_TEST_SUITE_P(
-   resolve_alias_test,
+   ResolveAliasTest,
    ResolveAliasTestFixture,
    ::testing::Values(
       TestParameter{"", ""},

--- a/src/silo/database.test.cpp
+++ b/src/silo/database.test.cpp
@@ -20,7 +20,7 @@ silo::Database buildTestDatabase() {
    return database;
 };
 
-TEST(database_test, should_build_database_without_errors) {
+TEST(DatabaseTest, shouldBuildDatabaseWithoutErrors) {
    auto database{buildTestDatabase()};
 
    const auto simple_database_info = database.getDatabaseInfo();
@@ -29,7 +29,7 @@ TEST(database_test, should_build_database_without_errors) {
    EXPECT_EQ(simple_database_info.sequence_count, 100);
 }
 
-TEST(database_info_test, should_return_correct_database_info) {
+TEST(DatabaseTest, shouldReturnCorrectDatabaseInfo) {
    auto database{buildTestDatabase()};
 
    const auto detailed_info = database.detailedDatabaseInfo();

--- a/src/silo/preprocessing/preprocessing_exception.test.cpp
+++ b/src/silo/preprocessing/preprocessing_exception.test.cpp
@@ -6,6 +6,6 @@ void testFunction() {
    throw silo::PreprocessingException("SomeText");
 }
 
-TEST(preprocessing_exception, assert_that_it_throws) {
+TEST(PreprocessingException, assertThatItThrows) {
    EXPECT_THROW(testFunction(), silo::PreprocessingException);
 }

--- a/src/silo/query_engine/query_engine.cpp
+++ b/src/silo/query_engine/query_engine.cpp
@@ -1,7 +1,6 @@
 #include "silo/query_engine/query_engine.h"
 
 #include <tbb/parallel_for.h>
-#include <tbb/parallel_for_each.h>
 #include <cassert>
 #include <memory>
 #include <roaring/roaring.hh>

--- a/src/silo/storage/position.test.cpp
+++ b/src/silo/storage/position.test.cpp
@@ -21,14 +21,14 @@ void deserializeFromFile(const std::string& filename, silo::Position& position) 
    input_file.close();
 }
 
-TEST(position, should_serialize_and_deserialize_postions_with_unset_optional) {
+TEST(Position, shouldSerializeAndDeserializePositionsWithEmptyOptional) {
    const std::string test_file = "test.bin";
 
    silo::Position const position_with_unset_optional;
-   ASSERT_NO_THROW(serializeToFile(test_file, position_with_unset_optional));
+   serializeToFile(test_file, position_with_unset_optional);
 
    silo::Position deserialized_position;
-   ASSERT_NO_THROW(deserializeFromFile(test_file, deserialized_position));
+   deserializeFromFile(test_file, deserialized_position);
 
    EXPECT_FALSE(position_with_unset_optional.symbol_whose_bitmap_is_flipped.has_value());
    EXPECT_FALSE(deserialized_position.symbol_whose_bitmap_is_flipped.has_value());
@@ -36,15 +36,15 @@ TEST(position, should_serialize_and_deserialize_postions_with_unset_optional) {
    ASSERT_NO_THROW(std::remove(test_file.c_str()));
 }
 
-TEST(position, should_serialize_and_deserialize_postions_with_set_optional) {
+TEST(Position, shouldSerializeAndDeserializePositionWithSetOptional) {
    const std::string test_file = "test.bin";
 
    silo::Position position_with_set_optional;
    position_with_set_optional.symbol_whose_bitmap_is_flipped = silo::NUCLEOTIDE_SYMBOL::A;
-   ASSERT_NO_THROW(serializeToFile(test_file, position_with_set_optional));
+   serializeToFile(test_file, position_with_set_optional);
 
    silo::Position deserialized_position;
-   ASSERT_NO_THROW(deserializeFromFile(test_file, deserialized_position));
+   deserializeFromFile(test_file, deserialized_position);
 
    EXPECT_TRUE(deserialized_position.symbol_whose_bitmap_is_flipped.has_value());
    ASSERT_EQ(

--- a/src/silo_api/variant_json_serializer.test.cpp
+++ b/src/silo_api/variant_json_serializer.test.cpp
@@ -11,7 +11,7 @@ struct TestStruct {
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(TestStruct, stringField, intField);
 
-TEST(variant_json_serializer, deserialize_struct_variant) {
+TEST(VariantJsonSerializer, deserializeStructVariant) {
    const int some_number = 42;
    const std::string some_string;
    const nlohmann::json json = {
@@ -26,7 +26,7 @@ TEST(variant_json_serializer, deserialize_struct_variant) {
    EXPECT_EQ(std::get<TestStruct>(result).intField, some_number);
 }
 
-TEST(variant_json_serializer, deserialize_string_variant) {
+TEST(VariantJsonSerializer, deserializeStringVariant) {
    const nlohmann::json json = "this is another string";
 
    auto result = json.get<std::variant<TestStruct, std::string>>();
@@ -35,7 +35,7 @@ TEST(variant_json_serializer, deserialize_string_variant) {
    EXPECT_EQ(std::get<std::string>(result), "this is another string");
 }
 
-TEST(variant_json_serializer, serialize_string_variant) {
+TEST(VariantJsonSerializer, serializeStringVariant) {
    const std::variant<TestStruct, std::string> value = "this is a string";
 
    auto result = nlohmann::json(value).dump();
@@ -43,7 +43,7 @@ TEST(variant_json_serializer, serialize_string_variant) {
    EXPECT_EQ(result, R"("this is a string")");
 }
 
-TEST(variant_json_serializer, serialize_struct_variant) {
+TEST(VariantJsonSerializer, serializeStructVariant) {
    const std::variant<TestStruct, std::string> value = TestStruct{"this is another string", 42};
 
    auto result = nlohmann::json(value).dump();


### PR DESCRIPTION
Rename the test case names, so they do not contain an underscore. Thus following the guides set by the gtest library

https://github.com/google/googletest/blob/main/docs/faq.md#why-should-test-suite-names-and-test-names-not-contain-underscore