### PR TITLE
fix: consistently name fields in SILO queries in camel case

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ COPY testBaseData .
 COPY --from=builder /src/siloApi .
 
 # call /info, extract "seqeunceCount" from the JSON and assert that the value is not 0. If any of those fails, "exit 1".
-HEALTHCHECK --start-period=20s CMD curl --fail --silent localhost:8080/info | jq .sequenceCount | xargs test 0 -ne || exit 1
+HEALTHCHECK --start-period=20s CMD curl --fail --silent localhost:8081/info | jq .sequenceCount | xargs test 0 -ne || exit 1
 
+EXPOSE 8081
 ENV SPDLOG_LEVEL="off,file_logger=debug"
 CMD ["./siloApi", "--api"]

--- a/docker-compose-for-tests.yml
+++ b/docker-compose-for-tests.yml
@@ -3,4 +3,4 @@ services:
   silo:
     image: ${SILO_IMAGE}
     ports:
-      - "8080:8080"
+      - "8080:8081"

--- a/endToEndTests/test/queries/pangoLIneageIncludingSublineages.json
+++ b/endToEndTests/test/queries/pangoLIneageIncludingSublineages.json
@@ -1,0 +1,16 @@
+{
+  "testCaseName": "pango lineage B.1.1.7 including sublineages",
+  "query": {
+    "action": {
+      "type": "Aggregated"
+    },
+    "filterExpression": {
+      "type": "PangoLineage",
+      "value": "B.1.1.7",
+      "includeSublineages": true
+    }
+  },
+  "expectedQueryResult": {
+    "count": 49
+  }
+}

--- a/endToEndTests/test/queries/pangoLIneageWithoutSublineages.json
+++ b/endToEndTests/test/queries/pangoLIneageWithoutSublineages.json
@@ -1,0 +1,16 @@
+{
+  "testCaseName": "pango lineage B.1.1.7 without sublineages",
+  "query": {
+    "action": {
+      "type": "Aggregated"
+    },
+    "filterExpression": {
+      "type": "PangoLineage",
+      "value": "B.1.1.7",
+      "includeSublineages": false
+    }
+  },
+  "expectedQueryResult": {
+    "count": 48
+  }
+}

--- a/src/silo/query_engine/query_engine.cpp
+++ b/src/silo/query_engine/query_engine.cpp
@@ -219,7 +219,14 @@ std::unique_ptr<BoolExpression> parseExpression(
       ));
    }
    if (expression_type == "PangoLineage") {
-      const bool include_sublineages = json_value["include_sublineages"].GetBool();
+      CHECK_SILO_QUERY(
+         json_value.HasMember("includeSublineages"),
+         "The field 'includeSublineages' is required in a PangoLineage expression"
+      );
+      const bool include_sublineages = json_value["includeSublineages"].GetBool();
+      CHECK_SILO_QUERY(
+         json_value.HasMember("value"), "The field 'value' is required in a PangoLineage expression"
+      );
       std::string lineage = json_value["value"].GetString();
       std::transform(lineage.begin(), lineage.end(), lineage.begin(), ::toupper);
       lineage = resolvePangoLineageAlias(database.getAliasKey(), lineage);

--- a/src/silo_api/api.cpp
+++ b/src/silo_api/api.cpp
@@ -63,7 +63,7 @@ class SiloServer : public Poco::Util::ServerApplication {
       [[maybe_unused]] const std::string& name,
       [[maybe_unused]] const std::string& value
    ) {
-      int const port = 8080;
+      int const port = 8081;
 
       const silo::InputDirectory input_directory{"./"};
       const silo::OutputDirectory output_directory{"./"};


### PR DESCRIPTION
This is prework for https://github.com/GenSpectrum/LAPIS/issues/201

Also listen on port 8081 to avoid conflicts with LAPIS in local setup.