### PR TITLE
build: remove -march=native in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ endif ()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
-set(CMAKE_CXX_FLAGS "-Wall -march=native")
+set(CMAKE_CXX_FLAGS "-Wall")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -static-libstdc++ -static-libgcc")
 


### PR DESCRIPTION
Sometimes we observe Docker images that cannot be run in other Github jobs. Very rarely we observe Docker images that cannot be run on our local machines ("Illegal instruction (core dumped)"). Maybe sometimes Github uses different architectures / CPUs in Github Actions? Let's observe whether this change resolves the problems.