### PR TITLE
Building for OS X / Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Build silo in `./build`. This build will load and build the required libraries t
 hand).
 
 ```shell
-./build_with_conan
+./build_with_conan.sh
 ```
 
 Executables are located in `build/` upon a successful build.

--- a/src/silo/common/format_number.cpp
+++ b/src/silo/common/format_number.cpp
@@ -1,5 +1,6 @@
 #include "silo/common/format_number.h"
 
+#include <memory>
 #include <sstream>
 #include <string>
 

--- a/src/silo/common/format_number.cpp
+++ b/src/silo/common/format_number.cpp
@@ -1,6 +1,6 @@
 #include "silo/common/format_number.h"
 
-#include <filesystem>
+#include <sstream>
 #include <string>
 
 namespace silo {

--- a/src/silo_api/error_request_handler.cpp
+++ b/src/silo_api/error_request_handler.cpp
@@ -1,6 +1,7 @@
 #include "silo_api/error_request_handler.h"
 
 #include <Poco/Net/HTTPServerResponse.h>
+#include <cxxabi.h>
 #include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
 
@@ -22,7 +23,7 @@ void ErrorRequestHandler::handleRequest(
       out_stream << nlohmann::json(ErrorResponse{"Internal server error", exception.what()});
    } catch (...) {
       const auto exception = std::current_exception();
-      const auto* message = exception ? exception.__cxa_exception_type()->name() : "null";
+      const auto* message = exception ? abi::__cxa_current_exception_type()->name() : "null";
       SPDLOG_ERROR("Caught something unexpected: {}", message);
 
       response.setStatus(Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
Will resolve #70

More changes should also be included in this PR such as #73 #68.

I will push the changes for #68 after #74 #75, so that I can merge conflicts locally.

I am interested whether the change in `format_numbers.cpp` from including `filesystem` to `sstream` creates any problems for you.