### PR TITLE
fix: do not ignore flipped bitmap in SequenceStore::getFlippedBitmapF…

### DIFF
--- a/include/silo/storage/sequence_store.h
+++ b/include/silo/storage/sequence_store.h
@@ -26,7 +26,7 @@ struct Position {
       archive& nucleotide_symbol_n_indexed;
    }
 
-   std::array<roaring::Roaring, SYMBOL_COUNT> bitmaps;
+   std::array<roaring::Roaring, SYMBOL_COUNT> bitmaps{};
    std::optional<NUCLEOTIDE_SYMBOL> symbol_whose_bitmap_is_flipped = std::nullopt;
    bool nucleotide_symbol_n_indexed = false;
 };
@@ -39,7 +39,7 @@ struct SequenceStoreInfo {
 
 class SequenceStore {
   private:
-   unsigned sequence_count;
+   unsigned sequence_count{};
 
   public:
    friend class boost::serialization::access;
@@ -51,8 +51,8 @@ class SequenceStore {
       archive& nucleotide_symbol_n_bitmaps;
    }
 
-   std::array<Position, GENOME_LENGTH> positions;
-   std::vector<roaring::Roaring> nucleotide_symbol_n_bitmaps;
+   std::array<Position, GENOME_LENGTH> positions{};
+   std::vector<roaring::Roaring> nucleotide_symbol_n_bitmaps{};
 
    SequenceStore();
 

--- a/src/silo/storage/sequence_store.cpp
+++ b/src/silo/storage/sequence_store.cpp
@@ -5,6 +5,7 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/parallel_for.h>
 #include <atomic>
+#include <memory>
 #include <roaring/roaring.hh>
 #include <string>
 #include <vector>
@@ -70,7 +71,7 @@ roaring::Roaring* silo::SequenceStore::getBitmapFromAmbiguousSymbol(
    size_t position,
    NUCLEOTIDE_SYMBOL ambiguous_symbol
 ) const {
-   static constexpr int COUNT_AMBIGUOUS_SYMBOLS = 8;
+   static constexpr int COUNT_AMBIGUOUS_SYMBOLS = 7;
    switch (ambiguous_symbol) {
       case NUCLEOTIDE_SYMBOL::A: {
          // NOLINTNEXTLINE(modernize-avoid-c-arrays)
@@ -138,14 +139,14 @@ roaring::Roaring* silo::SequenceStore::getFlippedBitmapFromAmbiguousSymbol(
    size_t position,
    NUCLEOTIDE_SYMBOL ambiguous_symbol
 ) const {
-   const auto* bitmap_to_flip = getBitmap(position, ambiguous_symbol);
-   roaring::api::roaring_bitmap_flip(&bitmap_to_flip->roaring, 0, sequence_count);
-   static constexpr int COUNT_AMBIGUOUS_SYMBOLS = 8;
+   auto bitmap_ambiguous_symbol = std::make_unique<roaring::Roaring>(*getBitmap(position, ambiguous_symbol));
+   static constexpr int COUNT_AMBIGUOUS_SYMBOLS = 7;
    switch (ambiguous_symbol) {
       case NUCLEOTIDE_SYMBOL::A: {
+         bitmap_ambiguous_symbol->flip(0, sequence_count);
          // NOLINTNEXTLINE(modernize-avoid-c-arrays)
          const roaring::Roaring* tmp[COUNT_AMBIGUOUS_SYMBOLS] = {
-            bitmap_to_flip,
+            bitmap_ambiguous_symbol.get(),
             getBitmap(position, NUCLEOTIDE_SYMBOL::R),
             getBitmap(position, NUCLEOTIDE_SYMBOL::W),
             getBitmap(position, NUCLEOTIDE_SYMBOL::M),
@@ -157,9 +158,10 @@ roaring::Roaring* silo::SequenceStore::getFlippedBitmapFromAmbiguousSymbol(
          return result;
       }
       case NUCLEOTIDE_SYMBOL::C: {
+         bitmap_ambiguous_symbol->flip(0, sequence_count);
          // NOLINTNEXTLINE(modernize-avoid-c-arrays)
          const roaring::Roaring* tmp[COUNT_AMBIGUOUS_SYMBOLS] = {
-            bitmap_to_flip,
+            bitmap_ambiguous_symbol.get(),
             getBitmap(position, NUCLEOTIDE_SYMBOL::Y),
             getBitmap(position, NUCLEOTIDE_SYMBOL::S),
             getBitmap(position, NUCLEOTIDE_SYMBOL::M),
@@ -173,7 +175,7 @@ roaring::Roaring* silo::SequenceStore::getFlippedBitmapFromAmbiguousSymbol(
       case NUCLEOTIDE_SYMBOL::G: {
          // NOLINTNEXTLINE(modernize-avoid-c-arrays)
          const roaring::Roaring* tmp[COUNT_AMBIGUOUS_SYMBOLS] = {
-            bitmap_to_flip,
+            bitmap_ambiguous_symbol.get(),
             getBitmap(position, NUCLEOTIDE_SYMBOL::R),
             getBitmap(position, NUCLEOTIDE_SYMBOL::S),
             getBitmap(position, NUCLEOTIDE_SYMBOL::K),
@@ -187,7 +189,7 @@ roaring::Roaring* silo::SequenceStore::getFlippedBitmapFromAmbiguousSymbol(
       case NUCLEOTIDE_SYMBOL::T: {
          // NOLINTNEXTLINE(modernize-avoid-c-arrays)
          const roaring::Roaring* tmp[COUNT_AMBIGUOUS_SYMBOLS] = {
-            bitmap_to_flip,
+            bitmap_ambiguous_symbol.get(),
             getBitmap(position, NUCLEOTIDE_SYMBOL::Y),
             getBitmap(position, NUCLEOTIDE_SYMBOL::W),
             getBitmap(position, NUCLEOTIDE_SYMBOL::K),
@@ -199,7 +201,7 @@ roaring::Roaring* silo::SequenceStore::getFlippedBitmapFromAmbiguousSymbol(
          return result;
       }
       default: {
-         return new roaring::Roaring(*getBitmap(position, ambiguous_symbol));
+         return bitmap_ambiguous_symbol.release();
       }
    }
 }

--- a/src/silo/storage/sequence_store.test.cpp
+++ b/src/silo/storage/sequence_store.test.cpp
@@ -1,0 +1,47 @@
+#include "silo/storage/sequence_store.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+std::unique_ptr<silo::SequenceStore> setupSequenceStore() {
+   std::unique_ptr<silo::SequenceStore> sequence_store = std::make_unique<silo::SequenceStore>();
+
+   // Construct test genomes.
+   std::string test_genome1 = "A";
+   test_genome1.reserve(silo::GENOME_LENGTH);
+   for (unsigned i = 1; i < silo::GENOME_LENGTH; ++i) {
+      test_genome1.push_back('A');
+   }
+
+   std::string test_genome2 = "C";
+   test_genome2.reserve(silo::GENOME_LENGTH);
+   for (unsigned i = 1; i < silo::GENOME_LENGTH; ++i) {
+      test_genome2.push_back('C');
+   }
+
+   sequence_store->interpret({std::move(test_genome1), std::move(test_genome2)});
+
+   return sequence_store;
+}
+
+TEST(SequenceStore, shouldReturnCorrectBitmapForAmbiguousSymbol) {
+  auto sequence_store = setupSequenceStore();
+
+  // Note: 1-indexed!
+  auto* bitmap2 = sequence_store->getBitmapFromAmbiguousSymbol(1, silo::NUCLEOTIDE_SYMBOL::A);
+  EXPECT_NE(bitmap2, nullptr);
+  EXPECT_TRUE(bitmap2->contains(0));
+  EXPECT_FALSE(bitmap2->contains(1));
+}
+
+TEST(SequenceStore, shouldReturnCorrectFlippedBitmapForAmbiguousSymbol) {
+  auto sequence_store = setupSequenceStore();
+
+  // Note: 1-indexed!
+  auto* bitmap = sequence_store->getFlippedBitmapFromAmbiguousSymbol(1, silo::NUCLEOTIDE_SYMBOL::A);
+  EXPECT_NE(bitmap, nullptr);
+  EXPECT_FALSE(bitmap->contains(0));
+  EXPECT_TRUE(bitmap->contains(1));
+}


### PR DESCRIPTION
…romAmbiguousSymbol

This PR fixes the following two bugs:

1. `COUNT_AMBIGUOUS_SYMBOLS` should be 7 and not 8 in `SequenceStore::getFlippedBitmapFromAmbiguousSymbol` and `SequenceStore::getBitmapFromAmbiguousSymbol` because the arrays only have 7 entries.

2. In `SequenceStore::getFlippedBitmapFromAmbiguousSymbol`, the result of `roaring::api::roaring_bitmap_flip(&bitmap_to_flip->roaring, 0, sequence_count)` was ignored. Hence, the behavior of `getFlippedBitmapFromAmbiguousSymbol` was exactly identical to `getBitmapFromAmbiguousSymbol`. As far as I understood it from the code, the intended behavior is to only flip the bitmap corresponding to the exact value of the nucleotide symbol.