### PR TITLE
ci: reduce build times by caching Docker layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,18 +31,21 @@ jobs:
     name: Build And Run linter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Docker Buildx
+      -
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Build linter image
+      -
+        name: Build linter image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: false
           target: linter
           tags: ${{ env.DOCKER_TEST_IMAGE_NAME }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ github.ref_name }}-linter-image-cache
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-linter-image-cache
           file: Dockerfile_linter
 
   dockerImage:
@@ -67,8 +70,8 @@ jobs:
           load: true
           target: builder
           tags: ${{ env.DOCKER_TEST_IMAGE_NAME }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ github.ref_name }}-image-cache
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-image-cache
       -
         name: Run tests
         uses: addnab/docker-run-action@v3
@@ -92,8 +95,6 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.dockerMetadata.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   endToEndTests:
     name: Run End To End Tests

--- a/Dockerfile_linter
+++ b/Dockerfile_linter
@@ -21,11 +21,14 @@ COPY conanfile.py conanprofile.docker .
 RUN mv conanprofile.docker conanprofile
 
 RUN --mount=type=cache,target=/root/.conan2 \
-    conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build -s build_type=Debug
+    conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build -s build_type=Debug\
+    && cp -R /root/.conan2 /root/.conan2_persisted && cp -R build build_persisted
+
+# Restore the cached directories as the cache mount deletes them.
+# We need this because cache mounts are not cached in GitHub Actions
+# (see https://github.com/docker/build-push-action/issues/716)
+RUN cp -R /root/.conan2_persisted /root/.conan2 && cp -R build_persisted build
 
 COPY . .
 
-RUN  \
-    --mount=type=cache,target=/root/.conan2 \
-    --mount=type=cache,target=build \
-    bash ./build_with_conan.sh
+RUN bash ./build_with_conan.sh

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ The Conan profile (myProfile) on your system might differ: Create a new profile 
 conan profile detect
 ```
 
-Insert info `os`, `os_build`, `arch` and `arch_build` of myProfile into `conanprofile.example` and rename
-to `conanprofile`.
+Copy `conanprofile.example` to `conanprofile` and insert the values of `os`, `os_build`, `arch` and `arch_build` from 
+myProfile.
 
 Build silo in `./build`. This build will load and build the required libraries to `~/.conan2/data/` (can not be set by
 hand).
@@ -54,8 +54,14 @@ docker build . --tag=silo
 Run docker container
 
 ```shell
-docker run -i silo
+docker run -p 8081:8081 silo
 ```
+
+Building Docker images locally relies on the local Docker cache.
+Docker will cache layers, and it will cache the dependencies built by Conan via cache mounts. 
+
+However, cache mounts don't work in GitHub Actions (https://github.com/docker/build-push-action/issues/716),
+so there we only rely on Docker's layer cache via Docker's gha cache backend.
 
 # Testing
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ class SiloRecipe(ConanFile):
         "boost/1.81.0",
         "poco/1.12.4",
         "onetbb/2021.7.0",
-        "xz_utils/5.2.5",
+        "xz_utils/5.4.2",
         "rapidjson/cci.20220822",
         "nlohmann_json/3.11.2",
         "gtest/cci.20210126",

--- a/src/silo_api/api.cpp
+++ b/src/silo_api/api.cpp
@@ -97,7 +97,7 @@ class SiloServer : public Poco::Util::ServerApplication {
       [[maybe_unused]] const std::string& name,
       [[maybe_unused]] const std::string& value
    ) {
-      std::cout << "handleProcessData is not implemented" << std::endl;
+      std::cout << "handleProcessData is not implemented\n" << std::flush;
    };
 
    void displayHelp(


### PR DESCRIPTION
issue: #92

This makes use of Docker's layer caching. It works as follows:
* layers that don't change are cached and thus not rebuilt.
* For local builds, we also would like to cache Conan's build directories to even further speed up builds there.
* In the images, backup the cached directories (because Docker's bind mounts delete their content after the step) and restore those backups.
* Layers including restoring the backup should be cached, so GitHub Actions should only need to build SILO itself.

Clang tidy still takes very long (~20 minutes). Maybe we can reduce this by refactoring the code into smaller files.