### PR TITLE
Configure columns

### DIFF
--- a/Dockerfile_linter
+++ b/Dockerfile_linter
@@ -5,7 +5,7 @@ WORKDIR /src
 RUN apt update \
     && apt install -y \
     cmake=3.22.1-1ubuntu1.22.04.1 \
-    python3-pip=22.0.2+dfsg-1ubuntu0.2 \
+    python3-pip=22.0.2+dfsg-1ubuntu0.3 \
     software-properties-common=0.99.22.7 \
     wget=1.21.2-2ubuntu1 \
     gnupg=2.2.27-3ubuntu2.1 \

--- a/include/silo/config/database_config.h
+++ b/include/silo/config/database_config.h
@@ -7,14 +7,17 @@
 
 namespace silo::config {
 
-enum class DatabaseMetadataType { STRING, PANGOLINEAGE, DATE };
+enum class ValueType { STRING, PANGOLINEAGE, DATE };
+enum class ColumnType { STRING, INDEXED_STRING, INDEXED_PANGOLINEAGE, DATE };
 
-DatabaseMetadataType toDatabaseMetadataType(std::string_view type);
+ValueType toDatabaseValueType(std::string_view type);
 
 struct DatabaseMetadata {
    std::string name;
-   DatabaseMetadataType type;
+   ValueType type;
    bool generate_index;
+
+   ColumnType getColumnType() const;
 };
 
 struct DatabaseSchema {

--- a/include/silo/config/database_config.h
+++ b/include/silo/config/database_config.h
@@ -1,6 +1,7 @@
 #ifndef SILO_INCLUDE_SILO_CONFIG_DATABASECONFIG_H_
 #define SILO_INCLUDE_SILO_CONFIG_DATABASECONFIG_H_
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -13,12 +14,15 @@ DatabaseMetadataType toDatabaseMetadataType(std::string_view type);
 struct DatabaseMetadata {
    std::string name;
    DatabaseMetadataType type;
+   bool generate_index;
 };
 
 struct DatabaseSchema {
    std::string instance_name;
    std::vector<DatabaseMetadata> metadata;
    std::string primary_key;
+   std::optional<std::string> date_to_sort_by;
+   std::string partition_by;
 };
 
 struct DatabaseConfig {

--- a/include/silo/prepare_dataset.h
+++ b/include/silo/prepare_dataset.h
@@ -24,13 +24,15 @@ class PangoLineageAliasLookup;
 [[maybe_unused]] void pruneSequences(
    const std::filesystem::path& metadata_in,
    silo::FastaReader& sequences_in,
-   std::ostream& sequences_out
+   std::ostream& sequences_out,
+   const silo::config::DatabaseConfig& database_config
 );
 
 [[maybe_unused]] void pruneMetadata(
    const std::filesystem::path& metadata_in,
    silo::FastaReader& sequences_in,
-   silo::preprocessing::MetadataWriter& metadata_writer
+   silo::preprocessing::MetadataWriter& metadata_writer,
+   const silo::config::DatabaseConfig& database_config
 );
 
 void partitionSequences(

--- a/include/silo/prepare_dataset.h
+++ b/include/silo/prepare_dataset.h
@@ -8,6 +8,10 @@
 
 namespace silo {
 
+namespace config {
+struct DatabaseConfig;
+}  // namespace config
+
 namespace preprocessing {
 struct Partitions;
 struct PangoLineageCounts;
@@ -36,7 +40,8 @@ void partitionSequences(
    const std::string& output_prefix,
    const PangoLineageAliasLookup& alias_key,
    const std::string& metadata_file_extension,
-   const std::string& sequence_file_extension
+   const std::string& sequence_file_extension,
+   const silo::config::DatabaseConfig& database_config
 );
 
 struct SortChunkConfig {

--- a/include/silo/prepare_dataset.h
+++ b/include/silo/prepare_dataset.h
@@ -39,12 +39,18 @@ void partitionSequences(
    const std::string& sequence_file_extension
 );
 
+struct SortChunkConfig {
+   std::string primary_key_name;
+   std::string date_column_to_sort_by;
+};
+
 void sortChunks(
    const preprocessing::Partitions& partitions,
    const std::string& input_prefix,
    const std::string& output_prefix,
    const std::string& metadata_file_extension,
-   const std::string& sequence_file_extension
+   const std::string& sequence_file_extension,
+   const SortChunkConfig& sort_chunk_config
 );
 
 }  // namespace silo

--- a/include/silo/preprocessing/metadata.h
+++ b/include/silo/preprocessing/metadata.h
@@ -9,8 +9,6 @@
 
 namespace silo::preprocessing {
 
-const std::string COLUMN_NAME_PRIMARY_KEY = "gisaid_epi_isl";
-
 class MetadataReader {
   public:
    static std::vector<std::string> getColumn(

--- a/include/silo/preprocessing/metadata.h
+++ b/include/silo/preprocessing/metadata.h
@@ -10,7 +10,6 @@
 namespace silo::preprocessing {
 
 const std::string COLUMN_NAME_PRIMARY_KEY = "gisaid_epi_isl";
-const std::string COLUMN_NAME_PANGO_LINEAGE = "pango_lineage";
 
 class MetadataReader {
   public:

--- a/include/silo/preprocessing/metadata.h
+++ b/include/silo/preprocessing/metadata.h
@@ -11,7 +11,6 @@ namespace silo::preprocessing {
 
 const std::string COLUMN_NAME_PRIMARY_KEY = "gisaid_epi_isl";
 const std::string COLUMN_NAME_PANGO_LINEAGE = "pango_lineage";
-const std::string COLUMN_NAME_DATE = "date";
 
 class MetadataReader {
   public:

--- a/include/silo/preprocessing/pango_lineage_count.h
+++ b/include/silo/preprocessing/pango_lineage_count.h
@@ -8,6 +8,10 @@
 namespace silo {
 struct PangoLineageAliasLookup;
 
+namespace config {
+struct DatabaseConfig;
+}  // namespace config
+
 namespace preprocessing {
 
 struct PangoLineageCount {
@@ -25,7 +29,8 @@ struct PangoLineageCounts {
 
 PangoLineageCounts buildPangoLineageCounts(
    const PangoLineageAliasLookup& alias_key,
-   const std::filesystem::path& metadata_path
+   const std::filesystem::path& metadata_path,
+   const silo::config::DatabaseConfig& database_config
 );
 
 }  // namespace preprocessing

--- a/include/silo/storage/metadata_store.h
+++ b/include/silo/storage/metadata_store.h
@@ -44,10 +44,7 @@ struct MetadataStore {
    );
 
   private:
-   void initializeColumns(
-      const config::DatabaseConfig& database_config,
-      const std::set<std::string>& columns_to_index
-   );
+   void initializeColumns(const config::DatabaseConfig& database_config);
 };
 
 }  // namespace silo

--- a/src/silo/config/config_repository.cpp
+++ b/src/silo/config/config_repository.cpp
@@ -17,18 +17,73 @@ DatabaseConfig ConfigRepository::getValidatedConfig(const std::filesystem::path&
    return config;
 }
 
-void ConfigRepository::validateConfig(const DatabaseConfig& config) const {
+std::map<std::string, DatabaseMetadataType> validateMetadataDefinitions(const DatabaseConfig& config
+) {
    std::map<std::string, DatabaseMetadataType> metadata_map;
    for (const auto& metadata : config.schema.metadata) {
       if (metadata_map.find(metadata.name) != metadata_map.end()) {
          throw ConfigException("Metadata " + metadata.name + " is defined twice in the config");
       }
+
+      const auto must_not_generate_index_on_type =
+         metadata.type != DatabaseMetadataType::STRING &&
+         metadata.type != DatabaseMetadataType::PANGOLINEAGE;
+      if (metadata.generate_index && must_not_generate_index_on_type) {
+         throw ConfigException(
+            "Metadata '" + metadata.name +
+            "' generate_index is set, but generating an index is only allowed for types STRING and "
+            "PANGOLINEAGE"
+         );
+      }
       metadata_map[metadata.name] = metadata.type;
    }
+   return metadata_map;
+}
+
+void validateDateToSortBy(
+   const DatabaseConfig& config,
+   std::map<std::string, DatabaseMetadataType>& metadata_map
+) {
+   if (!config.schema.date_to_sort_by.has_value()) {
+      return;
+   }
+
+   const std::string date_to_sort_by = config.schema.date_to_sort_by.value();
+   if (metadata_map.find(date_to_sort_by) == metadata_map.end()) {
+      throw ConfigException("date_to_sort_by '" + date_to_sort_by + "' is not in metadata");
+   }
+
+   if (metadata_map[date_to_sort_by] != DatabaseMetadataType::DATE) {
+      throw ConfigException("date_to_sort_by '" + date_to_sort_by + "' must be of type DATE");
+   }
+}
+
+void validatePartitionBy(
+   const DatabaseConfig& config,
+   std::map<std::string, DatabaseMetadataType>& metadata_map
+) {
+   if (metadata_map.find(config.schema.partition_by) == metadata_map.end()) {
+      throw ConfigException("partition_by '" + config.schema.partition_by + "' is not in metadata");
+   }
+
+   const auto& partition_by_type = metadata_map[config.schema.partition_by];
+   if (partition_by_type != DatabaseMetadataType::STRING && partition_by_type != DatabaseMetadataType::PANGOLINEAGE) {
+      throw ConfigException(
+         "partition_by '" + config.schema.partition_by + "' must be of type STRING or PANGOLINEAGE"
+      );
+   }
+}
+
+void ConfigRepository::validateConfig(const DatabaseConfig& config) const {
+   std::map<std::string, DatabaseMetadataType> metadata_map = validateMetadataDefinitions(config);
 
    if (metadata_map.find(config.schema.primary_key) == metadata_map.end()) {
       throw ConfigException("Primary key is not in metadata");
    }
+
+   validateDateToSortBy(config, metadata_map);
+
+   validatePartitionBy(config, metadata_map);
 }
 
 }  // namespace silo::config

--- a/src/silo/config/config_repository.cpp
+++ b/src/silo/config/config_repository.cpp
@@ -67,9 +67,9 @@ void validatePartitionBy(
    }
 
    const auto& partition_by_type = metadata_map[config.schema.partition_by];
-   if (partition_by_type != DatabaseMetadataType::STRING && partition_by_type != DatabaseMetadataType::PANGOLINEAGE) {
+   if (partition_by_type != DatabaseMetadataType::PANGOLINEAGE) {
       throw ConfigException(
-         "partition_by '" + config.schema.partition_by + "' must be of type STRING or PANGOLINEAGE"
+         "partition_by '" + config.schema.partition_by + "' must be of type PANGOLINEAGE"
       );
    }
 }

--- a/src/silo/config/config_repository.cpp
+++ b/src/silo/config/config_repository.cpp
@@ -17,17 +17,15 @@ DatabaseConfig ConfigRepository::getValidatedConfig(const std::filesystem::path&
    return config;
 }
 
-std::map<std::string, DatabaseMetadataType> validateMetadataDefinitions(const DatabaseConfig& config
-) {
-   std::map<std::string, DatabaseMetadataType> metadata_map;
+std::map<std::string, ValueType> validateMetadataDefinitions(const DatabaseConfig& config) {
+   std::map<std::string, ValueType> metadata_map;
    for (const auto& metadata : config.schema.metadata) {
       if (metadata_map.find(metadata.name) != metadata_map.end()) {
          throw ConfigException("Metadata " + metadata.name + " is defined twice in the config");
       }
 
       const auto must_not_generate_index_on_type =
-         metadata.type != DatabaseMetadataType::STRING &&
-         metadata.type != DatabaseMetadataType::PANGOLINEAGE;
+         metadata.type != ValueType::STRING && metadata.type != ValueType::PANGOLINEAGE;
       if (metadata.generate_index && must_not_generate_index_on_type) {
          throw ConfigException(
             "Metadata '" + metadata.name +
@@ -35,6 +33,16 @@ std::map<std::string, DatabaseMetadataType> validateMetadataDefinitions(const Da
             "PANGOLINEAGE"
          );
       }
+
+      const auto must_generate_index_on_type = metadata.type == ValueType::PANGOLINEAGE;
+      if (!metadata.generate_index && must_generate_index_on_type) {
+         throw ConfigException(
+            "Metadata '" + metadata.name +
+            "' generate_index is not set, but generating an index is mandatory for type "
+            "PANGOLINEAGE"
+         );
+      }
+
       metadata_map[metadata.name] = metadata.type;
    }
    return metadata_map;
@@ -42,7 +50,7 @@ std::map<std::string, DatabaseMetadataType> validateMetadataDefinitions(const Da
 
 void validateDateToSortBy(
    const DatabaseConfig& config,
-   std::map<std::string, DatabaseMetadataType>& metadata_map
+   std::map<std::string, ValueType>& metadata_map
 ) {
    if (!config.schema.date_to_sort_by.has_value()) {
       return;
@@ -53,21 +61,21 @@ void validateDateToSortBy(
       throw ConfigException("date_to_sort_by '" + date_to_sort_by + "' is not in metadata");
    }
 
-   if (metadata_map[date_to_sort_by] != DatabaseMetadataType::DATE) {
+   if (metadata_map[date_to_sort_by] != ValueType::DATE) {
       throw ConfigException("date_to_sort_by '" + date_to_sort_by + "' must be of type DATE");
    }
 }
 
 void validatePartitionBy(
    const DatabaseConfig& config,
-   std::map<std::string, DatabaseMetadataType>& metadata_map
+   std::map<std::string, ValueType>& metadata_map
 ) {
    if (metadata_map.find(config.schema.partition_by) == metadata_map.end()) {
       throw ConfigException("partition_by '" + config.schema.partition_by + "' is not in metadata");
    }
 
    const auto& partition_by_type = metadata_map[config.schema.partition_by];
-   if (partition_by_type != DatabaseMetadataType::PANGOLINEAGE) {
+   if (partition_by_type != ValueType::PANGOLINEAGE) {
       throw ConfigException(
          "partition_by '" + config.schema.partition_by + "' must be of type PANGOLINEAGE"
       );
@@ -75,7 +83,7 @@ void validatePartitionBy(
 }
 
 void ConfigRepository::validateConfig(const DatabaseConfig& config) const {
-   std::map<std::string, DatabaseMetadataType> metadata_map = validateMetadataDefinitions(config);
+   std::map<std::string, ValueType> metadata_map = validateMetadataDefinitions(config);
 
    if (metadata_map.find(config.schema.primary_key) == metadata_map.end()) {
       throw ConfigException("Primary key is not in metadata");

--- a/src/silo/config/config_repository.test.cpp
+++ b/src/silo/config/config_repository.test.cpp
@@ -154,9 +154,9 @@ TEST(ConfigRepository, givenConfigPartitionByThatIsNotPangoLineageThenThrows) {
       [&config_reader_mock]() {
          ConfigRepository(config_reader_mock).getValidatedConfig("test.yaml");
       },
-      ThrowsMessage<ConfigException>(::testing::HasSubstr(
-         "partition_by 'not a pango lineage' must be of type PANGOLINEAGE"
-      ))
+      ThrowsMessage<ConfigException>(
+         ::testing::HasSubstr("partition_by 'not a pango lineage' must be of type PANGOLINEAGE")
+      )
    );
 }
 

--- a/src/silo/config/config_repository.test.cpp
+++ b/src/silo/config/config_repository.test.cpp
@@ -137,17 +137,17 @@ TEST(ConfigRepository, givenConfigPartitionByThatIsNotConfiguredThenThrows) {
    );
 }
 
-TEST(ConfigRepository, givenConfigPartitionByThatIsNotStringOrPangoLineageThenThrows) {
+TEST(ConfigRepository, givenConfigPartitionByThatIsNotPangoLineageThenThrows) {
    const auto config_reader_mock = mockConfigReader(
       {"testInstanceName",
        {
           {"testPrimaryKey", DatabaseMetadataType::STRING},
           {"date_to_sort_by", DatabaseMetadataType::DATE},
-          {"not a string or pango lineage", DatabaseMetadataType::DATE},
+          {"not a pango lineage", DatabaseMetadataType::STRING},
        },
        "testPrimaryKey",
        "date_to_sort_by",
-       "not a string or pango lineage"}
+       "not a pango lineage"}
    );
 
    EXPECT_THAT(
@@ -155,7 +155,7 @@ TEST(ConfigRepository, givenConfigPartitionByThatIsNotStringOrPangoLineageThenTh
          ConfigRepository(config_reader_mock).getValidatedConfig("test.yaml");
       },
       ThrowsMessage<ConfigException>(::testing::HasSubstr(
-         "partition_by 'not a string or pango lineage' must be of type STRING or PANGOLINEAGE"
+         "partition_by 'not a pango lineage' must be of type PANGOLINEAGE"
       ))
    );
 }

--- a/src/silo/config/database_config.cpp
+++ b/src/silo/config/database_config.cpp
@@ -4,18 +4,38 @@
 
 namespace silo::config {
 
-DatabaseMetadataType toDatabaseMetadataType(std::string_view type) {
+ValueType toDatabaseValueType(std::string_view type) {
    if (type == "string") {
-      return DatabaseMetadataType::STRING;
+      return ValueType::STRING;
    }
    if (type == "date") {
-      return DatabaseMetadataType::DATE;
+      return ValueType::DATE;
    }
    if (type == "pango_lineage") {
-      return DatabaseMetadataType::PANGOLINEAGE;
+      return ValueType::PANGOLINEAGE;
    }
 
    throw ConfigException("Unknown metadata type: " + std::string(type));
+}
+
+ColumnType DatabaseMetadata::getColumnType() const {
+   if (type == ValueType::STRING) {
+      if (generate_index) {
+         return ColumnType::INDEXED_STRING;
+      }
+      return ColumnType::STRING;
+   }
+   if (type == ValueType::DATE) {
+      return ColumnType::DATE;
+   }
+   if (type == ValueType::PANGOLINEAGE) {
+      if (generate_index) {
+         return ColumnType::INDEXED_PANGOLINEAGE;
+      }
+      throw std::runtime_error("Found pango lineage column without index: " + std::string(name));
+   }
+
+   throw std::runtime_error("Unknown metadata type: " + std::string(name));
 }
 
 }  // namespace silo::config

--- a/src/silo/config/database_config_reader.cpp
+++ b/src/silo/config/database_config_reader.cpp
@@ -41,12 +41,11 @@ template <>
 struct convert<silo::config::DatabaseMetadata> {
    static bool decode(const Node& node, silo::config::DatabaseMetadata& metadata) {
       metadata.name = node["name"].as<std::string>();
-      metadata.type = silo::config::toDatabaseMetadataType(node["type"].as<std::string>());
+      metadata.type = silo::config::toDatabaseValueType(node["type"].as<std::string>());
       if (node["generateIndex"].IsDefined()) {
          metadata.generate_index = node["generateIndex"].as<bool>();
       } else {
-         metadata.generate_index =
-            metadata.type == silo::config::DatabaseMetadataType::PANGOLINEAGE;
+         metadata.generate_index = metadata.type == silo::config::ValueType::PANGOLINEAGE;
       }
       return true;
    }

--- a/src/silo/config/database_config_reader.cpp
+++ b/src/silo/config/database_config_reader.cpp
@@ -19,6 +19,12 @@ struct convert<silo::config::DatabaseSchema> {
    static bool decode(const Node& node, silo::config::DatabaseSchema& schema) {
       schema.instance_name = node["instanceName"].as<std::string>();
       schema.primary_key = node["primaryKey"].as<std::string>();
+      if (node["dateToSortBy"].IsDefined()) {
+         schema.date_to_sort_by = node["dateToSortBy"].as<std::string>();
+      } else {
+         schema.date_to_sort_by = std::nullopt;
+      }
+      schema.partition_by = node["partitionBy"].as<std::string>();
 
       if (!node["metadata"].IsSequence()) {
          return false;
@@ -36,6 +42,12 @@ struct convert<silo::config::DatabaseMetadata> {
    static bool decode(const Node& node, silo::config::DatabaseMetadata& metadata) {
       metadata.name = node["name"].as<std::string>();
       metadata.type = silo::config::toDatabaseMetadataType(node["type"].as<std::string>());
+      if (node["generateIndex"].IsDefined()) {
+         metadata.generate_index = node["generateIndex"].as<bool>();
+      } else {
+         metadata.generate_index =
+            metadata.type == silo::config::DatabaseMetadataType::PANGOLINEAGE;
+      }
       return true;
    }
 };

--- a/src/silo/config/database_config_reader.test.cpp
+++ b/src/silo/config/database_config_reader.test.cpp
@@ -8,7 +8,7 @@
 using silo::config::ConfigException;
 using silo::config::DatabaseConfig;
 using silo::config::DatabaseConfigReader;
-using silo::config::DatabaseMetadataType;
+using silo::config::ValueType;
 
 TEST(DatabaseConfigReader, shouldReadConfigWithCorrectParameters) {
    DatabaseConfig config;
@@ -22,25 +22,25 @@ TEST(DatabaseConfigReader, shouldReadConfigWithCorrectParameters) {
    ASSERT_EQ(config.schema.partition_by, "pango_lineage");
    ASSERT_EQ(config.schema.metadata.size(), 7);
    ASSERT_EQ(config.schema.metadata[0].name, "gisaid_epi_isl");
-   ASSERT_EQ(config.schema.metadata[0].type, DatabaseMetadataType::STRING);
+   ASSERT_EQ(config.schema.metadata[0].type, ValueType::STRING);
    ASSERT_EQ(config.schema.metadata[0].generate_index, false);
    ASSERT_EQ(config.schema.metadata[1].name, "date");
-   ASSERT_EQ(config.schema.metadata[1].type, DatabaseMetadataType::DATE);
+   ASSERT_EQ(config.schema.metadata[1].type, ValueType::DATE);
    ASSERT_EQ(config.schema.metadata[1].generate_index, false);
    ASSERT_EQ(config.schema.metadata[2].name, "unsorted_date");
-   ASSERT_EQ(config.schema.metadata[2].type, DatabaseMetadataType::DATE);
+   ASSERT_EQ(config.schema.metadata[2].type, ValueType::DATE);
    ASSERT_EQ(config.schema.metadata[2].generate_index, false);
    ASSERT_EQ(config.schema.metadata[3].name, "region");
-   ASSERT_EQ(config.schema.metadata[3].type, DatabaseMetadataType::STRING);
+   ASSERT_EQ(config.schema.metadata[3].type, ValueType::STRING);
    ASSERT_EQ(config.schema.metadata[3].generate_index, true);
    ASSERT_EQ(config.schema.metadata[4].name, "country");
-   ASSERT_EQ(config.schema.metadata[4].type, DatabaseMetadataType::STRING);
+   ASSERT_EQ(config.schema.metadata[4].type, ValueType::STRING);
    ASSERT_EQ(config.schema.metadata[4].generate_index, true);
    ASSERT_EQ(config.schema.metadata[5].name, "pango_lineage");
-   ASSERT_EQ(config.schema.metadata[5].type, DatabaseMetadataType::PANGOLINEAGE);
+   ASSERT_EQ(config.schema.metadata[5].type, ValueType::PANGOLINEAGE);
    ASSERT_EQ(config.schema.metadata[5].generate_index, true);
    ASSERT_EQ(config.schema.metadata[6].name, "division");
-   ASSERT_EQ(config.schema.metadata[6].type, DatabaseMetadataType::STRING);
+   ASSERT_EQ(config.schema.metadata[6].type, ValueType::STRING);
    ASSERT_EQ(config.schema.metadata[6].generate_index, true);
 }
 

--- a/src/silo/config/database_config_reader.test.cpp
+++ b/src/silo/config/database_config_reader.test.cpp
@@ -18,21 +18,30 @@ TEST(DatabaseConfigReader, shouldReadConfigWithCorrectParameters) {
 
    ASSERT_EQ(config.schema.instance_name, "sars_cov-2_minimal_test_config");
    ASSERT_EQ(config.schema.primary_key, "gisaid_epi_isl");
+   ASSERT_EQ(config.schema.date_to_sort_by, "date");
+   ASSERT_EQ(config.schema.partition_by, "pango_lineage");
    ASSERT_EQ(config.schema.metadata.size(), 7);
    ASSERT_EQ(config.schema.metadata[0].name, "gisaid_epi_isl");
    ASSERT_EQ(config.schema.metadata[0].type, DatabaseMetadataType::STRING);
+   ASSERT_EQ(config.schema.metadata[0].generate_index, false);
    ASSERT_EQ(config.schema.metadata[1].name, "date");
    ASSERT_EQ(config.schema.metadata[1].type, DatabaseMetadataType::DATE);
+   ASSERT_EQ(config.schema.metadata[1].generate_index, false);
    ASSERT_EQ(config.schema.metadata[2].name, "unsorted_date");
    ASSERT_EQ(config.schema.metadata[2].type, DatabaseMetadataType::DATE);
+   ASSERT_EQ(config.schema.metadata[2].generate_index, false);
    ASSERT_EQ(config.schema.metadata[3].name, "region");
    ASSERT_EQ(config.schema.metadata[3].type, DatabaseMetadataType::STRING);
+   ASSERT_EQ(config.schema.metadata[3].generate_index, true);
    ASSERT_EQ(config.schema.metadata[4].name, "country");
    ASSERT_EQ(config.schema.metadata[4].type, DatabaseMetadataType::STRING);
+   ASSERT_EQ(config.schema.metadata[4].generate_index, true);
    ASSERT_EQ(config.schema.metadata[5].name, "pango_lineage");
    ASSERT_EQ(config.schema.metadata[5].type, DatabaseMetadataType::PANGOLINEAGE);
+   ASSERT_EQ(config.schema.metadata[5].generate_index, true);
    ASSERT_EQ(config.schema.metadata[6].name, "division");
    ASSERT_EQ(config.schema.metadata[6].type, DatabaseMetadataType::STRING);
+   ASSERT_EQ(config.schema.metadata[6].generate_index, true);
 }
 
 TEST(DatabaseConfigReader, shouldThrowExceptionWhenConfigFileDoesNotExist) {
@@ -63,4 +72,12 @@ TEST(DatabaseConfigReader, shouldThrowIfTheConfigHasAnInvalidStructure) {
       ),
       YAML::InvalidNode
    );
+}
+
+TEST(DatabaseConfigReader, shouldReadConfigWithoutDateToSortBy) {
+   const DatabaseConfig& config = DatabaseConfigReader().readConfig(
+      "testBaseData/test_database_config_without_date_to_sort_by.yaml"
+   );
+
+   ASSERT_EQ(config.schema.date_to_sort_by, std::nullopt);
 }

--- a/src/silo/database.cpp
+++ b/src/silo/database.cpp
@@ -507,7 +507,7 @@ void silo::Database::preprocessing(const PreprocessingConfig& config) {
 
    SPDLOG_INFO("preprocessing - building pango lineage counts");
    pango_descriptor = std::make_unique<preprocessing::PangoLineageCounts>(
-      preprocessing::buildPangoLineageCounts(alias_key, config.metadata_file)
+      preprocessing::buildPangoLineageCounts(alias_key, config.metadata_file, database_config)
    );
 
    SPDLOG_INFO("preprocessing - building partitions");
@@ -525,7 +525,8 @@ void silo::Database::preprocessing(const PreprocessingConfig& config) {
       config.partition_folder.relative_path(),
       alias_key,
       config.metadata_file.extension(),
-      config.sequence_file.extension()
+      config.sequence_file.extension(),
+      database_config
    );
 
    if (database_config.schema.date_to_sort_by.has_value()) {

--- a/src/silo/database.cpp
+++ b/src/silo/database.cpp
@@ -528,14 +528,20 @@ void silo::Database::preprocessing(const PreprocessingConfig& config) {
       config.sequence_file.extension()
    );
 
-   SPDLOG_INFO("preprocessing - sorting chunks");
-   silo::sortChunks(
-      *partition_descriptor,
-      config.partition_folder.relative_path(),
-      config.sorted_partition_folder.relative_path(),
-      config.metadata_file.extension(),
-      config.sequence_file.extension()
-   );
+   if (database_config.schema.date_to_sort_by.has_value()) {
+      SPDLOG_INFO("preprocessing - sorting chunks");
+      silo::sortChunks(
+         *partition_descriptor,
+         config.partition_folder.relative_path(),
+         config.sorted_partition_folder.relative_path(),
+         config.metadata_file.extension(),
+         config.sequence_file.extension(),
+         {database_config.schema.primary_key, database_config.schema.date_to_sort_by.value()}
+      );
+   } else {
+      SPDLOG_INFO("preprocessing - skipping sorting chunks because no date to sort by was specified"
+      );
+   }
 
    SPDLOG_INFO("preprocessing - building database");
    build(

--- a/src/silo/preprocessing/metadata_validator.test.cpp
+++ b/src/silo/preprocessing/metadata_validator.test.cpp
@@ -14,9 +14,9 @@ TEST(
    const silo::config::DatabaseConfig some_config_with_one_column_not_in_metadata{
       "testInstanceName",
       {
-         {"gisaid_epi_isl", silo::config::DatabaseMetadataType::STRING},
-         {"notInMetadata", silo::config::DatabaseMetadataType::PANGOLINEAGE},
-         {"country", silo::config::DatabaseMetadataType::STRING},
+         {"gisaid_epi_isl", silo::config::ValueType::STRING},
+         {"notInMetadata", silo::config::ValueType::PANGOLINEAGE},
+         {"country", silo::config::ValueType::STRING},
       },
       "gisaid_epi_isl",
    };
@@ -39,10 +39,10 @@ TEST(MetadataValidator, isValidMedataFileShouldReturnTrueWithValidMetadataFile) 
    const silo::config::DatabaseConfig valid_config{
       "testInstanceName",
       {
-         {"gisaid_epi_isl", silo::config::DatabaseMetadataType::STRING},
-         {"pango_lineage", silo::config::DatabaseMetadataType::PANGOLINEAGE},
-         {"date", silo::config::DatabaseMetadataType::DATE},
-         {"country", silo::config::DatabaseMetadataType::STRING},
+         {"gisaid_epi_isl", silo::config::ValueType::STRING},
+         {"pango_lineage", silo::config::ValueType::PANGOLINEAGE},
+         {"date", silo::config::ValueType::DATE},
+         {"country", silo::config::ValueType::STRING},
       },
       "gisaid_epi_isl",
    };

--- a/src/silo/preprocessing/pango_lineage_count.cpp
+++ b/src/silo/preprocessing/pango_lineage_count.cpp
@@ -3,9 +3,9 @@
 #include <iostream>
 #include <unordered_map>
 
+#include "silo/config/database_config.h"
 #include "silo/preprocessing/metadata.h"
 #include "silo/storage/pango_lineage_alias.h"
-#include "silo/config/database_config.h"
 
 namespace silo::preprocessing {
 

--- a/src/silo/preprocessing/pango_lineage_count.cpp
+++ b/src/silo/preprocessing/pango_lineage_count.cpp
@@ -5,6 +5,7 @@
 
 #include "silo/preprocessing/metadata.h"
 #include "silo/storage/pango_lineage_alias.h"
+#include "silo/config/database_config.h"
 
 namespace silo::preprocessing {
 
@@ -36,7 +37,8 @@ PangoLineageCounts PangoLineageCounts::load(std::istream& input_stream) {
 
 PangoLineageCounts buildPangoLineageCounts(
    const PangoLineageAliasLookup& alias_key,
-   const std::filesystem::path& metadata_path
+   const std::filesystem::path& metadata_path,
+   const silo::config::DatabaseConfig& database_config
 ) {
    PangoLineageCounts pango_lineage_counts;
 
@@ -44,7 +46,7 @@ PangoLineageCounts buildPangoLineageCounts(
    std::unordered_map<std::string, uint32_t> pango_lineage_to_id;
 
    auto unresolved_pango_lineages = silo::preprocessing::MetadataReader::getColumn(
-      metadata_path, silo::preprocessing::COLUMN_NAME_PANGO_LINEAGE
+      metadata_path, database_config.schema.partition_by
    );
 
    for (const auto& unresolved_pango_lineage : unresolved_pango_lineages) {

--- a/src/silo/preprocessing/pango_lineage_count.test.cpp
+++ b/src/silo/preprocessing/pango_lineage_count.test.cpp
@@ -3,13 +3,16 @@
 #include <gtest/gtest.h>
 #include <filesystem>
 
+#include <silo/config/database_config.h>
 #include "silo/preprocessing/pango_lineage_count.h"
 
 TEST(PangoLineageCounts, buildPangoLineageCounts) {
    const std::filesystem::path metadata_path = "testBaseData/small_metadata_set.tsv";
+   const silo::config::DatabaseConfig database_config = {
+      .schema = {.partition_by = "pango_lineage"}};
 
    auto result = silo::preprocessing::buildPangoLineageCounts(
-      silo::PangoLineageAliasLookup::readFromFile("testBaseData/"), metadata_path
+      silo::PangoLineageAliasLookup::readFromFile("testBaseData/"), metadata_path, database_config
    );
 
    ASSERT_EQ(result.pango_lineage_counts.size(), 24);

--- a/src/silo/storage/metadata_store.cpp
+++ b/src/silo/storage/metadata_store.cpp
@@ -14,14 +14,7 @@ unsigned MetadataStore::fill(
 ) {
    auto metadata_reader = silo::preprocessing::MetadataReader::getReader(input_file);
 
-   std::set<std::string> columns_to_index;
-   for (const auto& element : database_config.schema.metadata) {
-      if (element.generate_index) {
-         columns_to_index.insert(element.name);
-      }
-   }
-
-   initializeColumns(database_config, columns_to_index);
+   initializeColumns(database_config);
 
    unsigned sequence_count = 0;
 
@@ -30,16 +23,15 @@ unsigned MetadataStore::fill(
       for (const auto& item : database_config.schema.metadata) {
          const std::string value = row[item.name].get();
 
-         if (item.type == silo::config::DatabaseMetadataType::STRING) {
-            if (columns_to_index.contains(item.name)) {
-               indexed_string_columns.at(item.name).insert(value);
-            } else {
-               raw_string_columns.at(item.name).insert(value);
-            }
-         } else if (item.type == silo::config::DatabaseMetadataType::PANGOLINEAGE) {
+         const auto column_type = item.getColumnType();
+         if (column_type == silo::config::ColumnType::INDEXED_STRING) {
+            indexed_string_columns.at(item.name).insert(value);
+         } else if (column_type == silo::config::ColumnType::STRING) {
+            raw_string_columns.at(item.name).insert(value);
+         } else if (column_type == silo::config::ColumnType::INDEXED_PANGOLINEAGE) {
             const std::string pango_lineage = alias_key.resolvePangoLineageAlias(value);
             pango_lineage_columns.at(item.name).insert({pango_lineage});
-         } else if (item.type == silo::config::DatabaseMetadataType::DATE) {
+         } else if (column_type == silo::config::ColumnType::DATE) {
             date_columns.at(item.name).insert(common::mapToTime(value));
          }
       }
@@ -49,20 +41,17 @@ unsigned MetadataStore::fill(
    return sequence_count;
 }
 
-void MetadataStore::initializeColumns(
-   const config::DatabaseConfig& database_config,
-   const std::set<std::string>& columns_to_index
-) {
+void MetadataStore::initializeColumns(const config::DatabaseConfig& database_config) {
    for (const auto& item : database_config.schema.metadata) {
-      if (item.type == config::DatabaseMetadataType::STRING) {
-         if (columns_to_index.contains(item.name)) {
-            this->indexed_string_columns[item.name] = storage::column::IndexedStringColumn();
-         } else {
-            this->raw_string_columns[item.name] = storage::column::RawStringColumn();
-         }
-      } else if (item.type == config::DatabaseMetadataType::PANGOLINEAGE) {
+      const auto column_type = item.getColumnType();
+
+      if (column_type == config::ColumnType::INDEXED_STRING) {
+         this->indexed_string_columns.emplace(item.name, storage::column::IndexedStringColumn());
+      } else if (column_type == config::ColumnType::STRING) {
+         this->raw_string_columns.emplace(item.name, storage::column::RawStringColumn());
+      } else if (column_type == config::ColumnType::INDEXED_PANGOLINEAGE) {
          pango_lineage_columns.emplace(item.name, storage::column::PangoLineageColumn());
-      } else if (item.type == config::DatabaseMetadataType::DATE) {
+      } else if (column_type == config::ColumnType::DATE) {
          const auto column = item.name == database_config.schema.date_to_sort_by
                                 ? storage::column::DateColumn(true)
                                 : storage::column::DateColumn(false);

--- a/src/silo/storage/metadata_store.cpp
+++ b/src/silo/storage/metadata_store.cpp
@@ -63,10 +63,9 @@ void MetadataStore::initializeColumns(
       } else if (item.type == config::DatabaseMetadataType::PANGOLINEAGE) {
          pango_lineage_columns.emplace(item.name, storage::column::PangoLineageColumn());
       } else if (item.type == config::DatabaseMetadataType::DATE) {
-         const auto column =
-            item.name == database_config.schema.date_to_sort_by
-               ? storage::column::DateColumn(true)
-               : storage::column::DateColumn(false);
+         const auto column = item.name == database_config.schema.date_to_sort_by
+                                ? storage::column::DateColumn(true)
+                                : storage::column::DateColumn(false);
          date_columns.emplace(item.name, column);
       }
    }

--- a/src/silo/storage/pango_lineage_alias.test.cpp
+++ b/src/silo/storage/pango_lineage_alias.test.cpp
@@ -4,6 +4,8 @@
 
 #include "silo/storage/pango_lineage_alias.h"
 
+namespace {
+
 struct TestParameter {
    std::string input;
    std::string expected_result;
@@ -45,3 +47,5 @@ TEST(PangoLineageAliasLookup, readFromFile) {
    ASSERT_EQ(under_test.resolvePangoLineageAlias("C"), "B.1.1.1");
    ASSERT_EQ(under_test.resolvePangoLineageAlias("EP"), "B.1.1.529.2.75.3.1.1.4");
 }
+
+}  // namespace

--- a/testBaseData/test_database_config.yaml
+++ b/testBaseData/test_database_config.yaml
@@ -9,10 +9,15 @@ schema:
       type: date
     - name: region
       type: string
+      generateIndex: true
     - name: country
       type: string
+      generateIndex: true
     - name: pango_lineage
       type: pango_lineage
     - name: division
       type: string
+      generateIndex: true
   primaryKey: gisaid_epi_isl
+  dateToSortBy: date
+  partitionBy: pango_lineage

--- a/testBaseData/test_database_config_with_additional_entries.yaml
+++ b/testBaseData/test_database_config_with_additional_entries.yaml
@@ -12,5 +12,7 @@ schema:
     - name: pangoLineage
       type: pango_lineage
   primaryKey: gisaid_epi_isl
+  dateToSortBy: date
+  partitionBy: pango_lineage
   features:
     - name: sarsCoV2VariantQuery

--- a/testBaseData/test_database_config_with_invalid_metadata_type.yaml
+++ b/testBaseData/test_database_config_with_invalid_metadata_type.yaml
@@ -4,3 +4,5 @@ schema:
     - name: wrongType
       type: wrong_type
   primaryKey: gisaid_epi_isl
+  dateToSortBy: date
+  partitionBy: pango_lineage

--- a/testBaseData/test_database_config_without_date_to_sort_by.yaml
+++ b/testBaseData/test_database_config_without_date_to_sort_by.yaml
@@ -1,0 +1,7 @@
+schema:
+  instanceName: Having no dateToSortBy is valid
+  metadata:
+    - name: gisaid_epi_isl
+      type: string
+  primaryKey: gisaid_epi_isl
+  partitionBy: pango_lineage


### PR DESCRIPTION
resolves #114 

I think allowing String columns as `partition_by` requires some work, because there is a lot of special logic for pango lineages.