### PR TITLE
ci: allow dependabot to push Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
   dockerImage:
     name: Build And Run Unit Tests
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
See https://github.com/GenSpectrum/cov-spectrum-website/blob/4331258af55fa25798cd4c073d7190e8588f6ec9/.github/workflows/open_docker.yml#L15-L16

This should fix the red builds on Dependabot PRs.