### PR TITLE
fix: metadata reader for large files

### DIFF
--- a/src/silo/prepare_dataset.cpp
+++ b/src/silo/prepare_dataset.cpp
@@ -59,40 +59,6 @@ const std::string TSV_EXTENSION(".tsv");
    }
 }
 
-[[maybe_unused]] void silo::pruneSequences(
-   silo::preprocessing::MetadataReader& metadata_reader,
-   silo::FastaReader& sequences_in,
-   std::ostream& sequences_out,
-   const silo::config::DatabaseConfig& database_config
-) {
-   SPDLOG_INFO("Pruning sequences");
-
-   const auto primary_key_vector = metadata_reader.getColumn(database_config.schema.primary_key);
-   const std::unordered_set<std::string> primary_keys(
-      primary_key_vector.begin(), primary_key_vector.end()
-   );
-
-   SPDLOG_INFO("Finished reading metadata, found {} rows", primary_keys.size());
-
-   uint32_t found_sequences_count = 0;
-   {
-      std::optional<std::string> key;
-      std::string genome;
-      while (true) {
-         key = sequences_in.next(genome);
-         if (!key.has_value()) {
-            break;
-         }
-         if (primary_keys.contains(*key)) {
-            found_sequences_count++;
-            sequences_out << *key << "\n" << genome << "\n";
-            sequences_out << *key << "\n" << genome << "\n";
-         }
-      }
-   }
-   SPDLOG_INFO("Finished reading sequences, found {} sequences", found_sequences_count);
-}
-
 std::unordered_map<std::string, std::unique_ptr<silo::preprocessing::MetadataWriter>>
 getMetadataWritersForChunks(
    const std::filesystem::path& output_folder,


### PR DESCRIPTION
Currently, the metadata reader crashes with a large file (8 million entries) on ubuntu.

The problem originates from `row[column_name].get<std::string>()` in metadata.cpp . 
This PR fixes the issue in a "hacky" way, since it introduces a small delay, so the memory can be freed. 

The original Error Message
`==98926==ERROR: AddressSanitizer: heap-use-after-free on address 0x6210061860b0 at pc 0x559ad04d84d8 bp 0x7fff3801b380 sp 0x7fff3801b370
READ of size 8 at 0x6210061860b0 thread T0
    #0 0x559ad04d84d7 in csv::internals::CSVFieldList::operator[](unsigned long) const /home/kellerer/.conan2/p/vince5ed0da49a4edc/p/include/csv.hpp:7632
    #1 0x559ad04d8d18 in csv::CSVRow::get_field(unsigned long) const /home/kellerer/.conan2/p/vince5ed0da49a4edc/p/include/csv.hpp:7691
    #2 0x559ad04d851d in csv::CSVRow::operator[](unsigned long) const /home/kellerer/.conan2/p/vince5ed0da49a4edc/p/include/csv.hpp:7653
    #3 0x559ad04d866a in csv::CSVRow::operator[](std::__cxx11::basic_string<char, std::char_traits<char>,`