### PR TITLE
feat: More robust InputStreamWrapper

### DIFF
--- a/src/silo/common/input_stream_wrapper.cpp
+++ b/src/silo/common/input_stream_wrapper.cpp
@@ -13,12 +13,12 @@
 
 namespace {
 
-std::filesystem::path appendXZ(const std::filesystem::path& filename) {
-   return {filename.string() + ".xz"};
+std::filesystem::path withXZending(const std::filesystem::path& filename) {
+   return {filename.extension() == ".xz" ? filename.string() : filename.string() + ".xz"};
 }
 
-std::filesystem::path appendZST(const std::filesystem::path& filename) {
-   return {filename.string() + ".zst"};
+std::filesystem::path withZSTending(const std::filesystem::path& filename) {
+   return {filename.extension() == ".zst" ? filename.string() : filename.string() + ".zst"};
 }
 
 }  // namespace
@@ -26,17 +26,17 @@ std::filesystem::path appendZST(const std::filesystem::path& filename) {
 namespace silo {
 InputStreamWrapper::InputStreamWrapper(const std::filesystem::path& filename)
     : input_stream(std::make_unique<boost::iostreams::filtering_istream>()) {
-   if (std::filesystem::exists(filename)) {
+   if (std::filesystem::is_regular_file(withZSTending(filename))) {
+      SPDLOG_INFO("Detected file-ending .zst for input file " + filename.string());
+      file = std::ifstream(withZSTending(filename), std::ios::binary);
+      input_stream->push(boost::iostreams::zstd_decompressor());
+   } else if (std::filesystem::is_regular_file(withXZending(filename))) {
+      SPDLOG_INFO("Detected file-ending .xz for input file " + filename.string());
+      file = std::ifstream(withXZending(filename), std::ios::binary);
+      input_stream->push(boost::iostreams::lzma_decompressor());
+   } else if (std::filesystem::is_regular_file(filename)) {
       SPDLOG_INFO("Detected file without specialized ending, processing raw: " + filename.string());
       file = std::ifstream(filename, std::ios::binary);
-   } else if (std::filesystem::exists(appendXZ(filename))) {
-      SPDLOG_INFO("Detected file-ending .xz for input file " + filename.string());
-      file = std::ifstream(appendXZ(filename), std::ios::binary);
-      input_stream->push(boost::iostreams::lzma_decompressor());
-   } else if (std::filesystem::exists(appendZST(filename))) {
-      SPDLOG_INFO("Detected file-ending .zst for input file " + filename.string());
-      file = std::ifstream(appendZST(filename), std::ios::binary);
-      input_stream->push(boost::iostreams::zstd_decompressor());
    } else {
       throw silo::PreprocessingException(
          "Cannot find file with name or associated endings (.xz, .zst): " + filename.string()


### PR DESCRIPTION
A very small PR with 2 QoL changes.

I lost quite some time debugging, because a file due to experiments, a **folder** was generated that had the name (minus compression extension) of an input file. This was also detected by filesystem::exists. Now we check for actual regular files.

Moreover, a user should also be able to specify compressed files as input, and the InputStreamWrapper should recognise that it already has a .xz or .zst ending, without trying to forcefully append the ending when it wants to read compressed input files.