### PR TITLE
feat: reenable pushdown of And expressions through selections

### DIFF
--- a/include/silo/common/string.h
+++ b/include/silo/common/string.h
@@ -68,6 +68,8 @@ struct String {
    bool operator!=(const String& other) const;
 };
 
+typedef common::String<STRING_SIZE> SiloString;
+
 }  // namespace silo::common
 
 template <size_t I>

--- a/include/silo/query_engine/filter_expressions/and.h
+++ b/include/silo/query_engine/filter_expressions/and.h
@@ -16,6 +16,7 @@ class DatabasePartition;
 namespace query_engine {
 namespace operators {
 class Operator;
+class Predicate;
 }  // namespace operators
 }  // namespace query_engine
 struct Database;
@@ -29,7 +30,8 @@ struct And : public Expression {
 
    std::tuple<
       std::vector<std::unique_ptr<operators::Operator>>,
-      std::vector<std::unique_ptr<operators::Operator>>>
+      std::vector<std::unique_ptr<operators::Operator>>,
+      std::vector<std::unique_ptr<operators::Predicate>>>
    compileChildren(
       const Database& database,
       const DatabasePartition& database_partition,

--- a/include/silo/query_engine/operators/selection.h
+++ b/include/silo/query_engine/operators/selection.h
@@ -10,26 +10,63 @@
 #include "silo/query_engine/operator_result.h"
 #include "silo/query_engine/operators/operator.h"
 
+namespace silo::query_engine::filter_expressions {
+struct And;
+}
+
 namespace silo::query_engine::operators {
 
-template <typename T>
-class Selection : public Operator {
+class Predicate {
   public:
-   enum Comparator { EQUALS, LESS, HIGHER, LESS_OR_EQUALS, HIGHER_OR_EQUALS, NOT_EQUALS };
+   virtual ~Predicate() noexcept = default;
 
-  private:
+   virtual std::string toString() const = 0;
+   virtual bool match(uint32_t row_id) const = 0;
+   virtual std::unique_ptr<Predicate> copy() const = 0;
+   virtual std::unique_ptr<Predicate> negate() const = 0;
+};
+
+enum class Comparator { EQUALS, LESS, HIGHER, LESS_OR_EQUALS, HIGHER_OR_EQUALS, NOT_EQUALS };
+
+template <typename T>
+class CompareToValueSelection : public Predicate {
    const std::vector<T>& column;
    Comparator comparator;
    T value;
+
+  public:
+   explicit CompareToValueSelection(const std::vector<T>& column, Comparator comparator, T value);
+
+   [[nodiscard]] std::string toString() const override;
+   [[nodiscard]] bool match(uint32_t row_id) const override;
+   [[nodiscard]] std::unique_ptr<Predicate> copy() const override;
+   [[nodiscard]] std::unique_ptr<Predicate> negate() const override;
+};
+
+class Selection : public Operator {
+   friend class filter_expressions::And;
+
+  private:
+   std::optional<std::unique_ptr<Operator>> child_operator;
+   std::vector<std::unique_ptr<Predicate>> predicates;
    uint32_t row_count;
 
   public:
-   explicit Selection(
-      const std::vector<T>& column,
-      Comparator comparator,
-      T value,
+   Selection(
+      std::unique_ptr<Operator>&& child_operator,
+      std::vector<std::unique_ptr<Predicate>>&& predicates,
       uint32_t row_count
    );
+
+   Selection(
+      std::unique_ptr<Operator>&& child_operator,
+      std::unique_ptr<Predicate> predicate,
+      uint32_t row_count
+   );
+
+   Selection(std::vector<std::unique_ptr<Predicate>>&& predicates, uint32_t row_count);
+
+   Selection(std::unique_ptr<Predicate> predicate, uint32_t row_count);
 
    ~Selection() noexcept override;
 
@@ -42,6 +79,9 @@ class Selection : public Operator {
    virtual std::unique_ptr<Operator> copy() const override;
 
    virtual std::unique_ptr<Operator> negate() const override;
+
+  private:
+   virtual bool matchesPredicates(uint32_t row) const;
 };
 
 }  // namespace silo::query_engine::operators

--- a/src/silo/preprocessing/partition.cpp
+++ b/src/silo/preprocessing/partition.cpp
@@ -90,7 +90,7 @@ std::vector<silo::preprocessing::Chunk> mergePangosToChunks(
 }
 
 silo::preprocessing::Partition::Partition(std::vector<Chunk>&& chunks_)
-    : chunks(chunks_) {
+    : chunks(std::move(chunks_)) {
    uint32_t running_total = 0;
    for (Chunk& chunk : chunks) {
       chunk.offset = running_total;

--- a/src/silo/query_engine/filter_expressions/and.cpp
+++ b/src/silo/query_engine/filter_expressions/and.cpp
@@ -16,6 +16,7 @@
 #include "silo/query_engine/operators/full.h"
 #include "silo/query_engine/operators/intersection.h"
 #include "silo/query_engine/operators/operator.h"
+#include "silo/query_engine/operators/selection.h"
 #include "silo/query_engine/operators/union.h"
 #include "silo/query_engine/query_parse_exception.h"
 #include "silo/storage/database_partition.h"
@@ -27,6 +28,7 @@ struct Database;
 namespace silo::query_engine::filter_expressions {
 
 using OperatorVector = std::vector<std::unique_ptr<operators::Operator>>;
+using operators::Operator;
 
 And::And(std::vector<std::unique_ptr<Expression>>&& children)
     : children(std::move(children)) {}
@@ -45,21 +47,26 @@ std::string And::toString(const silo::Database& database) const {
 
 namespace {
 
-void inline appendVectorToVector(OperatorVector& vec_1, OperatorVector& vec_2) {
+template <typename T>
+void inline appendVectorToVector(
+   std::vector<std::unique_ptr<T>>& vec_1,
+   std::vector<std::unique_ptr<T>>& vec_2
+) {
    std::transform(
       vec_1.begin(),
       vec_1.end(),
       std::back_inserter(vec_2),
-      [&](std::unique_ptr<operators::Operator>& ele) { return std::move(ele); }
+      [&](std::unique_ptr<T>& ele) { return std::move(ele); }
    );
 }
 }  // namespace
 
-std::tuple<OperatorVector, OperatorVector> And::compileChildren(
-   const Database& database,
-   const DatabasePartition& database_partition,
-   AmbiguityMode mode
-) const {
+std::tuple<OperatorVector, OperatorVector, std::vector<std::unique_ptr<operators::Predicate>>> And::
+   compileChildren(
+      const Database& database,
+      const DatabasePartition& database_partition,
+      AmbiguityMode mode
+   ) const {
    OperatorVector all_child_operators;
    std::transform(
       children.begin(),
@@ -71,6 +78,7 @@ std::tuple<OperatorVector, OperatorVector> And::compileChildren(
    );
    OperatorVector non_negated_child_operators;
    OperatorVector negated_child_operators;
+   std::vector<std::unique_ptr<operators::Predicate>> predicates;
    for (auto& child : all_child_operators) {
       if (child->type() == operators::FULL) {
          continue;
@@ -78,7 +86,10 @@ std::tuple<OperatorVector, OperatorVector> And::compileChildren(
       if (child->type() == operators::EMPTY) {
          OperatorVector empty;
          empty.emplace_back(std::make_unique<operators::Empty>(database_partition.sequenceCount));
-         return {std::move(empty), OperatorVector()};
+         return {
+            std::move(empty),
+            OperatorVector(),
+            std::vector<std::unique_ptr<operators::Predicate>>{}};
       }
       if (child->type() == operators::INTERSECTION) {
          auto* intersection_child = dynamic_cast<operators::Intersection*>(child.get());
@@ -86,46 +97,65 @@ std::tuple<OperatorVector, OperatorVector> And::compileChildren(
          appendVectorToVector(intersection_child->negated_children, negated_child_operators);
       } else if (child->type() == operators::COMPLEMENT) {
          negated_child_operators.emplace_back(child->negate());
+      } else if (child->type() == operators::SELECTION) {
+         auto* selection_child = dynamic_cast<operators::Selection*>(child.get());
+         appendVectorToVector<operators::Predicate>(predicates, selection_child->predicates);
+         if (selection_child->child_operator.has_value()) {
+            all_child_operators.emplace_back(std::move(*selection_child->child_operator));
+         }
       } else {
          non_negated_child_operators.push_back(std::move(child));
       }
    }
-   return {std::move(non_negated_child_operators), std::move(negated_child_operators)};
+   return {
+      std::move(non_negated_child_operators),
+      std::move(negated_child_operators),
+      std::move(predicates)};
 }
 
-std::unique_ptr<operators::Operator> And::compile(
+std::unique_ptr<Operator> And::compile(
    const Database& database,
    const DatabasePartition& database_partition,
    AmbiguityMode mode
 ) const {
-   OperatorVector non_negated_child_operators;
-   OperatorVector negated_child_operators;
-   std::tie(non_negated_child_operators, negated_child_operators) =
+   auto [non_negated_child_operators, negated_child_operators, predicates] =
       compileChildren(database, database_partition, mode);
 
+   std::optional<std::unique_ptr<Operator>> index_arithmetic_operator;
    if (non_negated_child_operators.empty() && negated_child_operators.empty()) {
-      return std::make_unique<operators::Full>(database_partition.sequenceCount);
-   }
-   if (non_negated_child_operators.size() == 1 && negated_child_operators.empty()) {
-      return std::move(non_negated_child_operators[0]);
-   }
-   if (negated_child_operators.size() == 1 && non_negated_child_operators.empty()) {
-      return std::make_unique<operators::Complement>(
+      if (predicates.empty()) {
+         return std::make_unique<operators::Full>(database_partition.sequenceCount);
+      }
+   } else if (non_negated_child_operators.size() == 1 && negated_child_operators.empty()) {
+      index_arithmetic_operator = std::move(non_negated_child_operators[0]);
+   } else if (negated_child_operators.size() == 1 && non_negated_child_operators.empty()) {
+      index_arithmetic_operator = std::make_unique<operators::Complement>(
          std::move(negated_child_operators[0]), database_partition.sequenceCount
       );
-   }
-   if (non_negated_child_operators.empty()) {
+   } else if (non_negated_child_operators.empty()) {
       std::unique_ptr<operators::Union> union_ret = std::make_unique<operators::Union>(
          std::move(negated_child_operators), database_partition.sequenceCount
       );
-      return std::make_unique<operators::Complement>(
+      index_arithmetic_operator = std::make_unique<operators::Complement>(
          std::move(union_ret), database_partition.sequenceCount
       );
+   } else {
+      index_arithmetic_operator = std::make_unique<operators::Intersection>(
+         std::move(non_negated_child_operators),
+         std::move(negated_child_operators),
+         database_partition.sequenceCount
+      );
    }
-   return std::make_unique<operators::Intersection>(
-      std::move(non_negated_child_operators),
-      std::move(negated_child_operators),
-      database_partition.sequenceCount
+   if (predicates.empty() && index_arithmetic_operator.has_value()) {
+      return std::move(*index_arithmetic_operator);
+   }
+   if (index_arithmetic_operator == std::nullopt) {
+      return std::make_unique<operators::Selection>(
+         std::move(predicates), database_partition.sequenceCount
+      );
+   }
+   return std::make_unique<operators::Selection>(
+      std::move(*index_arithmetic_operator), std::move(predicates), database_partition.sequenceCount
    );
 }
 

--- a/src/silo/query_engine/filter_expressions/float_equals.cpp
+++ b/src/silo/query_engine/filter_expressions/float_equals.cpp
@@ -44,10 +44,10 @@ std::unique_ptr<silo::query_engine::operators::Operator> FloatEquals::compile(
 
    const auto& float_column = database_partition.columns.float_columns.at(column);
 
-   return std::make_unique<operators::Selection<double>>(
-      float_column.getValues(),
-      operators::Selection<double>::EQUALS,
-      value,
+   return std::make_unique<operators::Selection>(
+      std::make_unique<operators::CompareToValueSelection<double>>(
+         float_column.getValues(), operators::Comparator::EQUALS, value
+      ),
       database_partition.sequenceCount
    );
 }

--- a/src/silo/query_engine/filter_expressions/int_equals.cpp
+++ b/src/silo/query_engine/filter_expressions/int_equals.cpp
@@ -42,10 +42,10 @@ std::unique_ptr<silo::query_engine::operators::Operator> IntEquals::compile(
 
    const auto& int_column = database_partition.columns.int_columns.at(column);
 
-   return std::make_unique<operators::Selection<int32_t>>(
-      int_column.getValues(),
-      operators::Selection<int32_t>::EQUALS,
-      value,
+   return std::make_unique<operators::Selection>(
+      std::make_unique<operators::CompareToValueSelection<int32_t>>(
+         int_column.getValues(), operators::Comparator::EQUALS, value
+      ),
       database_partition.sequenceCount
    );
 }

--- a/src/silo/query_engine/filter_expressions/nof.cpp
+++ b/src/silo/query_engine/filter_expressions/nof.cpp
@@ -225,10 +225,7 @@ std::unique_ptr<operators::Operator> NOf::rewriteNonExact(
 ) const {
    std::vector<std::unique_ptr<operators::Operator>> at_least_k;
    {
-      int updated_number_of_matchers;
-      std::vector<std::unique_ptr<operators::Operator>> non_negated_child_operators;
-      std::vector<std::unique_ptr<operators::Operator>> negated_child_operators;
-      std::tie(non_negated_child_operators, negated_child_operators, updated_number_of_matchers) =
+      auto [non_negated_child_operators, negated_child_operators, updated_number_of_matchers] =
          mapChildExpressions(database, database_partition, mode);
       at_least_k.emplace_back(toOperator(
          updated_number_of_matchers,
@@ -241,10 +238,7 @@ std::unique_ptr<operators::Operator> NOf::rewriteNonExact(
 
    std::vector<std::unique_ptr<operators::Operator>> at_least_k_plus_one;
    {
-      int updated_number_of_matchers;
-      std::vector<std::unique_ptr<operators::Operator>> non_negated_child_operators;
-      std::vector<std::unique_ptr<operators::Operator>> negated_child_operators;
-      std::tie(non_negated_child_operators, negated_child_operators, updated_number_of_matchers) =
+      auto [non_negated_child_operators, negated_child_operators, updated_number_of_matchers] =
          mapChildExpressions(database, database_partition, mode);
       at_least_k_plus_one.emplace_back(toOperator(
          updated_number_of_matchers + 1,
@@ -269,10 +263,7 @@ std::unique_ptr<operators::Operator> NOf::compile(
    const silo::DatabasePartition& database_partition,
    Expression::AmbiguityMode mode
 ) const {
-   int updated_number_of_matchers;
-   std::vector<std::unique_ptr<operators::Operator>> non_negated_child_operators;
-   std::vector<std::unique_ptr<operators::Operator>> negated_child_operators;
-   std::tie(non_negated_child_operators, negated_child_operators, updated_number_of_matchers) =
+   auto [non_negated_child_operators, negated_child_operators, updated_number_of_matchers] =
       mapChildExpressions(database, database_partition, mode);
 
    // We cannot easily map ambiguity modes through an exact NOf expression -> rewrite without exact

--- a/src/silo/query_engine/filter_expressions/string_equals.cpp
+++ b/src/silo/query_engine/filter_expressions/string_equals.cpp
@@ -56,10 +56,10 @@ std::unique_ptr<silo::query_engine::operators::Operator> StringEquals::compile(
       const auto& string_column = database_partition.columns.string_columns.at(column);
       const auto& embedded_string = string_column.embedString(value);
       if (embedded_string.has_value()) {
-         return std::make_unique<operators::Selection<common::String<silo::common::STRING_SIZE>>>(
-            string_column.getValues(),
-            operators::Selection<common::String<silo::common::STRING_SIZE>>::EQUALS,
-            embedded_string.value(),
+         return std::make_unique<operators::Selection>(
+            std::make_unique<operators::CompareToValueSelection<common::SiloString>>(
+               string_column.getValues(), operators::Comparator::EQUALS, embedded_string.value()
+            ),
             database_partition.sequenceCount
          );
       }

--- a/src/silo/query_engine/operators/selection.test.cpp
+++ b/src/silo/query_engine/operators/selection.test.cpp
@@ -3,14 +3,18 @@
 #include <gtest/gtest.h>
 #include <roaring/roaring.hh>
 
+using silo::query_engine::operators::Comparator;
+using silo::query_engine::operators::CompareToValueSelection;
 using silo::query_engine::operators::Selection;
 
 TEST(OperatorSelection, equalsShouldReturnCorrectValues) {
    const std::vector<int32_t> test_column({{0, 1, 4, 4, 4, 1, 1, 1, 1, 1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection<int32_t> under_test(
-      test_column, Selection<int32_t>::Comparator::EQUALS, 1, row_count
+   const Selection under_test(
+
+      std::make_unique<CompareToValueSelection<int32_t>>(test_column, Comparator::EQUALS, 1),
+      row_count
    );
 
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({1, 5, 6, 7, 8, 9}));
@@ -22,8 +26,10 @@ TEST(OperatorSelection, notEqualsShouldReturnCorrectValues) {
    const std::vector<int32_t> test_column({{0, 1, 4, 4, 4, 1, 1, 1, 1, 1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection<int32_t> under_test(
-      test_column, Selection<int32_t>::Comparator::NOT_EQUALS, 1, row_count
+   const Selection under_test(
+
+      std::make_unique<CompareToValueSelection<int32_t>>(test_column, Comparator::NOT_EQUALS, 1),
+      row_count
    );
 
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({0, 2, 3, 4}));
@@ -35,8 +41,9 @@ TEST(OperatorSelection, lessShouldReturnCorrectValues) {
    const std::vector<int32_t> test_column({{0, 1, 4, 4, 4, 1, 1, 1, 1, 1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection<int32_t> under_test(
-      test_column, Selection<int32_t>::Comparator::LESS, 1, row_count
+   const Selection under_test(
+      std::make_unique<CompareToValueSelection<int32_t>>(test_column, Comparator::LESS, 1),
+      row_count
    );
 
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({0}));
@@ -48,8 +55,11 @@ TEST(OperatorSelection, lessOrEqualsShouldReturnCorrectValues) {
    const std::vector<int32_t> test_column({{0, 1, 4, 4, 4, 1, 1, 1, 1, 1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection<int32_t> under_test(
-      test_column, Selection<int32_t>::Comparator::LESS_OR_EQUALS, 1, row_count
+   const Selection under_test(
+      std::make_unique<CompareToValueSelection<int32_t>>(
+         test_column, Comparator::LESS_OR_EQUALS, 1
+      ),
+      row_count
    );
 
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({0, 1, 5, 6, 7, 8, 9}));
@@ -61,8 +71,12 @@ TEST(OperatorSelection, higherOrEqualsShouldReturnCorrectValues) {
    const std::vector<int32_t> test_column({{0, 1, 4, 4, 4, 1, 1, 1, 1, 1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection<int32_t> under_test(
-      test_column, Selection<int32_t>::Comparator::HIGHER_OR_EQUALS, 1, row_count
+   const Selection under_test(
+
+      std::make_unique<CompareToValueSelection<int32_t>>(
+         test_column, Comparator::HIGHER_OR_EQUALS, 1
+      ),
+      row_count
    );
 
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({1, 2, 3, 4, 5, 6, 7, 8, 9}));
@@ -74,8 +88,10 @@ TEST(OperatorSelection, higherShouldReturnCorrectValues) {
    const std::vector<int32_t> test_column({{0, 1, 4, 4, 4, 1, 1, 1, 1, 1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection<int32_t> under_test(
-      test_column, Selection<int32_t>::Comparator::HIGHER, 1, row_count
+   const Selection under_test(
+
+      std::make_unique<CompareToValueSelection<int32_t>>(test_column, Comparator::HIGHER, 1),
+      row_count
    );
 
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({2, 3, 4}));
@@ -87,8 +103,10 @@ TEST(OperatorSelection, correctWithNegativeNumbers) {
    const std::vector<int32_t> test_column({{0, -1, 4, 4, 4, -1, -1, -1, -1, -1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection<int32_t> under_test(
-      test_column, Selection<int32_t>::Comparator::EQUALS, -1, row_count
+   const Selection under_test(
+
+      std::make_unique<CompareToValueSelection<int32_t>>(test_column, Comparator::EQUALS, -1),
+      row_count
    );
 
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({1, 5, 6, 7, 8, 9}));
@@ -98,8 +116,10 @@ TEST(OperatorSelection, returnsCorrectTypeInfo) {
    const std::vector<int32_t> test_column({{0, -1, 4, 4, 4, -1, -1, -1, -1, -1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection<int32_t> under_test(
-      test_column, Selection<int32_t>::Comparator::EQUALS, -1, row_count
+   const Selection under_test(
+
+      std::make_unique<CompareToValueSelection<int32_t>>(test_column, Comparator::EQUALS, -1),
+      row_count
    );
 
    ASSERT_EQ(under_test.type(), silo::query_engine::operators::SELECTION);


### PR DESCRIPTION
The initial version (aka Master Thesis state) of SILO had push down of And expressions / Intersection operators through Selections that need to iterate over all values.
This helped to separate the part for which SILO was really optimized for: working with indexes that have already been precomputed and performing the requested arithmetic on them

The queries for which we do not have indexes are best evaluated at the end, when we already reduced the number of rows we need to check using our indexes.

With this PR selections can have child operators again and will only be evaluated on those. If no child operator is present, they still iterate over the entire Table.