### PR TITLE
feat: use same default min proportions for mutations actions as LAPIS

### DIFF
--- a/include/silo/query_engine/actions/aa_mutations.h
+++ b/include/silo/query_engine/actions/aa_mutations.h
@@ -65,7 +65,7 @@ class AAMutations : public Action {
    };
 
   public:
-   static constexpr double DEFAULT_MIN_PROPORTION = 0.02;
+   static constexpr double DEFAULT_MIN_PROPORTION = 0.05;
 
   private:
    static PrefilteredBitmaps preFilterBitmaps(

--- a/include/silo/query_engine/actions/nuc_mutations.h
+++ b/include/silo/query_engine/actions/nuc_mutations.h
@@ -49,7 +49,7 @@ class NucMutations : public Action {
    };
 
   public:
-   static constexpr double DEFAULT_MIN_PROPORTION = 0.02;
+   static constexpr double DEFAULT_MIN_PROPORTION = 0.05;
 
   private:
    static PrefilteredBitmaps preFilterBitmaps(


### PR DESCRIPTION
See https://github.com/GenSpectrum/LAPIS/blob/a5cd5a431a88318ab2593bd6c884960ea8ef1f6a/server/src/main/java/ch/ethz/lapis/api/entity/req/MutationRequest.java#L6