### PR TITLE
Return the data version

### DIFF
--- a/endToEndTests/test/common.js
+++ b/endToEndTests/test/common.js
@@ -1,4 +1,5 @@
 const supertest = require('supertest');
+const { expect } = require('chai');
 
 const siloUrl = process.env.SILO_URL;
 if (!siloUrl) {
@@ -7,6 +8,15 @@ if (!siloUrl) {
 
 const server = supertest.agent(siloUrl);
 
+function headerToHaveDataVersion(response) {
+  const headers = response.headers;
+  expect(headers).to.have.property('data-version');
+  const dataVersion = headers['data-version'];
+  expect(dataVersion).to.be.a('string');
+  expect(dataVersion).to.match(/\d{10}/);
+}
+
 module.exports = {
   server,
+  headerToHaveDataVersion,
 };

--- a/endToEndTests/test/info.test.js
+++ b/endToEndTests/test/info.test.js
@@ -1,4 +1,4 @@
-const { server } = require('./common');
+const { server, headerToHaveDataVersion } = require('./common');
 const { expect } = require('chai');
 
 describe('The /info endpoint', () => {
@@ -7,6 +7,7 @@ describe('The /info endpoint', () => {
       .get('/info')
       .expect(200)
       .expect('Content-Type', 'application/json')
+      .expect(headerToHaveDataVersion)
       .expect({ nBitmapsSize: 3898, sequenceCount: 100, totalSize: 60057070 })
       .end(done);
   });
@@ -79,6 +80,7 @@ describe('The /info endpoint', () => {
           'Y': 5980620,
         });
       })
+      .expect(headerToHaveDataVersion)
       .end(done);
   });
 });

--- a/endToEndTests/test/query.test.js
+++ b/endToEndTests/test/query.test.js
@@ -1,4 +1,4 @@
-const { server } = require('./common');
+const { server, headerToHaveDataVersion } = require('./common');
 const fs = require('fs');
 const { expect } = require('chai');
 
@@ -16,7 +16,8 @@ describe('The /query endpoint', () => {
         .post('/query')
         .send(testCase.query)
         .expect(200)
-        .expect('Content-Type', 'application/json');
+        .expect('Content-Type', 'application/json')
+        .expect(headerToHaveDataVersion);
       return expect(response.body.queryResult).to.deep.equal(testCase.expectedQueryResult);
     })
   );

--- a/include/silo/common/data_version.h
+++ b/include/silo/common/data_version.h
@@ -1,0 +1,17 @@
+#ifndef SILO_INCLUDE_SILO_COMMON_DATAVERSION_H_
+#define SILO_INCLUDE_SILO_COMMON_DATAVERSION_H_
+
+#include <string>
+
+class DataVersion {
+  public:
+   explicit DataVersion(const std::string& data_version = "");
+   [[nodiscard]] std::string toString() const;
+
+   static std::string mineDataVersion();
+
+  private:
+   std::string data_version;
+};
+
+#endif  // SILO_INCLUDE_SILO_COMMON_DATAVERSION_H_

--- a/include/silo/common/data_version.h
+++ b/include/silo/common/data_version.h
@@ -3,6 +3,8 @@
 
 #include <string>
 
+namespace silo {
+
 class DataVersion {
   public:
    explicit DataVersion(const std::string& data_version = "");
@@ -13,5 +15,7 @@ class DataVersion {
   private:
    std::string data_version;
 };
+
+}  // namespace silo
 
 #endif  // SILO_INCLUDE_SILO_COMMON_DATAVERSION_H_

--- a/include/silo/database.h
+++ b/include/silo/database.h
@@ -61,7 +61,7 @@ class Database {
    [[nodiscard]] const PangoLineageAliasLookup& getAliasKey() const;
 
    void setDataVersion(const DataVersion& data_version);
-   DataVersion getDataVersion() const;
+   virtual DataVersion getDataVersion() const;
 
   private:
    PangoLineageAliasLookup alias_key;

--- a/include/silo/database.h
+++ b/include/silo/database.h
@@ -1,6 +1,7 @@
 #ifndef SILO_DATABASE_H
 #define SILO_DATABASE_H
 
+#include <silo/common/data_version.h>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
@@ -36,9 +37,6 @@ struct PreprocessingConfig;
 namespace silo {
 
 class Database {
-  private:
-   PangoLineageAliasLookup alias_key;
-
   public:
    silo::config::DatabaseConfig database_config;
    std::vector<DatabasePartition> partitions;
@@ -62,7 +60,13 @@ class Database {
 
    [[nodiscard]] const PangoLineageAliasLookup& getAliasKey() const;
 
+   void setDataVersion(const DataVersion& data_version);
+   DataVersion getDataVersion() const;
+
   private:
+   PangoLineageAliasLookup alias_key;
+   DataVersion data_version_;
+
    void build(
       const preprocessing::PreprocessingConfig& preprocessing_config,
       const preprocessing::Partitions& partition_descriptor,

--- a/include/silo/database.h
+++ b/include/silo/database.h
@@ -1,7 +1,6 @@
 #ifndef SILO_DATABASE_H
 #define SILO_DATABASE_H
 
-#include <silo/common/data_version.h>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
@@ -9,6 +8,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "silo/common/data_version.h"
 #include "silo/config/database_config.h"
 #include "silo/storage/aa_store.h"
 #include "silo/storage/column/date_column.h"

--- a/include/silo_api/query_handler.h
+++ b/include/silo_api/query_handler.h
@@ -14,9 +14,13 @@ namespace silo_api {
 class QueryHandler : public RestResource {
   private:
    const silo::query_engine::QueryEngine& query_engine;
+   const std::string data_version;
 
   public:
-   explicit QueryHandler(const silo::query_engine::QueryEngine& query_engine);
+   explicit QueryHandler(
+      const silo::query_engine::QueryEngine& query_engine,
+      std::string data_version
+   );
 
    void post(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response)
       override;

--- a/include/silo_api/query_handler.h
+++ b/include/silo_api/query_handler.h
@@ -9,17 +9,20 @@
 namespace silo::query_engine {
 class QueryEngine;
 }
+namespace silo {
+class Database;
+}
 
 namespace silo_api {
 class QueryHandler : public RestResource {
   private:
    const silo::query_engine::QueryEngine& query_engine;
-   const std::string data_version;
+   const silo::Database& database;
 
   public:
    explicit QueryHandler(
       const silo::query_engine::QueryEngine& query_engine,
-      std::string data_version
+      const silo::Database& database
    );
 
    void post(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response)

--- a/src/silo/common/data_version.cpp
+++ b/src/silo/common/data_version.cpp
@@ -2,6 +2,8 @@
 
 #include <chrono>
 
+namespace silo {
+
 std::string DataVersion::mineDataVersion() {
    const auto now = std::chrono::system_clock::now();
    const auto now_as_time_t = std::chrono::system_clock::to_time_t(now);
@@ -14,3 +16,5 @@ DataVersion::DataVersion(const std::string& data_version)
 std::string DataVersion::toString() const {
    return data_version;
 }
+
+}  // namespace silo

--- a/src/silo/common/data_version.cpp
+++ b/src/silo/common/data_version.cpp
@@ -1,0 +1,16 @@
+#include "silo/common/data_version.h"
+
+#include <chrono>
+
+std::string DataVersion::mineDataVersion() {
+   const auto now = std::chrono::system_clock::now();
+   const auto now_as_time_t = std::chrono::system_clock::to_time_t(now);
+   return std::to_string(now_as_time_t);
+}
+
+DataVersion::DataVersion(const std::string& data_version)
+    : data_version(data_version) {}
+
+std::string DataVersion::toString() const {
+   return data_version;
+}

--- a/src/silo/common/data_version.test.cpp
+++ b/src/silo/common/data_version.test.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+using silo::DataVersion;
+
 TEST(DataVersion, shouldMineDataVersionFromUnixTime) {
    const auto mined_version = DataVersion::mineDataVersion();
    EXPECT_EQ(mined_version.size(), 10);

--- a/src/silo/common/data_version.test.cpp
+++ b/src/silo/common/data_version.test.cpp
@@ -1,0 +1,19 @@
+#include "silo/common/data_version.h"
+
+#include <gtest/gtest.h>
+
+TEST(DataVersion, shouldMineDataVersionFromUnixTime) {
+   const auto mined_version = DataVersion::mineDataVersion();
+   EXPECT_EQ(mined_version.size(), 10);
+   EXPECT_EQ(mined_version[0], '1');
+}
+
+TEST(DataVersion, shouldConstructFromVersionString) {
+   const auto version = DataVersion("1234567890");
+   EXPECT_EQ(version.toString(), "1234567890");
+}
+
+TEST(DataVersion, shouldConstructWithDefaultVersion) {
+   const auto version = DataVersion();
+   EXPECT_EQ(version.toString(), "");
+}

--- a/src/silo_api/info_handler.cpp
+++ b/src/silo_api/info_handler.cpp
@@ -88,6 +88,8 @@ void InfoHandler::get(
 ) {
    const auto request_parameter = getQueryParameter(request);
 
+   response.set("data-version", database.getDataVersion().toString());
+
    if(request_parameter.find("details") != request_parameter.end() && request_parameter.at("details") == "true") {
       returnDetailedDatabaseInfo(response);
       return;

--- a/src/silo_api/query_handler.cpp
+++ b/src/silo_api/query_handler.cpp
@@ -8,6 +8,7 @@
 #include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
 
+#include "silo/database.h"
 #include "silo/query_engine/query_engine.h"
 #include "silo/query_engine/query_parse_exception.h"
 #include "silo/query_engine/query_result.h"
@@ -17,10 +18,10 @@ namespace silo_api {
 
 QueryHandler::QueryHandler(
    const silo::query_engine::QueryEngine& query_engine,
-   std::string data_version
+   const silo::Database& database
 )
     : query_engine(query_engine),
-      data_version(std::move(data_version)) {}
+      database(database) {}
 
 void QueryHandler::post(
    Poco::Net::HTTPServerRequest& request,
@@ -36,7 +37,7 @@ void QueryHandler::post(
    try {
       const auto query_result = query_engine.executeQuery(query);
 
-      response.set("data-version", data_version);
+      response.set("data-version", database.getDataVersion().toString());
 
       std::ostream& out_stream = response.send();
       out_stream << nlohmann::json(query_result);

--- a/src/silo_api/query_handler.cpp
+++ b/src/silo_api/query_handler.cpp
@@ -15,8 +15,12 @@
 
 namespace silo_api {
 
-QueryHandler::QueryHandler(const silo::query_engine::QueryEngine& query_engine)
-    : query_engine(query_engine) {}
+QueryHandler::QueryHandler(
+   const silo::query_engine::QueryEngine& query_engine,
+   std::string data_version
+)
+    : query_engine(query_engine),
+      data_version(std::move(data_version)) {}
 
 void QueryHandler::post(
    Poco::Net::HTTPServerRequest& request,
@@ -29,9 +33,10 @@ void QueryHandler::post(
    SPDLOG_INFO("received query: {}", query);
 
    response.setContentType("application/json");
-
    try {
       const auto query_result = query_engine.executeQuery(query);
+
+      response.set("Data-Version", data_version);
 
       std::ostream& out_stream = response.send();
       out_stream << nlohmann::json(query_result);

--- a/src/silo_api/query_handler.cpp
+++ b/src/silo_api/query_handler.cpp
@@ -36,7 +36,7 @@ void QueryHandler::post(
    try {
       const auto query_result = query_engine.executeQuery(query);
 
-      response.set("Data-Version", data_version);
+      response.set("data-version", data_version);
 
       std::ostream& out_stream = response.send();
       out_stream << nlohmann::json(query_result);

--- a/src/silo_api/request_handler_factory.cpp
+++ b/src/silo_api/request_handler_factory.cpp
@@ -36,7 +36,7 @@ Poco::Net::HTTPRequestHandler* SiloRequestHandlerFactory::routeRequest(
       return new silo_api::InfoHandler(database);
    }
    if (path == "/query") {
-      return new silo_api::QueryHandler(query_engine, database.getDataVersion().toString());
+      return new silo_api::QueryHandler(query_engine, database);
    }
    return new silo_api::NotFoundHandler;
 }

--- a/src/silo_api/request_handler_factory.cpp
+++ b/src/silo_api/request_handler_factory.cpp
@@ -36,7 +36,7 @@ Poco::Net::HTTPRequestHandler* SiloRequestHandlerFactory::routeRequest(
       return new silo_api::InfoHandler(database);
    }
    if (path == "/query") {
-      return new silo_api::QueryHandler(query_engine);
+      return new silo_api::QueryHandler(query_engine, database.getDataVersion().toString());
    }
    return new silo_api::NotFoundHandler;
 }

--- a/src/silo_api/request_handler_factory.test.cpp
+++ b/src/silo_api/request_handler_factory.test.cpp
@@ -2,6 +2,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "silo/common/data_version.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/database.h"
 #include "silo/database_info.h"
@@ -20,6 +21,7 @@ class MockDatabase : public silo::Database {
   public:
    MOCK_METHOD(silo::DatabaseInfo, getDatabaseInfo, (), (const));
    MOCK_METHOD(silo::DetailedDatabaseInfo, detailedDatabaseInfo, (), (const));
+   MOCK_METHOD(DataVersion, getDataVersion, (), (const));
 };
 
 class MockQueryEngine : public silo::query_engine::QueryEngine {
@@ -54,6 +56,7 @@ class RequestHandlerTestFixture : public ::testing::Test {
 TEST_F(RequestHandlerTestFixture, handlesGetInfoRequest) {
    EXPECT_CALL(mock_database, getDatabaseInfo)
       .WillRepeatedly(testing::Return(silo::DatabaseInfo{1, 2, 3}));
+   EXPECT_CALL(mock_database, getDataVersion).WillRepeatedly(testing::Return(DataVersion("1234")));
 
    request.setURI("/info");
 
@@ -61,6 +64,7 @@ TEST_F(RequestHandlerTestFixture, handlesGetInfoRequest) {
 
    EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_OK);
    EXPECT_EQ(response.out_stream.str(), R"({"nBitmapsSize":3,"sequenceCount":1,"totalSize":2})");
+   EXPECT_EQ(response.get("data-version"), "1234");
 }
 
 TEST_F(RequestHandlerTestFixture, handlesGetInfoRequestDetails) {
@@ -78,6 +82,7 @@ TEST_F(RequestHandlerTestFixture, handlesGetInfoRequestDetails) {
 
    EXPECT_CALL(mock_database, detailedDatabaseInfo)
       .WillRepeatedly(testing::Return(detailed_database_info));
+   EXPECT_CALL(mock_database, getDataVersion).WillRepeatedly(testing::Return(DataVersion("1234")));
 
    request.setURI("/info?details=true");
 
@@ -88,6 +93,7 @@ TEST_F(RequestHandlerTestFixture, handlesGetInfoRequestDetails) {
       response.out_stream.str(),
       R"({"bitmapContainerSizePerGenomeSection":{"bitmapContainerSizeStatistic":{"numberOfArrayContainers":0,"numberOfBitsetContainers":0,"numberOfRunContainers":0,"numberOfValuesStoredInArrayContainers":0,"numberOfValuesStoredInBitsetContainers":0,"numberOfValuesStoredInRunContainers":0,"totalBitmapSizeArrayContainers":0,"totalBitmapSizeBitsetContainers":0,"totalBitmapSizeRunContainers":0},"sectionLength":4567,"sizePerGenomeSymbolAndSection":{"-":[0,0,0,0,0,0,0],"N":[0,0,0,0,0,0,0],"NOT_N_NOT_GAP":[0,0,0,0,0,0,0]},"totalBitmapSizeComputed":0,"totalBitmapSizeFrozen":0},"bitmapSizePerSymbol":{"-":0,"A":1234,"B":0,"C":0,"D":0,"G":0,"H":0,"K":0,"M":0,"N":0,"R":0,"S":0,"T":0,"V":0,"W":0,"Y":0}})"
    );  // NOLINT
+   EXPECT_EQ(response.get("data-version"), "1234");
 }
 
 TEST_F(RequestHandlerTestFixture, returnsMethodNotAllowedOnPostInfoRequest) {
@@ -110,6 +116,7 @@ TEST_F(RequestHandlerTestFixture, handlesPostQueryRequest) {
    const std::vector<silo::query_engine::QueryResultEntry> tmp{{fields}};
    const silo::query_engine::QueryResult query_result{tmp};
    EXPECT_CALL(mock_query_engine, executeQuery).WillRepeatedly(testing::Return(query_result));
+   EXPECT_CALL(mock_database, getDataVersion).WillRepeatedly(testing::Return(DataVersion("1234")));
 
    request.setMethod("POST");
    request.setURI("/query");
@@ -118,6 +125,7 @@ TEST_F(RequestHandlerTestFixture, handlesPostQueryRequest) {
 
    EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_OK);
    EXPECT_EQ(response.out_stream.str(), R"({"queryResult":[{"count":5}]})");
+   EXPECT_EQ(response.get("data-version"), "1234");
 }
 
 TEST_F(RequestHandlerTestFixture, returnsMethodNotAllowedOnGetQuery) {

--- a/src/silo_api/request_handler_factory.test.cpp
+++ b/src/silo_api/request_handler_factory.test.cpp
@@ -21,7 +21,7 @@ class MockDatabase : public silo::Database {
   public:
    MOCK_METHOD(silo::DatabaseInfo, getDatabaseInfo, (), (const));
    MOCK_METHOD(silo::DetailedDatabaseInfo, detailedDatabaseInfo, (), (const));
-   MOCK_METHOD(DataVersion, getDataVersion, (), (const));
+   MOCK_METHOD(silo::DataVersion, getDataVersion, (), (const));
 };
 
 class MockQueryEngine : public silo::query_engine::QueryEngine {
@@ -56,7 +56,8 @@ class RequestHandlerTestFixture : public ::testing::Test {
 TEST_F(RequestHandlerTestFixture, handlesGetInfoRequest) {
    EXPECT_CALL(mock_database, getDatabaseInfo)
       .WillRepeatedly(testing::Return(silo::DatabaseInfo{1, 2, 3}));
-   EXPECT_CALL(mock_database, getDataVersion).WillRepeatedly(testing::Return(DataVersion("1234")));
+   EXPECT_CALL(mock_database, getDataVersion)
+      .WillRepeatedly(testing::Return(silo::DataVersion("1234")));
 
    request.setURI("/info");
 
@@ -82,7 +83,8 @@ TEST_F(RequestHandlerTestFixture, handlesGetInfoRequestDetails) {
 
    EXPECT_CALL(mock_database, detailedDatabaseInfo)
       .WillRepeatedly(testing::Return(detailed_database_info));
-   EXPECT_CALL(mock_database, getDataVersion).WillRepeatedly(testing::Return(DataVersion("1234")));
+   EXPECT_CALL(mock_database, getDataVersion)
+      .WillRepeatedly(testing::Return(silo::DataVersion("1234")));
 
    request.setURI("/info?details=true");
 
@@ -116,7 +118,8 @@ TEST_F(RequestHandlerTestFixture, handlesPostQueryRequest) {
    const std::vector<silo::query_engine::QueryResultEntry> tmp{{fields}};
    const silo::query_engine::QueryResult query_result{tmp};
    EXPECT_CALL(mock_query_engine, executeQuery).WillRepeatedly(testing::Return(query_result));
-   EXPECT_CALL(mock_database, getDataVersion).WillRepeatedly(testing::Return(DataVersion("1234")));
+   EXPECT_CALL(mock_database, getDataVersion)
+      .WillRepeatedly(testing::Return(silo::DataVersion("1234")));
 
    request.setMethod("POST");
    request.setURI("/query");


### PR DESCRIPTION
Resolves #130

The data version is returned in the header as `Data-Version` and not `Lapis-Data-Version` as requested in the ticked, since it is the data version from silo. 

This should be reworked, with the verbose preprocessing.