### PR TITLE
feat: make partition_by field in config optional

### DIFF
--- a/include/silo/common/data_version.h
+++ b/include/silo/common/data_version.h
@@ -7,7 +7,7 @@ namespace silo {
 
 class DataVersion {
   public:
-   explicit DataVersion(const std::string& data_version = "");
+   explicit DataVersion(std::string data_version = "");
    [[nodiscard]] std::string toString() const;
 
    static std::string mineDataVersion();

--- a/include/silo/config/database_config.h
+++ b/include/silo/config/database_config.h
@@ -28,7 +28,7 @@ struct DatabaseSchema {
    std::vector<DatabaseMetadata> metadata;
    std::string primary_key;
    std::optional<std::string> date_to_sort_by;
-   std::string partition_by;
+   std::optional<std::string> partition_by;
 };
 
 struct DatabaseConfig {

--- a/include/silo/prepare_dataset.h
+++ b/include/silo/prepare_dataset.h
@@ -34,7 +34,6 @@ void partitionData(
 
 void copyDataToPartitionDirectory(
    const preprocessing::PreprocessingConfig& preprocessing_config,
-   const std::string& primary_key_field,
    const ReferenceGenomes& reference_genomes
 );
 

--- a/include/silo/prepare_dataset.h
+++ b/include/silo/prepare_dataset.h
@@ -27,7 +27,14 @@ void partitionData(
    const silo::preprocessing::PreprocessingConfig& preprocessing_config,
    const preprocessing::Partitions& partitions,
    const PangoLineageAliasLookup& alias_key,
-   const silo::config::DatabaseConfig& database_config,
+   const std::string& primary_key_field,
+   const std::string& partition_by_field,
+   const ReferenceGenomes& reference_genomes
+);
+
+void copyDataToPartitionDirectory(
+   const preprocessing::PreprocessingConfig& preprocessing_config,
+   const std::string& primary_key_field,
    const ReferenceGenomes& reference_genomes
 );
 

--- a/include/silo/preprocessing/pango_lineage_count.h
+++ b/include/silo/preprocessing/pango_lineage_count.h
@@ -34,7 +34,7 @@ struct PangoLineageCounts {
 PangoLineageCounts buildPangoLineageCounts(
    const PangoLineageAliasLookup& alias_key,
    const std::filesystem::path& metadata_path,
-   const silo::config::DatabaseConfig& database_config
+   const std::string& partition_by
 );
 
 }  // namespace preprocessing

--- a/include/silo/preprocessing/partition.h
+++ b/include/silo/preprocessing/partition.h
@@ -2,6 +2,7 @@
 #define SILO_PARTITION_H
 
 #include <cstdint>
+#include <filesystem>
 #include <functional>
 #include <iosfwd>
 #include <string>
@@ -16,6 +17,9 @@ class access;
 }
 namespace silo::common {
 class UnaliasedPangoLineage;
+}
+namespace silo::config {
+class DatabaseConfig;
 }
 
 namespace silo::preprocessing {
@@ -88,6 +92,8 @@ class Partitions {
    std::unordered_map<std::string, silo::preprocessing::PartitionChunk> pango_to_chunk;
 
   public:
+   Partitions();
+
    explicit Partitions(std::vector<Partition> partitions_);
 
    void save(std::ostream& output_file) const;
@@ -103,6 +109,11 @@ class Partitions {
 };
 
 Partitions buildPartitions(const PangoLineageCounts& pango_lineage_counts, Architecture arch);
+
+Partitions createSingletonPartitions(
+   const std::filesystem::path& metadata_path,
+   const silo::config::DatabaseConfig& database_config
+);
 
 }  // namespace silo::preprocessing
 

--- a/include/silo/preprocessing/preprocessing_config.h
+++ b/include/silo/preprocessing/preprocessing_config.h
@@ -27,7 +27,7 @@ struct MetadataFilename {
 };
 
 struct PangoLineageDefinitionFilename {
-   std::string filename;
+   std::optional<std::string> filename;
 };
 
 struct NucleotideSequencePrefix {
@@ -58,7 +58,7 @@ class PreprocessingConfig {
    friend class fmt::formatter<silo::preprocessing::PreprocessingConfig>;
 
    std::filesystem::path input_directory;
-   std::filesystem::path pango_lineage_definition_file;
+   std::optional<std::filesystem::path> pango_lineage_definition_file;
    std::filesystem::path metadata_file;
    std::filesystem::path partition_folder;
    std::filesystem::path sorted_partition_folder;
@@ -83,7 +83,7 @@ class PreprocessingConfig {
       const GenePrefix& gene_prefix_
    );
 
-   [[nodiscard]] std::filesystem::path getPangoLineageDefinitionFilename() const;
+   [[nodiscard]] std::optional<std::filesystem::path> getPangoLineageDefinitionFilename() const;
 
    [[nodiscard]] std::filesystem::path getReferenceGenomeFilename() const;
 

--- a/include/silo/preprocessing/preprocessing_config.h
+++ b/include/silo/preprocessing/preprocessing_config.h
@@ -2,17 +2,15 @@
 #define SILO_PREPROCESSING_CONFIG_H
 
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <unordered_map>
-
-namespace silo::preprocessing {
-struct PartitionChunk;
-struct Partitions;
-}  // namespace silo::preprocessing
 
 #include <fmt/core.h>
 
 namespace silo::preprocessing {
+struct PartitionChunk;
+struct Partitions;
 
 struct InputDirectory {
    std::string directory;

--- a/src/silo/common/data_version.cpp
+++ b/src/silo/common/data_version.cpp
@@ -10,8 +10,8 @@ std::string DataVersion::mineDataVersion() {
    return std::to_string(now_as_time_t);
 }
 
-DataVersion::DataVersion(const std::string& data_version)
-    : data_version(data_version) {}
+DataVersion::DataVersion(std::string data_version)
+    : data_version(std::move(data_version)) {}
 
 std::string DataVersion::toString() const {
    return data_version;

--- a/src/silo/config/config_repository.cpp
+++ b/src/silo/config/config_repository.cpp
@@ -72,15 +72,19 @@ void validatePartitionBy(
    const DatabaseConfig& config,
    std::map<std::string, ValueType>& metadata_map
 ) {
-   if (metadata_map.find(config.schema.partition_by) == metadata_map.end()) {
-      throw ConfigException("partition_by '" + config.schema.partition_by + "' is not in metadata");
+   if (config.schema.partition_by == std::nullopt) {
+      return;
    }
 
-   const auto& partition_by_type = metadata_map[config.schema.partition_by];
+   const std::string partition_by = config.schema.partition_by.value();
+
+   if (metadata_map.find(partition_by) == metadata_map.end()) {
+      throw ConfigException("partition_by '" + partition_by + "' is not in metadata");
+   }
+
+   const auto& partition_by_type = metadata_map[partition_by];
    if (partition_by_type != ValueType::PANGOLINEAGE) {
-      throw ConfigException(
-         "partition_by '" + config.schema.partition_by + "' must be of type PANGOLINEAGE"
-      );
+      throw ConfigException("partition_by '" + partition_by + "' must be of type PANGOLINEAGE");
    }
 }
 

--- a/src/silo/config/database_config.test.cpp
+++ b/src/silo/config/database_config.test.cpp
@@ -160,4 +160,12 @@ TEST(DatabaseConfigReader, shouldReadConfigWithoutDateToSortBy) {
    ASSERT_EQ(config.schema.date_to_sort_by, std::nullopt);
 }
 
+TEST(DatabaseConfigReader, shouldReadConfigWithoutPartitionBy) {
+   const DatabaseConfig& config = DatabaseConfigReader().readConfig(
+      "testBaseData/test_database_config_without_partition_by.yaml"
+   );
+
+   ASSERT_EQ(config.schema.partition_by, std::nullopt);
+}
+
 }  // namespace

--- a/src/silo/database.cpp
+++ b/src/silo/database.cpp
@@ -520,9 +520,11 @@ Database Database::preprocessing(
    );
 
    SPDLOG_INFO("preprocessing - building alias key");
-   database.alias_key =
-      PangoLineageAliasLookup::readFromFile(preprocessing_config.getPangoLineageDefinitionFilename()
+   if (preprocessing_config.getPangoLineageDefinitionFilename().has_value()) {
+      database.alias_key = PangoLineageAliasLookup::readFromFile(
+         preprocessing_config.getPangoLineageDefinitionFilename().value()
       );
+   }
 
    SPDLOG_INFO("preprocessing - reading reference genome");
    const ReferenceGenomes& reference_genomes =
@@ -540,9 +542,9 @@ Database Database::preprocessing(
       );
 
       SPDLOG_INFO("preprocessing - calculating partitions");
-      partition_descriptor = preprocessing::Partitions(preprocessing::buildPartitions(
+      partition_descriptor = preprocessing::buildPartitions(
          pango_descriptor, preprocessing::Architecture::MAX_PARTITIONS
-      ));
+      );
 
       SPDLOG_INFO("preprocessing - partitioning data");
       partitionData(
@@ -564,9 +566,7 @@ Database Database::preprocessing(
          preprocessing_config.getMetadataInputFilename(), database_config_
       );
 
-      copyDataToPartitionDirectory(
-         preprocessing_config, database_config_.schema.primary_key, reference_genomes
-      );
+      copyDataToPartitionDirectory(preprocessing_config, reference_genomes);
    }
 
    if (database_config_.schema.date_to_sort_by.has_value()) {

--- a/src/silo/database.cpp
+++ b/src/silo/database.cpp
@@ -520,10 +520,11 @@ Database Database::preprocessing(
    );
 
    SPDLOG_INFO("preprocessing - building alias key");
-   if (preprocessing_config.getPangoLineageDefinitionFilename().has_value()) {
-      database.alias_key = PangoLineageAliasLookup::readFromFile(
-         preprocessing_config.getPangoLineageDefinitionFilename().value()
-      );
+   const auto pango_lineage_definition_filename =
+      preprocessing_config.getPangoLineageDefinitionFilename();
+   if (pango_lineage_definition_filename.has_value()) {
+      database.alias_key =
+         PangoLineageAliasLookup::readFromFile(pango_lineage_definition_filename.value());
    }
 
    SPDLOG_INFO("preprocessing - reading reference genome");

--- a/src/silo/database.test.cpp
+++ b/src/silo/database.test.cpp
@@ -31,6 +31,25 @@ TEST(DatabaseTest, shouldBuildDatabaseWithoutErrors) {
    EXPECT_EQ(simple_database_info.sequence_count, 100);
 }
 
+TEST(DatabaseTest, shouldBuildPartitionLessDatabaseWithoutErrors) {
+   const silo::preprocessing::InputDirectory input_directory{"./testBaseData/"};
+
+   auto config = silo::preprocessing::PreprocessingConfigReader().readConfig(
+      input_directory.directory + "test_preprocessing_config.yaml"
+   );
+
+   const auto database_config = silo::config::ConfigRepository().getValidatedConfig(
+      input_directory.directory + "test_database_config_without_partition_by.yaml"
+   );
+
+   auto database = silo::Database::preprocessing(config, database_config);
+
+   const auto simple_database_info = database.getDatabaseInfo();
+
+   EXPECT_GT(simple_database_info.total_size, 0);
+   EXPECT_EQ(simple_database_info.sequence_count, 100);
+}
+
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST(DatabaseTest, shouldReturnCorrectDatabaseInfo) {
    auto database{buildTestDatabase()};

--- a/src/silo/database.test.cpp
+++ b/src/silo/database.test.cpp
@@ -31,7 +31,7 @@ TEST(DatabaseTest, shouldBuildDatabaseWithoutErrors) {
    EXPECT_EQ(simple_database_info.sequence_count, 100);
 }
 
-TEST(DatabaseTest, shouldBuildPartitionLessDatabaseWithoutErrors) {
+TEST(DatabaseTest, shouldSuccessfullyBuildDatabaseWithoutPartitionBy) {
    const silo::preprocessing::InputDirectory input_directory{"./testBaseData/"};
 
    auto config = silo::preprocessing::PreprocessingConfigReader().readConfig(

--- a/src/silo/prepare_dataset.cpp
+++ b/src/silo/prepare_dataset.cpp
@@ -128,8 +128,7 @@ std::unordered_map<std::string, silo::preprocessing::PartitionChunk> partitionMe
 
 void copyMetadataFile(
    csv::CSVReader& metadata_reader,
-   silo::preprocessing::MetadataWriter& metadata_writer,
-   const std::string& primary_key_field
+   silo::preprocessing::MetadataWriter& metadata_writer
 ) {
    metadata_writer.writeHeader(metadata_reader);
    for (auto& row : metadata_reader) {
@@ -262,7 +261,6 @@ void silo::partitionData(
 
 void silo::copyDataToPartitionDirectory(
    const preprocessing::PreprocessingConfig& preprocessing_config,
-   const std::string& primary_key_field,
    const ReferenceGenomes& reference_genomes
 ) {
    const std::filesystem::path metadata_filename = preprocessing_config.getMetadataInputFilename();
@@ -271,7 +269,7 @@ void silo::copyDataToPartitionDirectory(
    auto metadata_partition_filename = preprocessing_config.getMetadataPartitionFilename(0, 0);
    auto metadata_writer = preprocessing::MetadataWriter(metadata_partition_filename);
 
-   copyMetadataFile(metadata_reader.reader, metadata_writer, primary_key_field);
+   copyMetadataFile(metadata_reader.reader, metadata_writer);
 
    for (const auto& [nuc_name, reference_genome] : reference_genomes.raw_nucleotide_sequences) {
       const std::filesystem::path sequence_in_filename =

--- a/src/silo/prepare_dataset.cpp
+++ b/src/silo/prepare_dataset.cpp
@@ -126,17 +126,6 @@ std::unordered_map<std::string, silo::preprocessing::PartitionChunk> partitionMe
    );
 }
 
-void copyMetadataFile(
-   csv::CSVReader& metadata_reader,
-   silo::preprocessing::MetadataWriter& metadata_writer
-) {
-   metadata_writer.writeHeader(metadata_reader);
-   for (auto& row : metadata_reader) {
-      std::this_thread::sleep_for(std::chrono::nanoseconds(2));
-      metadata_writer.writeRow(row);
-   }
-}
-
 std::unordered_map<silo::preprocessing::PartitionChunk, silo::ZstdFastaWriter>
 getSequenceWritersForChunks(
    const std::unordered_map<silo::preprocessing::PartitionChunk, std::filesystem::path>&
@@ -264,12 +253,14 @@ void silo::copyDataToPartitionDirectory(
    const ReferenceGenomes& reference_genomes
 ) {
    const std::filesystem::path metadata_filename = preprocessing_config.getMetadataInputFilename();
-   auto metadata_reader = preprocessing::MetadataReader(metadata_filename);
 
    auto metadata_partition_filename = preprocessing_config.getMetadataPartitionFilename(0, 0);
-   auto metadata_writer = preprocessing::MetadataWriter(metadata_partition_filename);
 
-   copyMetadataFile(metadata_reader.reader, metadata_writer);
+   std::filesystem::copy(
+      metadata_filename,
+      metadata_partition_filename,
+      std::filesystem::copy_options::overwrite_existing
+   );
 
    for (const auto& [nuc_name, reference_genome] : reference_genomes.raw_nucleotide_sequences) {
       const std::filesystem::path sequence_in_filename =

--- a/src/silo/preprocessing/pango_lineage_count.cpp
+++ b/src/silo/preprocessing/pango_lineage_count.cpp
@@ -41,7 +41,7 @@ PangoLineageCounts PangoLineageCounts::load(std::istream& input_stream) {
 PangoLineageCounts buildPangoLineageCounts(
    const PangoLineageAliasLookup& alias_key,
    const std::filesystem::path& metadata_path,
-   const silo::config::DatabaseConfig& database_config
+   const std::string& partition_by
 ) {
    PangoLineageCounts pango_lineage_counts;
 
@@ -49,8 +49,7 @@ PangoLineageCounts buildPangoLineageCounts(
    std::unordered_map<common::UnaliasedPangoLineage, uint32_t> pango_lineage_to_id;
 
    const std::vector<std::string> unresolved_pango_lineages =
-      silo::preprocessing::MetadataReader(metadata_path)
-         .getColumn(database_config.schema.partition_by);
+      silo::preprocessing::MetadataReader(metadata_path).getColumn(partition_by);
 
    for (const auto& unresolved_pango_lineage : unresolved_pango_lineages) {
       const common::UnaliasedPangoLineage pango_lineage =

--- a/src/silo/preprocessing/pango_lineage_count.test.cpp
+++ b/src/silo/preprocessing/pango_lineage_count.test.cpp
@@ -8,15 +8,13 @@
 
 TEST(PangoLineageCounts, buildPangoLineageCounts) {
    const std::filesystem::path metadata_path = "testBaseData/exampleDataset/small_metadata_set.tsv";
-   const silo::config::DatabaseConfig database_config = {
-      .schema = {.partition_by = "pango_lineage"}};
 
    auto result = silo::preprocessing::buildPangoLineageCounts(
       silo::PangoLineageAliasLookup::readFromFile(
          "testBaseData/exampleDataset/pangolineage_alias.json"
       ),
       metadata_path,
-      database_config
+      "pango_lineage"
    );
 
    ASSERT_EQ(result.pango_lineage_counts.size(), 25);

--- a/src/silo/preprocessing/preprocessing_config.cpp
+++ b/src/silo/preprocessing/preprocessing_config.cpp
@@ -66,8 +66,10 @@ PreprocessingConfig::PreprocessingConfig(
    }
 
    metadata_file = createPath(input_directory, metadata_filename_.filename);
-   pango_lineage_definition_file =
-      createPath(input_directory, pango_lineage_definition_filename_.filename);
+   if (pango_lineage_definition_filename_.filename.has_value()) {
+      pango_lineage_definition_file =
+         createPath(input_directory, pango_lineage_definition_filename_.filename.value());
+   }
    reference_genome_file = createPath(input_directory, reference_genome_filename_.filename);
 
    const std::filesystem::path output_directory(output_directory_.directory);
@@ -82,7 +84,8 @@ PreprocessingConfig::PreprocessingConfig(
    gene_prefix = gene_prefix_.prefix;
 }
 
-std::filesystem::path PreprocessingConfig::getPangoLineageDefinitionFilename() const {
+std::optional<std::filesystem::path> PreprocessingConfig::getPangoLineageDefinitionFilename(
+) const {
    return pango_lineage_definition_file;
 }
 
@@ -230,12 +233,14 @@ std::filesystem::path PreprocessingConfig::getGeneSortedPartitionFilename(
 ) -> decltype(ctx.out()) {
    return format_to(
       ctx.out(),
-      "{{ input directory: '{}', pango_lineage_definition_file: '{}', "
+      "{{ input directory: '{}', pango_lineage_definition_file: {}, "
       "metadata_file: '{}', partition_folder: '{}', sorted_partition_folder: '{}', "
       "serialization_folder: '{}', reference_genome_file: '{}',  gene_file_prefix: '{}',  "
       "nucleotide_sequence_file_prefix: '{}' }}",
       preprocessing_config.input_directory.string(),
-      preprocessing_config.pango_lineage_definition_file.string(),
+      preprocessing_config.pango_lineage_definition_file.has_value()
+         ? "'" + preprocessing_config.pango_lineage_definition_file->string() + "'"
+         : "none",
       preprocessing_config.metadata_file.string(),
       preprocessing_config.partition_folder.string(),
       preprocessing_config.sorted_partition_folder.string(),

--- a/src/silo/preprocessing/preprocessing_config_reader.cpp
+++ b/src/silo/preprocessing/preprocessing_config_reader.cpp
@@ -71,7 +71,9 @@ struct convert<PreprocessingConfig> {
       const OutputDirectory output_directory{node["outputDirectory"].as<std::string>()};
       const MetadataFilename metadata_filename{node["metadataFilename"].as<std::string>()};
       const PangoLineageDefinitionFilename pango_lineage_definition_filename{
-         node["pangoLineageDefinitionFilename"].as<std::string>()};
+         node["pangoLineageDefinitionFilename"].IsDefined()
+            ? std::optional<std::string>{node["pangoLineageDefinitionFilename"].as<std::string>()}
+            : std::nullopt};
       const ReferenceGenomeFilename reference_genome_filename{
          node["referenceGenomeFilename"].as<std::string>()};
 

--- a/testBaseData/test_database_config_without_partition_by.yaml
+++ b/testBaseData/test_database_config_without_partition_by.yaml
@@ -1,0 +1,28 @@
+schema:
+  instanceName: sars_cov-2_minimal_test_config
+  metadata:
+    - name: gisaid_epi_isl
+      type: string
+    - name: date
+      type: date
+    - name: unsorted_date
+      type: date
+    - name: region
+      type: string
+      generateIndex: true
+    - name: country
+      type: string
+      generateIndex: true
+    - name: pango_lineage
+      type: pango_lineage
+    - name: division
+      type: string
+      generateIndex: true
+    - name: age
+      type: int
+    - name: qc_value
+      type: float
+    - name: insertions
+      type: insertion
+  primaryKey: gisaid_epi_isl
+  dateToSortBy: date


### PR DESCRIPTION
Not all datasets will contain pango_lineages to partition by for increased compression ratios. Therefore, this PR makes the `partition_by` field optional