### PR TITLE
Improve details endpoint

### DIFF
--- a/endToEndTests/test/invalidQueries/OffsetNegative.json
+++ b/endToEndTests/test/invalidQueries/OffsetNegative.json
@@ -1,5 +1,5 @@
 {
-  "testCaseName": "Details action with order by field EPI_ISL",
+  "testCaseName": "Details action with negative offset",
   "query": {
     "action": {
       "type": "Details",

--- a/endToEndTests/test/queries/DetailsOrderByLimit.json
+++ b/endToEndTests/test/queries/DetailsOrderByLimit.json
@@ -26,6 +26,18 @@
   },
   "expectedQueryResult": [
     {
+      "age": 50,
+      "country": "Switzerland",
+      "date": "2021-03-03",
+      "division": "Valais",
+      "gisaid_epi_isl": "EPI_ISL_1408062",
+      "insertions": "22204:CAGAA",
+      "pango_lineage": "B.1.1.7",
+      "qc_value": 0.97,
+      "region": "Europe",
+      "unsorted_date": "2020-11-24"
+    },
+    {
       "age": 4,
       "country": "Switzerland",
       "date": "2021-03-18",
@@ -36,18 +48,6 @@
       "qc_value": 0.98,
       "region": "Europe",
       "unsorted_date": null
-    },
-    {
-      "age": 51,
-      "country": "Switzerland",
-      "date": "2021-03-21",
-      "division": "Vaud",
-      "gisaid_epi_isl": "EPI_ISL_1597890",
-      "insertions": "22339:GCTGGT",
-      "pango_lineage": "B.1.1.7",
-      "qc_value": 0.96,
-      "region": null,
-      "unsorted_date": "2021-01-25"
     }
   ]
 }

--- a/include/silo/common/string.h
+++ b/include/silo/common/string.h
@@ -2,6 +2,7 @@
 #define SILO_STRING_H
 
 #include <array>
+#include <compare>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -41,7 +42,7 @@ struct String {
 
    std::array<char, I + 4> data;
 
-   int compare(const String& other) const;
+   std::optional<std::strong_ordering> fastCompare(const String& other) const;
 
    String() = default;
 
@@ -56,14 +57,6 @@ struct String {
    [[nodiscard]] std::string toString(const BidirectionalMap<std::string>& dictionary) const;
 
    bool operator==(const String& other) const;
-
-   bool operator<(const String& other) const;
-
-   bool operator<=(const String& other) const;
-
-   bool operator>(const String& other) const;
-
-   bool operator>=(const String& other) const;
 
    bool operator!=(const String& other) const;
 };

--- a/include/silo/query_engine/actions/action.h
+++ b/include/silo/query_engine/actions/action.h
@@ -22,19 +22,19 @@ struct DatabasePartition;
 
 namespace silo::query_engine::actions {
 
-class Action {
-  public:
-   struct OrderByField {
-      std::string name;
-      bool ascending;
-   };
+struct OrderByField {
+   std::string name;
+   bool ascending;
+};
 
+class Action {
   protected:
    std::vector<OrderByField> order_by_fields;
    std::optional<uint32_t> limit;
    std::optional<uint32_t> offset;
 
-   void applyOrderByAndLimit(QueryResult& result) const;
+   void applySort(QueryResult& result) const;
+   void applyOffsetAndLimit(QueryResult& result) const;
 
    [[nodiscard]] virtual void validateOrderByFields(const Database& database) const = 0;
 
@@ -53,7 +53,7 @@ class Action {
       std::optional<uint32_t> offset
    );
 
-   [[nodiscard]] QueryResult executeAndOrder(
+   [[nodiscard]] virtual QueryResult executeAndOrder(
       const Database& database,
       std::vector<OperatorResult> bitmap_filter
    ) const;

--- a/include/silo/query_engine/actions/details.h
+++ b/include/silo/query_engine/actions/details.h
@@ -29,6 +29,9 @@ class Details : public Action {
 
   public:
    explicit Details(std::vector<std::string> fields);
+
+   QueryResult executeAndOrder(const Database& database, std::vector<OperatorResult> bitmap_filter)
+      const override;
 };
 
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/include/silo/query_engine/actions/tuple.h
+++ b/include/silo/query_engine/actions/tuple.h
@@ -12,7 +12,7 @@ namespace silo::query_engine::actions {
 
 struct OrderByField;
 
-size_t getTupleSize(const std::vector<silo::storage::ColumnMetadata>& group_by_metadata);
+size_t getTupleSize(const std::vector<silo::storage::ColumnMetadata>& metadata_list);
 
 struct TupleFieldComparator {
    size_t offset;
@@ -20,31 +20,29 @@ struct TupleFieldComparator {
    bool ascending;
 };
 
-struct Tuple {
-   typedef std::function<bool(const Tuple&, const Tuple&)> Comparator;
+class Tuple {
+   friend class TupleFactory;
 
    const silo::storage::ColumnPartitionGroup* columns;
-   std::vector<char> data;
-
-   Tuple(
-      uint32_t sequence_id,
-      const silo::storage::ColumnPartitionGroup* columns,
-      size_t tuple_size
-   );
-
-   Tuple() = default;
-   Tuple(const Tuple& other);
-   Tuple(Tuple&& other);
-   Tuple& operator=(const Tuple& other);
-   Tuple& operator=(Tuple&& other);
-
-   [[nodiscard]] std::map<std::string, std::optional<std::variant<std::string, int32_t, double>>>
-   getFields() const;
+   std::byte* data;
+   size_t data_size;
 
    static std::vector<TupleFieldComparator> getCompareFields(
       const std::vector<silo::storage::ColumnMetadata>& columns_metadata,
       const std::vector<OrderByField>& order_by_fields
    );
+
+  public:
+   typedef std::function<bool(const Tuple&, const Tuple&)> Comparator;
+
+   Tuple(const silo::storage::ColumnPartitionGroup* columns, std::byte* data, size_t data_size);
+   Tuple(Tuple&& other) noexcept;
+   Tuple& operator=(const Tuple& other);
+   Tuple& operator=(Tuple&& other) noexcept;
+
+   [[nodiscard]] std::map<std::string, std::optional<std::variant<std::string, int32_t, double>>>
+   getFields() const;
+
    static Comparator getComparator(
       const std::vector<silo::storage::ColumnMetadata>& columns_metadata,
       const std::vector<OrderByField>& order_by_fields
@@ -59,16 +57,43 @@ struct Tuple {
    bool operator>(const Tuple& other) const;
    bool operator<=(const Tuple& other) const;
    bool operator>=(const Tuple& other) const;
+
+   friend std::hash<Tuple>;
 };
 
 }  // namespace silo::query_engine::actions
 
 template <>
 struct std::hash<silo::query_engine::actions::Tuple> {
-   std::size_t operator()(const silo::query_engine::actions::Tuple& tuple) const {
-      const std::string_view str_view(tuple.data.data(), tuple.data.size());
-      return std::hash<std::string_view>{}(str_view);
-   }
+   std::size_t operator()(const silo::query_engine::actions::Tuple& tuple) const;
 };
+
+namespace silo::query_engine::actions {
+
+class TupleFactory {
+   std::deque<std::vector<std::byte>> all_tuple_data;
+   silo::storage::ColumnPartitionGroup columns;
+   size_t tuple_size;
+
+  public:
+   explicit TupleFactory(
+      const silo::storage::ColumnPartitionGroup& all_columns,
+      const std::vector<silo::storage::ColumnMetadata>& fields
+   );
+
+   Tuple allocateOne(uint32_t sequence_id);
+
+   Tuple& overwrite(Tuple& tuple, uint32_t sequence_id);
+
+   Tuple copyTuple(const Tuple& tuple);
+
+   /// The vector will contain null-initialized Tuples.
+   /// The caller needs to guarantee that these Tuples will be overwritten using the
+   /// TupleFactory::overwrite method, before any member function is called
+   /// on them.
+   std::vector<Tuple> allocateMany(size_t count);
+};
+
+}  // namespace silo::query_engine::actions
 
 #endif  // SILO_TUPLE_H

--- a/include/silo/query_engine/actions/tuple.h
+++ b/include/silo/query_engine/actions/tuple.h
@@ -1,0 +1,74 @@
+#ifndef SILO_TUPLE_H
+#define SILO_TUPLE_H
+
+#include <optional>
+#include <string>
+
+#include "silo/common/date.h"
+#include "silo/common/string.h"
+#include "silo/storage/column_group.h"
+
+namespace silo::query_engine::actions {
+
+struct OrderByField;
+
+size_t getTupleSize(const std::vector<silo::storage::ColumnMetadata>& group_by_metadata);
+
+struct TupleFieldComparator {
+   size_t offset;
+   silo::storage::ColumnMetadata type;
+   bool ascending;
+};
+
+struct Tuple {
+   typedef std::function<bool(const Tuple&, const Tuple&)> Comparator;
+
+   const silo::storage::ColumnPartitionGroup* columns;
+   std::vector<char> data;
+
+   Tuple(
+      uint32_t sequence_id,
+      const silo::storage::ColumnPartitionGroup* columns,
+      size_t tuple_size
+   );
+
+   Tuple() = default;
+   Tuple(const Tuple& other);
+   Tuple(Tuple&& other);
+   Tuple& operator=(const Tuple& other);
+   Tuple& operator=(Tuple&& other);
+
+   [[nodiscard]] std::map<std::string, std::optional<std::variant<std::string, int32_t, double>>>
+   getFields() const;
+
+   static std::vector<TupleFieldComparator> getCompareFields(
+      const std::vector<silo::storage::ColumnMetadata>& columns_metadata,
+      const std::vector<OrderByField>& order_by_fields
+   );
+   static Comparator getComparator(
+      const std::vector<silo::storage::ColumnMetadata>& columns_metadata,
+      const std::vector<OrderByField>& order_by_fields
+   );
+
+   bool compareLess(const Tuple& other, const std::vector<TupleFieldComparator>& fields) const;
+
+   bool operator==(const Tuple& other) const;
+   bool operator!=(const Tuple& other) const;
+
+   bool operator<(const Tuple& other) const;
+   bool operator>(const Tuple& other) const;
+   bool operator<=(const Tuple& other) const;
+   bool operator>=(const Tuple& other) const;
+};
+
+}  // namespace silo::query_engine::actions
+
+template <>
+struct std::hash<silo::query_engine::actions::Tuple> {
+   std::size_t operator()(const silo::query_engine::actions::Tuple& tuple) const {
+      const std::string_view str_view(tuple.data.data(), tuple.data.size());
+      return std::hash<std::string_view>{}(str_view);
+   }
+};
+
+#endif  // SILO_TUPLE_H

--- a/include/silo/query_engine/actions/tuple.h
+++ b/include/silo/query_engine/actions/tuple.h
@@ -14,23 +14,26 @@ struct OrderByField;
 
 size_t getTupleSize(const std::vector<silo::storage::ColumnMetadata>& metadata_list);
 
-struct TupleFieldComparator {
-   size_t offset;
-   silo::storage::ColumnMetadata type;
-   bool ascending;
-};
-
 class Tuple {
    friend class TupleFactory;
+
+   struct ComparatorField {
+      size_t offset;
+      silo::storage::ColumnMetadata type;
+      bool ascending;
+   };
 
    const silo::storage::ColumnPartitionGroup* columns;
    std::byte* data;
    size_t data_size;
 
-   static std::vector<TupleFieldComparator> getCompareFields(
+   static std::vector<ComparatorField> getCompareFields(
       const std::vector<silo::storage::ColumnMetadata>& columns_metadata,
       const std::vector<OrderByField>& order_by_fields
    );
+
+   [[nodiscard]] bool compareLess(const Tuple& other, const std::vector<ComparatorField>& fields)
+      const;
 
   public:
    typedef std::function<bool(const Tuple&, const Tuple&)> Comparator;
@@ -47,8 +50,6 @@ class Tuple {
       const std::vector<silo::storage::ColumnMetadata>& columns_metadata,
       const std::vector<OrderByField>& order_by_fields
    );
-
-   bool compareLess(const Tuple& other, const std::vector<TupleFieldComparator>& fields) const;
 
    bool operator==(const Tuple& other) const;
    bool operator!=(const Tuple& other) const;

--- a/include/silo/storage/column_group.h
+++ b/include/silo/storage/column_group.h
@@ -43,6 +43,11 @@ class DatabaseConfig;
 
 namespace silo::storage {
 
+struct ColumnMetadata {
+   std::string name;
+   silo::config::ColumnType type;
+};
+
 class ColumnPartitionGroup {
    friend class boost::serialization::access;
 
@@ -74,7 +79,7 @@ class ColumnPartitionGroup {
    }
 
   public:
-   std::vector<config::DatabaseMetadata> metadata;
+   std::vector<ColumnMetadata> metadata;
 
    std::map<std::string, storage::column::StringColumnPartition&> string_columns;
    std::map<std::string, storage::column::IndexedStringColumnPartition&> indexed_string_columns;
@@ -90,7 +95,7 @@ class ColumnPartitionGroup {
    );
 
    [[nodiscard]] ColumnPartitionGroup getSubgroup(
-      const std::vector<config::DatabaseMetadata>& fields
+      const std::vector<silo::storage::ColumnMetadata>& fields
    ) const;
 
    std::optional<std::variant<std::string, int32_t, double>> getValue(
@@ -130,7 +135,7 @@ class ColumnGroup {
    }
 
   public:
-   std::vector<config::DatabaseMetadata> metadata;
+   std::vector<ColumnMetadata> metadata;
 
    std::map<std::string, storage::column::StringColumn> string_columns;
    std::map<std::string, storage::column::IndexedStringColumn> indexed_string_columns;

--- a/src/silo/common/string.cpp
+++ b/src/silo/common/string.cpp
@@ -1,3 +1,4 @@
+
 #include "silo/common/string.h"
 
 #include <cstring>
@@ -64,7 +65,11 @@ std::optional<std::strong_ordering> String<I>::fastCompare(const String<I>& othe
       return std::strong_ordering::equal;
    }
 
-   const int prefix_compare = memcmp(this->data.data() + 4, other.data.data() + 4, I - 4);
+   const size_t to_compare = *reinterpret_cast<const uint32_t*>(data.data()) <= I &&
+                                   *reinterpret_cast<const uint32_t*>(other.data.data())
+                                ? I
+                                : I - 4;
+   const int prefix_compare = memcmp(this->data.data() + 4, other.data.data() + 4, to_compare);
    if (prefix_compare < 0) {
       return std::strong_ordering::less;
    }

--- a/src/silo/common/string.cpp
+++ b/src/silo/common/string.cpp
@@ -59,49 +59,24 @@ std::optional<common::String<I>> String<I>::embedString(
 }
 
 template <size_t I>
-int String<I>::compare(const String<I>& other) const {
-   return memcmp(this->data.data(), other.data.data(), I + 4);
+std::optional<std::strong_ordering> String<I>::fastCompare(const String<I>& other) const {
+   if (memcmp(this->data.data(), other.data.data(), I + 4) == 0) {
+      return std::strong_ordering::equal;
+   }
+
+   const int prefix_compare = memcmp(this->data.data() + 4, other.data.data() + 4, I - 4);
+   if (prefix_compare < 0) {
+      return std::strong_ordering::less;
+   }
+   if (prefix_compare > 0) {
+      return std::strong_ordering::greater;
+   }
+   return std::nullopt;
 }
 
 template <size_t I>
 bool String<I>::operator==(const String<I>& other) const {
-   return this->compare(other) == 0;
-}
-
-template <size_t I>
-bool String<I>::operator<(const String<I>& other) const {
-   const int prefix_compare = memcmp(this->data.data() + 4, other.data.data() + 4, 8);
-   if (prefix_compare < 0) {
-      return true;
-   }
-   if (prefix_compare > 0) {
-      return false;
-   }
-   // TODO(#137) implement more than just prefix matching
-   return false;
-}
-
-template <size_t I>
-bool String<I>::operator<=(const String<I>& other) const {
-   const int prefix_compare = memcmp(this->data.data() + 4, other.data.data() + 4, 8);
-   if (prefix_compare < 0) {
-      return true;
-   }
-   if (prefix_compare > 0) {
-      return false;
-   }
-   // TODO(#137) implement more than just prefix matching
-   return true;
-}
-
-template <size_t I>
-bool String<I>::operator>(const String<I>& other) const {
-   return other < *this;
-}
-
-template <size_t I>
-bool String<I>::operator>=(const String<I>& other) const {
-   return other <= *this;
+   return memcmp(this->data.data(), other.data.data(), I + 4) == 0;
 }
 
 template <size_t I>

--- a/src/silo/common/string.test.cpp
+++ b/src/silo/common/string.test.cpp
@@ -71,3 +71,26 @@ TEST(String, comparesCorrectlyIfPrefixesMatchUpTo32Positions) {
       EXPECT_EQ(under_test2, under_test3);
    }
 }
+
+TEST(String, fastComparesCorrectlyIfPrefixesMatchUpTo32Positions) {
+   BidirectionalMap<std::string> dict;
+   const std::string value = "1234567890abcdefghijklmnopqrstuv";
+   for (size_t i = 0; i < 16; ++i) {
+      const String<STRING_SIZE> under_test1(value.substr(0, i) + "x", dict);
+      const String<STRING_SIZE> under_test2(value.substr(0, i) + "y", dict);
+      EXPECT_EQ(under_test1.fastCompare(under_test2), std::strong_ordering::less);
+      EXPECT_EQ(under_test2.fastCompare(under_test1), std::strong_ordering::greater);
+      const String<STRING_SIZE> under_test3(value.substr(0, i) + "y", dict);
+      EXPECT_EQ(under_test2.fastCompare(under_test3), std::strong_ordering::equal);
+      EXPECT_EQ(under_test3.fastCompare(under_test2), std::strong_ordering::equal);
+   }
+   for (size_t i = 16; i < value.size(); ++i) {
+      const String<STRING_SIZE> under_test1(value.substr(0, i) + "x", dict);
+      const String<STRING_SIZE> under_test2(value.substr(0, i) + "y", dict);
+      EXPECT_EQ(under_test1.fastCompare(under_test2), std::nullopt);
+      EXPECT_EQ(under_test2.fastCompare(under_test1), std::nullopt);
+      const String<STRING_SIZE> under_test3(value.substr(0, i) + "y", dict);
+      EXPECT_EQ(under_test2.fastCompare(under_test3), std::strong_ordering::equal);
+      EXPECT_EQ(under_test3.fastCompare(under_test2), std::strong_ordering::equal);
+   }
+}

--- a/src/silo/database.cpp
+++ b/src/silo/database.cpp
@@ -658,10 +658,12 @@ Database Database::preprocessing(
 
 void Database::initializeColumn(config::ColumnType column_type, const std::string& name) {
    SPDLOG_TRACE("Initializing column {}", name);
+   columns.metadata.push_back({name, column_type});
    switch (column_type) {
       case config::ColumnType::STRING:
          columns.string_columns.emplace(name, storage::column::StringColumn());
          for (auto& partition : partitions) {
+            partition.columns.metadata.push_back({name, column_type});
             partition.insertColumn(name, columns.string_columns.at(name).createPartition());
          }
          break;
@@ -669,6 +671,7 @@ void Database::initializeColumn(config::ColumnType column_type, const std::strin
          auto column = storage::column::IndexedStringColumn();
          columns.indexed_string_columns.emplace(name, std::move(column));
          for (auto& partition : partitions) {
+            partition.columns.metadata.push_back({name, column_type});
             partition.insertColumn(name, columns.indexed_string_columns.at(name).createPartition());
          }
       } break;
@@ -677,6 +680,7 @@ void Database::initializeColumn(config::ColumnType column_type, const std::strin
             name, storage::column::PangoLineageColumn(alias_key)
          );
          for (auto& partition : partitions) {
+            partition.columns.metadata.push_back({name, column_type});
             partition.insertColumn(name, columns.pango_lineage_columns.at(name).createPartition());
          }
          break;
@@ -686,24 +690,28 @@ void Database::initializeColumn(config::ColumnType column_type, const std::strin
                           : storage::column::DateColumn(false);
          columns.date_columns.emplace(name, std::move(column));
          for (auto& partition : partitions) {
+            partition.columns.metadata.push_back({name, column_type});
             partition.insertColumn(name, columns.date_columns.at(name).createPartition());
          }
       } break;
       case config::ColumnType::INT:
          columns.int_columns.emplace(name, storage::column::IntColumn());
          for (auto& partition : partitions) {
+            partition.columns.metadata.push_back({name, column_type});
             partition.insertColumn(name, columns.int_columns.at(name).createPartition());
          }
          break;
       case config::ColumnType::FLOAT:
          columns.float_columns.emplace(name, storage::column::FloatColumn());
          for (auto& partition : partitions) {
+            partition.columns.metadata.push_back({name, column_type});
             partition.insertColumn(name, columns.float_columns.at(name).createPartition());
          }
          break;
       case config::ColumnType::INSERTION:
          columns.insertion_columns.emplace(name, storage::column::InsertionColumn());
          for (auto& partition : partitions) {
+            partition.columns.metadata.push_back({name, column_type});
             partition.insertColumn(name, columns.insertion_columns.at(name).createPartition());
          }
          break;

--- a/src/silo/query_engine/actions/aa_mutations.cpp
+++ b/src/silo/query_engine/actions/aa_mutations.cpp
@@ -117,7 +117,7 @@ void AAMutations::validateOrderByFields(const Database& /*database*/) const {
    const std::vector<std::string> result_field_names{
       {POSITION_FIELD_NAME, PROPORTION_FIELD_NAME, COUNT_FIELD_NAME}};
 
-   for (const Action::OrderByField& field : order_by_fields) {
+   for (const OrderByField& field : order_by_fields) {
       CHECK_SILO_QUERY(
          std::any_of(
             result_field_names.begin(),

--- a/src/silo/query_engine/actions/action.cpp
+++ b/src/silo/query_engine/actions/action.cpp
@@ -43,7 +43,7 @@ void Action::applySort(QueryResult& result) const {
       }
       return false;
    };
-   size_t end_of_sort = std::min(
+   const size_t end_of_sort = std::min(
       static_cast<size_t>(limit.value_or(result_vector.size()) + offset.value_or(0UL)),
       result_vector.size()
    );

--- a/src/silo/query_engine/actions/aggregated.cpp
+++ b/src/silo/query_engine/actions/aggregated.cpp
@@ -28,6 +28,7 @@
 #include "silo/config/database_config.h"
 #include "silo/database.h"
 #include "silo/query_engine/actions/action.h"
+#include "silo/query_engine/actions/tuple.h"
 #include "silo/query_engine/operator_result.h"
 #include "silo/query_engine/query_parse_exception.h"
 #include "silo/query_engine/query_result.h"
@@ -42,180 +43,22 @@
 
 namespace {
 
-std::vector<silo::config::DatabaseMetadata> parseGroupByFields(
+std::vector<silo::storage::ColumnMetadata> parseGroupByFields(
    const silo::Database& database,
    const std::vector<std::string>& group_by_fields
 ) {
-   std::vector<silo::config::DatabaseMetadata> group_by_metadata;
+   std::vector<silo::storage::ColumnMetadata> group_by_metadata;
    for (const std::string& group_by_field : group_by_fields) {
       const auto& metadata = database.database_config.getMetadata(group_by_field);
       CHECK_SILO_QUERY(
          metadata.has_value(), "Metadata field '" + group_by_field + "' to group by not found"
       )
-      group_by_metadata.push_back(*metadata);
+      group_by_metadata.push_back({metadata->name, metadata->getColumnType()});
    }
    return group_by_metadata;
 }
 
-size_t getTupleSize(const std::vector<silo::config::DatabaseMetadata>& group_by_metadata) {
-   size_t size = 0;
-   for (const auto& metadata : group_by_metadata) {
-      if (metadata.getColumnType() == silo::config::ColumnType::STRING) {
-         size += sizeof(silo::common::String<silo::common::STRING_SIZE>);
-      } else if (metadata.getColumnType() == silo::config::ColumnType::FLOAT) {
-         size += sizeof(double);
-      } else if (metadata.getColumnType() == silo::config::ColumnType::INT) {
-         size += sizeof(int32_t);
-      } else if (metadata.getColumnType() == silo::config::ColumnType::DATE) {
-         size += sizeof(silo::common::Date);
-      } else {
-         size += sizeof(silo::Idx);
-      }
-   }
-   return size;
-}
 }  // namespace
-
-namespace silo::query_engine::actions {
-
-using json_value_type = std::optional<std::variant<std::string, int32_t, double>>;
-
-struct Tuple {
-   std::vector<char> data;
-   const silo::storage::ColumnPartitionGroup& columns;
-
-   Tuple(
-      uint32_t sequence_id,
-      const silo::storage::ColumnPartitionGroup& columns,
-      size_t tuple_size
-   )
-       : columns(columns) {
-      data.resize(tuple_size);
-      char* data_pointer = data.data();
-      for (const auto& metadata : columns.metadata) {
-         if (metadata.getColumnType() == config::ColumnType::DATE) {
-            const common::Date value =
-               columns.date_columns.at(metadata.name).getValues()[sequence_id];
-            *reinterpret_cast<common::Date*>(data_pointer) = value;
-            data_pointer += sizeof(decltype(value));
-         } else if (metadata.getColumnType() == config::ColumnType::INT) {
-            const int32_t value = columns.int_columns.at(metadata.name).getValues()[sequence_id];
-            *reinterpret_cast<int32_t*>(data_pointer) = value;
-            data_pointer += sizeof(decltype(value));
-         } else if (metadata.getColumnType() == config::ColumnType::FLOAT) {
-            const double value = columns.float_columns.at(metadata.name).getValues()[sequence_id];
-            *reinterpret_cast<double*>(data_pointer) = value;
-            data_pointer += sizeof(decltype(value));
-         } else if (metadata.getColumnType() == config::ColumnType::STRING) {
-            const common::String<common::STRING_SIZE> value =
-               columns.string_columns.at(metadata.name).getValues()[sequence_id];
-            *reinterpret_cast<common::String<common::STRING_SIZE>*>(data_pointer) = value;
-            data_pointer += sizeof(decltype(value));
-         } else if (metadata.getColumnType() == config::ColumnType::INDEXED_PANGOLINEAGE) {
-            const silo::Idx value =
-               columns.pango_lineage_columns.at(metadata.name).getValues()[sequence_id];
-            *reinterpret_cast<silo::Idx*>(data_pointer) = value;
-            data_pointer += sizeof(decltype(value));
-         } else if (metadata.getColumnType() == config::ColumnType::INDEXED_STRING) {
-            const silo::Idx value =
-               columns.indexed_string_columns.at(metadata.name).getValues()[sequence_id];
-            *reinterpret_cast<silo::Idx*>(data_pointer) = value;
-            data_pointer += sizeof(decltype(value));
-         } else if (metadata.getColumnType() == config::ColumnType::INSERTION) {
-            const silo::Idx value =
-               columns.insertion_columns.at(metadata.name).getValues()[sequence_id];
-            *reinterpret_cast<silo::Idx*>(data_pointer) = value;
-            data_pointer += sizeof(decltype(value));
-         } else {
-            throw std::runtime_error("Unchecked column type of column " + metadata.name);
-         }
-      }
-   }
-
-   // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-   [[nodiscard]] std::map<std::string, json_value_type> getFields() const {
-      std::map<std::string, json_value_type> fields;
-      const char* data_pointer = data.data();
-      for (const auto& metadata : columns.metadata) {
-         if (metadata.getColumnType() == config::ColumnType::DATE) {
-            const common::Date value = *reinterpret_cast<const common::Date*>(data_pointer);
-            fields[metadata.name] = common::dateToString(value);
-            data_pointer += sizeof(decltype(value));
-         } else if (metadata.getColumnType() == config::ColumnType::INT) {
-            const int32_t value = *reinterpret_cast<const int32_t*>(data_pointer);
-            if (value == INT32_MIN) {
-               fields[metadata.name] = std::nullopt;
-            } else {
-               fields[metadata.name] = value;
-            }
-            data_pointer += sizeof(decltype(value));
-         } else if (metadata.getColumnType() == config::ColumnType::FLOAT) {
-            const double value = *reinterpret_cast<const double*>(data_pointer);
-            if (std::isnan(value)) {
-               fields[metadata.name] = std::nullopt;
-            } else {
-               fields[metadata.name] = value;
-            }
-            data_pointer += sizeof(decltype(value));
-         } else if (metadata.getColumnType() == config::ColumnType::STRING) {
-            const common::String<common::STRING_SIZE> value =
-               *reinterpret_cast<const common::String<common::STRING_SIZE>*>(data_pointer);
-            std::string string_value = columns.string_columns.at(metadata.name).lookupValue(value);
-            if (string_value.empty()) {
-               fields[metadata.name] = std::nullopt;
-            } else {
-               fields[metadata.name] = std::move(string_value);
-            }
-            data_pointer += sizeof(decltype(value));
-         } else if (metadata.getColumnType() == config::ColumnType::INDEXED_PANGOLINEAGE) {
-            const silo::Idx value = *reinterpret_cast<const silo::Idx*>(data_pointer);
-            std::string string_value =
-               columns.pango_lineage_columns.at(metadata.name).lookupValue(value).value;
-            if (string_value.empty()) {
-               fields[metadata.name] = std::nullopt;
-            } else {
-               fields[metadata.name] = std::move(string_value);
-            }
-            data_pointer += sizeof(decltype(value));
-         } else if (metadata.getColumnType() == config::ColumnType::INDEXED_STRING) {
-            const silo::Idx value = *reinterpret_cast<const silo::Idx*>(data_pointer);
-            std::string string_value =
-               columns.indexed_string_columns.at(metadata.name).lookupValue(value);
-            if (string_value.empty()) {
-               fields[metadata.name] = std::nullopt;
-            } else {
-               fields[metadata.name] = std::move(string_value);
-            }
-            data_pointer += sizeof(decltype(value));
-         } else if (metadata.getColumnType() == config::ColumnType::INSERTION) {
-            const silo::Idx value = *reinterpret_cast<const silo::Idx*>(data_pointer);
-            std::string string_value =
-               columns.insertion_columns.at(metadata.name).lookupValue(value);
-            if (string_value.empty()) {
-               fields[metadata.name] = std::nullopt;
-            } else {
-               fields[metadata.name] = std::move(string_value);
-            }
-            data_pointer += sizeof(decltype(value));
-         } else {
-            throw std::runtime_error("Unchecked column type of column " + metadata.name);
-         }
-      }
-      return fields;
-   }
-
-   bool operator==(const Tuple& other) const { return this->data == other.data; }
-};
-
-}  // namespace silo::query_engine::actions
-
-template <>
-struct std::hash<silo::query_engine::actions::Tuple> {
-   std::size_t operator()(const silo::query_engine::actions::Tuple& tuple) const {
-      const std::string_view str_view(tuple.data.data(), tuple.data.size());
-      return std::hash<std::string_view>{}(str_view);
-   }
-};
 
 namespace silo::query_engine::actions {
 
@@ -225,7 +68,8 @@ std::vector<QueryResultEntry> generateResult(std::unordered_map<Tuple, uint32_t>
    std::vector<QueryResultEntry> result;
    result.reserve(tuple_counts.size());
    for (auto& [tuple, count] : tuple_counts) {
-      std::map<std::string, json_value_type> fields = tuple.getFields();
+      std::map<std::string, std::optional<std::variant<std::string, int32_t, double>>> fields =
+         tuple.getFields();
       fields[COUNT_FIELD] = static_cast<int32_t>(count);
       result.push_back({fields});
    }
@@ -237,7 +81,7 @@ QueryResult aggregateWithoutGrouping(const std::vector<OperatorResult>& bitmap_f
    for (const auto& filter : bitmap_filters) {
       count += filter->cardinality();
    };
-   std::map<std::string, json_value_type> tuple_fields;
+   std::map<std::string, std::optional<std::variant<std::string, int32_t, double>>> tuple_fields;
    tuple_fields[COUNT_FIELD] = static_cast<int32_t>(count);
    return QueryResult{std::vector<QueryResultEntry>{{tuple_fields}}};
 }
@@ -246,17 +90,18 @@ Aggregated::Aggregated(std::vector<std::string> group_by_fields)
     : group_by_fields(std::move(group_by_fields)) {}
 
 void Aggregated::validateOrderByFields(const Database& database) const {
-   const std::vector<config::DatabaseMetadata> field_metadata =
+   const std::vector<silo::storage::ColumnMetadata> field_metadata =
       parseGroupByFields(database, group_by_fields);
 
-   for (const Action::OrderByField& field : order_by_fields) {
+   for (const OrderByField& field : order_by_fields) {
       CHECK_SILO_QUERY(
-         field.name == "count" ||
-            std::any_of(
-               field_metadata.begin(),
-               field_metadata.end(),
-               [&](const config::DatabaseMetadata& metadata) { return metadata.name == field.name; }
-            ),
+         field.name == COUNT_FIELD || std::any_of(
+                                         field_metadata.begin(),
+                                         field_metadata.end(),
+                                         [&](const silo::storage::ColumnMetadata& metadata) {
+                                            return metadata.name == field.name;
+                                         }
+                                      ),
          "The orderByField '" + field.name +
             "' cannot be ordered by, as it does not appear in the groupByFields."
       )
@@ -273,7 +118,7 @@ QueryResult Aggregated::execute(
    // TODO(#133) optimize when equal to partition_by field
    // TODO(#133) optimize single field groupby
 
-   const std::vector<config::DatabaseMetadata> group_by_metadata =
+   const std::vector<silo::storage::ColumnMetadata> group_by_metadata =
       parseGroupByFields(database, group_by_fields);
 
    std::vector<storage::ColumnPartitionGroup> group_by_column_groups;
@@ -292,7 +137,7 @@ QueryResult Aggregated::execute(
          std::unordered_map<Tuple, uint32_t>& map = maps.local();
          for (uint32_t partition_id = range.begin(); partition_id != range.end(); ++partition_id) {
             for (const uint32_t sequence_id : *bitmap_filters[partition_id]) {
-               ++map[Tuple(sequence_id, group_by_column_groups[partition_id], tuple_size)];
+               ++map[Tuple(sequence_id, &group_by_column_groups[partition_id], tuple_size)];
             }
          }
       }

--- a/src/silo/query_engine/actions/details.cpp
+++ b/src/silo/query_engine/actions/details.cpp
@@ -11,6 +11,8 @@
 #include <utility>
 #include <variant>
 
+#include <tbb/enumerable_thread_specific.h>
+#include <tbb/parallel_for.h>
 #include <nlohmann/json.hpp>
 #include <roaring/roaring.hh>
 
@@ -21,6 +23,7 @@
 #include "silo/config/database_config.h"
 #include "silo/database.h"
 #include "silo/query_engine/actions/action.h"
+#include "silo/query_engine/actions/tuple.h"
 #include "silo/query_engine/operator_result.h"
 #include "silo/query_engine/query_parse_exception.h"
 #include "silo/query_engine/query_result.h"
@@ -35,18 +38,18 @@
 
 namespace {
 
-std::vector<silo::config::DatabaseMetadata> parseFields(
+std::vector<silo::storage::ColumnMetadata> parseFields(
    const silo::Database& database,
    const std::vector<std::string>& fields
 ) {
    if (fields.empty()) {
-      return database.database_config.schema.metadata;
+      return database.columns.metadata;
    }
-   std::vector<silo::config::DatabaseMetadata> field_metadata;
+   std::vector<silo::storage::ColumnMetadata> field_metadata;
    for (const std::string& field : fields) {
       const auto& metadata = database.database_config.getMetadata(field);
       CHECK_SILO_QUERY(metadata.has_value(), "Metadata field " + field + " not found.")
-      field_metadata.push_back(metadata.value());
+      field_metadata.push_back({metadata->name, metadata->getColumnType()});
    }
    return field_metadata;
 }
@@ -58,98 +61,167 @@ Details::Details(std::vector<std::string> fields)
     : fields(std::move(fields)) {}
 
 void Details::validateOrderByFields(const Database& database) const {
-   const std::vector<config::DatabaseMetadata> field_metadata = parseFields(database, fields);
+   const std::vector<silo::storage::ColumnMetadata> field_metadata = parseFields(database, fields);
 
-   for (const Action::OrderByField& field : order_by_fields) {
+   for (const OrderByField& field : order_by_fields) {
       CHECK_SILO_QUERY(
          std::any_of(
             field_metadata.begin(),
             field_metadata.end(),
-            [&](const config::DatabaseMetadata& metadata) { return metadata.name == field.name; }
+            [&](const silo::storage::ColumnMetadata& metadata) {
+               return metadata.name == field.name;
+            }
          ),
          "OrderByField " + field.name + " is not contained in the result of this operation."
       )
    }
 }
 
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 QueryResult Details::execute(
    const silo::Database& database,
-   std::vector<silo::query_engine::OperatorResult> bitmap_filter
+   std::vector<OperatorResult> bitmap_filter
 ) const {
-   const std::vector<config::DatabaseMetadata> field_metadata = parseFields(database, fields);
+   return QueryResult{};
+}
 
-   QueryResult results;
-   for (size_t partition_id = 0; partition_id < database.partitions.size(); partition_id++) {
-      const auto& bitmap = bitmap_filter[partition_id];
-      const auto& columns = database.partitions[partition_id].columns;
-      for (const Idx sequence_id : *bitmap) {
-         std::map<std::string, std::optional<std::variant<std::string, int32_t, double>>>
-            row_fields;
-         for (const auto& metadata : field_metadata) {
-            if (metadata.getColumnType() == config::ColumnType::DATE) {
-               const common::Date value =
-                  columns.date_columns.at(metadata.name).getValues()[sequence_id];
-               row_fields[metadata.name] = common::dateToString(value);
-            } else if (metadata.getColumnType() == config::ColumnType::INT) {
-               const int32_t value = columns.int_columns.at(metadata.name).getValues()[sequence_id];
-               if (value == INT32_MIN) {
-                  row_fields[metadata.name] = std::nullopt;
-               } else {
-                  row_fields[metadata.name] = value;
-               }
-            } else if (metadata.getColumnType() == config::ColumnType::FLOAT) {
-               const double value =
-                  columns.float_columns.at(metadata.name).getValues()[sequence_id];
-               if (value == std::nan("")) {
-                  row_fields[metadata.name] = std::nullopt;
-               } else {
-                  row_fields[metadata.name] = value;
-               }
-            } else if (metadata.getColumnType() == config::ColumnType::STRING) {
-               const auto& column = columns.string_columns.at(metadata.name);
-               const common::String<common::STRING_SIZE> value = column.getValues()[sequence_id];
-               std::string string_value = column.lookupValue(value);
-               if (string_value.empty()) {
-                  row_fields[metadata.name] = std::nullopt;
-               } else {
-                  row_fields[metadata.name] = std::move(string_value);
-               }
-            } else if (metadata.getColumnType() == config::ColumnType::INDEXED_PANGOLINEAGE) {
-               const auto& column = columns.pango_lineage_columns.at(metadata.name);
-               const silo::Idx value = column.getValues()[sequence_id];
-               std::string string_value = column.lookupValue(value).value;
-               if (string_value.empty()) {
-                  row_fields[metadata.name] = std::nullopt;
-               } else {
-                  row_fields[metadata.name] = std::move(string_value);
-               }
-            } else if (metadata.getColumnType() == config::ColumnType::INDEXED_STRING) {
-               const auto& column = columns.indexed_string_columns.at(metadata.name);
-               const silo::Idx value = column.getValues()[sequence_id];
-               std::string string_value = column.lookupValue(value);
-               if (string_value.empty()) {
-                  row_fields[metadata.name] = std::nullopt;
-               } else {
-                  row_fields[metadata.name] = std::move(string_value);
-               }
-            } else if (metadata.getColumnType() == config::ColumnType::INSERTION) {
-               const auto& column = columns.insertion_columns.at(metadata.name);
-               const silo::Idx value = column.getValues()[sequence_id];
-               std::string string_value = column.lookupValue(value);
-               if (string_value.empty()) {
-                  row_fields[metadata.name] = std::nullopt;
-               } else {
-                  row_fields[metadata.name] = std::move(string_value);
-               }
-            } else {
-               throw std::runtime_error("Unchecked column type of column " + metadata.name);
-            }
-         }
-         results.query_result.push_back(QueryResultEntry{row_fields});
+std::vector<actions::Tuple> mergeSortedTuples(
+   const Tuple::Comparator tuple_comparator,
+   std::vector<std::vector<actions::Tuple>>& tuples,
+   const uint32_t to_produce
+) {
+   using iterator = std::vector<actions::Tuple>::const_iterator;
+   std::vector<std::pair<iterator, iterator>> min_heap;
+   for (auto& tuple_vector : tuples) {
+      if (tuple_vector.begin() != tuple_vector.end()) {
+         min_heap.emplace_back(tuple_vector.begin(), tuple_vector.end());
       }
    }
-   return results;
+
+   auto heap_cmp =
+      [&](const std::pair<iterator, iterator>& lhs, const std::pair<iterator, iterator>& rhs) {
+         return tuple_comparator(*rhs.first, *lhs.first);
+      };
+   std::make_heap(min_heap.begin(), min_heap.end(), heap_cmp);
+
+   std::vector<actions::Tuple> result;
+
+   for (uint32_t counter = 0; counter < to_produce && !min_heap.empty(); counter++) {
+      std::pop_heap(min_heap.begin(), min_heap.end(), heap_cmp);
+      auto& current = min_heap.back();
+      result.emplace_back(*current.first);
+      current.first++;
+      if (current.first == current.second) {
+         min_heap.pop_back();
+      } else {
+         std::push_heap(min_heap.begin(), min_heap.end(), heap_cmp);
+      }
+   }
+
+   return result;
+}
+
+std::vector<actions::Tuple> produceSortedTuplesWithLimit(
+   const std::vector<storage::ColumnPartitionGroup>& column_groups,
+   std::vector<OperatorResult>& bitmap_filter,
+   const std::vector<silo::storage::ColumnMetadata>& field_metadata,
+   const std::vector<OrderByField>& order_by_fields,
+   const uint32_t to_produce
+) {
+   auto cmp = Tuple::getComparator(field_metadata, order_by_fields);
+   std::vector<std::vector<actions::Tuple>> tuples_per_partition(bitmap_filter.size());
+   tbb::parallel_for(tbb::blocked_range<size_t>(0u, bitmap_filter.size()), [&](auto local) {
+      for (size_t partition_id = local.begin(); partition_id != local.end(); partition_id++) {
+         const auto& columns = column_groups.at(partition_id);
+
+         size_t tuple_size = getTupleSize(field_metadata);
+         const auto& bitmap = bitmap_filter.at(partition_id);
+         std::vector<actions::Tuple>& my_tuples = tuples_per_partition.at(partition_id);
+         auto it = bitmap->begin();
+         auto end = bitmap->end();
+         uint32_t counter = 0;
+         for (; it != end && counter < to_produce; it++) {
+            my_tuples.emplace_back(*it, &columns, tuple_size);
+            counter++;
+         }
+         std::make_heap(my_tuples.begin(), my_tuples.end(), cmp);
+         for (; it != end; it++) {
+            Tuple tuple(*it, &columns, tuple_size);
+            if (cmp(tuple, my_tuples.front())) {
+               std::pop_heap(my_tuples.begin(), my_tuples.end(), cmp);
+               my_tuples.back() = tuple;
+               std::push_heap(my_tuples.begin(), my_tuples.end(), cmp);
+            }
+         }
+         std::sort_heap(my_tuples.begin(), my_tuples.end());
+      }
+   });
+   return mergeSortedTuples(cmp, tuples_per_partition, to_produce);
+}
+
+std::vector<Tuple> produceAllTuples(
+   const std::vector<storage::ColumnPartitionGroup>& column_groups,
+   std::vector<OperatorResult>& bitmap_filter,
+   const std::vector<silo::storage::ColumnMetadata>& field_metadata
+) {
+   size_t tuple_size = getTupleSize(field_metadata);
+
+   std::vector<size_t> offsets(bitmap_filter.size() + 1);
+   for (size_t partition_id = 0; partition_id != bitmap_filter.size(); partition_id++) {
+      offsets[partition_id + 1] =
+         offsets[partition_id] + bitmap_filter.at(partition_id)->cardinality();
+   }
+
+   std::vector<Tuple> all_tuples;
+   all_tuples.resize(offsets.back());
+   tbb::parallel_for(tbb::blocked_range<size_t>(0u, bitmap_filter.size()), [&](auto local) {
+      for (size_t partition_id = local.begin(); partition_id != local.end(); partition_id++) {
+         const auto& columns = column_groups.at(partition_id);
+         const auto& bitmap = bitmap_filter.at(partition_id);
+         auto cursor = all_tuples.begin() + offsets.at(partition_id);
+         for (auto it : *bitmap) {
+            *(cursor++) = Tuple(it, &columns, tuple_size);
+         }
+      }
+   });
+   return all_tuples;
+}
+
+QueryResult Details::executeAndOrder(
+   const silo::Database& database,
+   std::vector<OperatorResult> bitmap_filter
+) const {
+   validateOrderByFields(database);
+   const std::vector<storage::ColumnMetadata> field_metadata = parseFields(database, fields);
+
+   std::vector<storage::ColumnPartitionGroup> column_groups;
+   column_groups.reserve(database.partitions.size());
+   for (const auto& partition : database.partitions) {
+      column_groups.emplace_back(partition.columns.getSubgroup(field_metadata));
+   }
+
+   std::vector<actions::Tuple> tuples;
+   if (limit.has_value()) {
+      tuples = produceSortedTuplesWithLimit(
+         column_groups,
+         bitmap_filter,
+         field_metadata,
+         order_by_fields,
+         this->limit.value() + offset.value_or(0)
+      );
+   } else {
+      tuples = produceAllTuples(column_groups, bitmap_filter, field_metadata);
+      if (!order_by_fields.empty()) {
+         auto cmp = Tuple::getComparator(field_metadata, order_by_fields);
+         std::sort(tuples.begin(), tuples.end(), cmp);
+      }
+   }
+
+   QueryResult results_in_format;
+   for (const auto& tuple : tuples) {
+      results_in_format.query_result.push_back({tuple.getFields()});
+   }
+   applyOffsetAndLimit(results_in_format);
+   return results_in_format;
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/src/silo/query_engine/actions/details.cpp
+++ b/src/silo/query_engine/actions/details.cpp
@@ -223,8 +223,9 @@ QueryResult Details::executeAndOrder(
    } else {
       tuples = produceAllTuples(tuple_factories, bitmap_filter);
       if (!order_by_fields.empty()) {
-         auto cmp = Tuple::getComparator(field_metadata, order_by_fields);
-         std::sort(tuples.begin(), tuples.end(), cmp);
+         std::sort(
+            tuples.begin(), tuples.end(), Tuple::getComparator(field_metadata, order_by_fields)
+         );
       }
    }
 

--- a/src/silo/query_engine/actions/fasta_aligned.cpp
+++ b/src/silo/query_engine/actions/fasta_aligned.cpp
@@ -17,7 +17,7 @@ FastaAligned::FastaAligned(std::vector<std::string>&& sequence_names)
 
 void FastaAligned::validateOrderByFields(const Database& database) const {
    const std::string& primary_key_field = database.database_config.schema.primary_key;
-   for (const Action::OrderByField& field : order_by_fields) {
+   for (const OrderByField& field : order_by_fields) {
       CHECK_SILO_QUERY(
          field.name == primary_key_field ||
             std::find(sequence_names.begin(), sequence_names.end(), field.name) !=

--- a/src/silo/query_engine/actions/nuc_mutations.cpp
+++ b/src/silo/query_engine/actions/nuc_mutations.cpp
@@ -116,7 +116,7 @@ void NucMutations::validateOrderByFields(const Database& /*database*/) const {
    const std::vector<std::string> result_field_names{
       {POSITION_FIELD_NAME, PROPORTION_FIELD_NAME, COUNT_FIELD_NAME}};
 
-   for (const Action::OrderByField& field : order_by_fields) {
+   for (const OrderByField& field : order_by_fields) {
       CHECK_SILO_QUERY(
          std::any_of(
             result_field_names.begin(),

--- a/src/silo/query_engine/actions/tuple.cpp
+++ b/src/silo/query_engine/actions/tuple.cpp
@@ -1,0 +1,377 @@
+#include "silo/query_engine/actions/tuple.h"
+
+#include "silo/query_engine/actions/action.h"
+
+using namespace silo::query_engine::actions;
+
+using json_value_type = std::optional<std::variant<std::string, int32_t, double>>;
+
+namespace {
+using silo::common::Date;
+using silo::common::String;
+using silo::common::STRING_SIZE;
+using silo::config::ColumnType;
+
+void assignTupleField(
+   char** data_pointer,
+   uint32_t sequence_id,
+   const silo::storage::ColumnMetadata& metadata,
+   const silo::storage::ColumnPartitionGroup& columns
+) {
+   if (metadata.type == ColumnType::DATE) {
+      const Date value = columns.date_columns.at(metadata.name).getValues()[sequence_id];
+      *reinterpret_cast<Date*>(*data_pointer) = value;
+      *data_pointer += sizeof(decltype(value));
+   } else if (metadata.type == ColumnType::INT) {
+      const int32_t value = columns.int_columns.at(metadata.name).getValues()[sequence_id];
+      *reinterpret_cast<int32_t*>(*data_pointer) = value;
+      *data_pointer += sizeof(decltype(value));
+   } else if (metadata.type == ColumnType::FLOAT) {
+      const double value = columns.float_columns.at(metadata.name).getValues()[sequence_id];
+      *reinterpret_cast<double*>(*data_pointer) = value;
+      *data_pointer += sizeof(decltype(value));
+   } else if (metadata.type == ColumnType::STRING) {
+      const String<STRING_SIZE> value =
+         columns.string_columns.at(metadata.name).getValues()[sequence_id];
+      *reinterpret_cast<String<STRING_SIZE>*>(*data_pointer) = value;
+      *data_pointer += sizeof(decltype(value));
+   } else if (metadata.type == ColumnType::INDEXED_PANGOLINEAGE) {
+      const silo::Idx value =
+         columns.pango_lineage_columns.at(metadata.name).getValues()[sequence_id];
+      *reinterpret_cast<silo::Idx*>(*data_pointer) = value;
+      *data_pointer += sizeof(decltype(value));
+   } else if (metadata.type == ColumnType::INDEXED_STRING) {
+      const silo::Idx value =
+         columns.indexed_string_columns.at(metadata.name).getValues()[sequence_id];
+      *reinterpret_cast<silo::Idx*>(*data_pointer) = value;
+      *data_pointer += sizeof(decltype(value));
+   } else if (metadata.type == ColumnType::INSERTION) {
+      const silo::Idx value = columns.insertion_columns.at(metadata.name).getValues()[sequence_id];
+      *reinterpret_cast<silo::Idx*>(*data_pointer) = value;
+      *data_pointer += sizeof(decltype(value));
+   } else {
+      throw std::runtime_error("Unchecked column type of column " + metadata.name);
+   }
+}
+
+json_value_type tupleFieldToValueType(
+   const char** data_pointer,
+   const silo::storage::ColumnMetadata& metadata,
+   const silo::storage::ColumnPartitionGroup& columns
+) {
+   if (metadata.type == ColumnType::DATE) {
+      const Date value = *reinterpret_cast<const Date*>(*data_pointer);
+      *data_pointer += sizeof(decltype(value));
+      return silo::common::dateToString(value);
+   } else if (metadata.type == ColumnType::INT) {
+      const int32_t value = *reinterpret_cast<const int32_t*>(*data_pointer);
+      *data_pointer += sizeof(decltype(value));
+      if (value == INT32_MIN) {
+         return std::nullopt;
+      } else {
+         return value;
+      }
+   } else if (metadata.type == ColumnType::FLOAT) {
+      const double value = *reinterpret_cast<const double*>(*data_pointer);
+      *data_pointer += sizeof(decltype(value));
+      if (std::isnan(value)) {
+         return std::nullopt;
+      } else {
+         return value;
+      }
+   } else if (metadata.type == ColumnType::STRING) {
+      const String<STRING_SIZE> value =
+         *reinterpret_cast<const String<STRING_SIZE>*>(*data_pointer);
+      *data_pointer += sizeof(decltype(value));
+      std::string string_value = columns.string_columns.at(metadata.name).lookupValue(value);
+      if (string_value.empty()) {
+         return std::nullopt;
+      } else {
+         return std::move(string_value);
+      }
+   } else if (metadata.type == ColumnType::INDEXED_PANGOLINEAGE) {
+      const silo::Idx value = *reinterpret_cast<const silo::Idx*>(*data_pointer);
+      *data_pointer += sizeof(decltype(value));
+      std::string string_value =
+         columns.pango_lineage_columns.at(metadata.name).lookupValue(value).value;
+      if (string_value.empty()) {
+         return std::nullopt;
+      } else {
+         return std::move(string_value);
+      }
+   } else if (metadata.type == ColumnType::INDEXED_STRING) {
+      const silo::Idx value = *reinterpret_cast<const silo::Idx*>(*data_pointer);
+      *data_pointer += sizeof(decltype(value));
+      std::string string_value =
+         columns.indexed_string_columns.at(metadata.name).lookupValue(value);
+      if (string_value.empty()) {
+         return std::nullopt;
+      } else {
+         return std::move(string_value);
+      }
+   } else if (metadata.type == ColumnType::INSERTION) {
+      const silo::Idx value = *reinterpret_cast<const silo::Idx*>(*data_pointer);
+      *data_pointer += sizeof(decltype(value));
+      std::string string_value = columns.insertion_columns.at(metadata.name).lookupValue(value);
+      if (string_value.empty()) {
+         return std::nullopt;
+      } else {
+         return std::move(string_value);
+      }
+   } else {
+      throw std::runtime_error("Unchecked column type of column " + metadata.name);
+   }
+}
+
+std::strong_ordering compareDouble(double value1, double value2) {
+   std::partial_ordering compare = value1 <=> value2;
+   if (compare == std::partial_ordering::less) {
+      return std::strong_ordering::less;
+   }
+   if (compare == std::partial_ordering::equivalent) {
+      return std::strong_ordering::equal;
+   }
+   if (compare == std::partial_ordering::greater) {
+      return std::strong_ordering::greater;
+   }
+   if (std::isnan(value2)) {
+      if (std::isnan(value1)) {
+         return std::strong_ordering::equal;
+      } else {
+         return std::strong_ordering::less;
+      }
+   } else {
+      return std::strong_ordering::greater;
+   }
+}
+
+std::strong_ordering compareString(const std::string& value1, const std::string& value2) {
+   int cmp = value1.compare(value2);
+   if (cmp < 0) {
+      return std::strong_ordering::less;
+   }
+   if (cmp > 0) {
+      return std::strong_ordering::greater;
+   }
+   return std::strong_ordering::equal;
+}
+
+std::strong_ordering compareTupleFields(
+   const char** data_pointer1,
+   const char** data_pointer2,
+   const silo::storage::ColumnMetadata& metadata,
+   const silo::storage::ColumnPartitionGroup& columns
+) {
+   if (metadata.type == ColumnType::DATE) {
+      const Date value1 = *reinterpret_cast<const Date*>(*data_pointer1);
+      *data_pointer1 += sizeof(decltype(value1));
+      const Date value2 = *reinterpret_cast<const Date*>(*data_pointer2);
+      *data_pointer2 += sizeof(decltype(value2));
+      return value1 <=> value2;
+   } else if (metadata.type == ColumnType::INT) {
+      const int32_t value1 = *reinterpret_cast<const int32_t*>(*data_pointer1);
+      *data_pointer1 += sizeof(decltype(value1));
+      const int32_t value2 = *reinterpret_cast<const int32_t*>(*data_pointer2);
+      *data_pointer2 += sizeof(decltype(value2));
+      return value1 <=> value2;
+   } else if (metadata.type == ColumnType::FLOAT) {
+      const double value1 = *reinterpret_cast<const double*>(*data_pointer1);
+      *data_pointer1 += sizeof(decltype(value1));
+      const double value2 = *reinterpret_cast<const double*>(*data_pointer2);
+      *data_pointer2 += sizeof(decltype(value2));
+      return compareDouble(value1, value2);
+   } else if (metadata.type == ColumnType::STRING) {
+      const String<STRING_SIZE> value1 =
+         *reinterpret_cast<const String<STRING_SIZE>*>(*data_pointer1);
+      *data_pointer1 += sizeof(decltype(value1));
+      const String<STRING_SIZE> value2 =
+         *reinterpret_cast<const String<STRING_SIZE>*>(*data_pointer2);
+      *data_pointer2 += sizeof(decltype(value2));
+
+      auto fast_compare = value1.fastCompare(value2);
+      if (fast_compare) {
+         return fast_compare.value();
+      }
+      std::string string_value1 = columns.string_columns.at(metadata.name).lookupValue(value1);
+      std::string string_value2 = columns.string_columns.at(metadata.name).lookupValue(value2);
+      return compareString(string_value1, string_value2);
+   } else if (metadata.type == ColumnType::INDEXED_PANGOLINEAGE) {
+      const silo::Idx value1 = *reinterpret_cast<const silo::Idx*>(*data_pointer1);
+      *data_pointer1 += sizeof(decltype(value1));
+      std::string string_value1 =
+         columns.pango_lineage_columns.at(metadata.name).lookupValue(value1).value;
+      const silo::Idx value2 = *reinterpret_cast<const silo::Idx*>(*data_pointer2);
+      *data_pointer2 += sizeof(decltype(value2));
+      std::string string_value2 =
+         columns.pango_lineage_columns.at(metadata.name).lookupValue(value2).value;
+      return compareString(string_value1, string_value2);
+   } else if (metadata.type == ColumnType::INDEXED_STRING) {
+      const silo::Idx value1 = *reinterpret_cast<const silo::Idx*>(*data_pointer1);
+      *data_pointer1 += sizeof(decltype(value1));
+      std::string string_value1 =
+         columns.indexed_string_columns.at(metadata.name).lookupValue(value1);
+      const silo::Idx value2 = *reinterpret_cast<const silo::Idx*>(*data_pointer2);
+      *data_pointer2 += sizeof(decltype(value2));
+      std::string string_value2 =
+         columns.indexed_string_columns.at(metadata.name).lookupValue(value2);
+      return compareString(string_value1, string_value2);
+   } else if (metadata.type == ColumnType::INSERTION) {
+      const silo::Idx value1 = *reinterpret_cast<const silo::Idx*>(*data_pointer1);
+      *data_pointer1 += sizeof(decltype(value1));
+      std::string string_value1 = columns.insertion_columns.at(metadata.name).lookupValue(value1);
+      const silo::Idx value2 = *reinterpret_cast<const silo::Idx*>(*data_pointer2);
+      *data_pointer2 += sizeof(decltype(value2));
+      std::string string_value2 = columns.insertion_columns.at(metadata.name).lookupValue(value2);
+      return compareString(string_value1, string_value2);
+   } else {
+      throw std::runtime_error("Unchecked column type of column " + metadata.name);
+   }
+}
+
+size_t getColumnSize(const silo::storage::ColumnMetadata& metadata) {
+   if (metadata.type == silo::config::ColumnType::STRING) {
+      return sizeof(silo::common::String<silo::common::STRING_SIZE>);
+   } else if (metadata.type == silo::config::ColumnType::FLOAT) {
+      return sizeof(double);
+   } else if (metadata.type == silo::config::ColumnType::INT) {
+      return sizeof(int32_t);
+   } else if (metadata.type == silo::config::ColumnType::DATE) {
+      return sizeof(silo::common::Date);
+   } else {
+      return sizeof(silo::Idx);
+   }
+}
+
+}  // namespace
+
+size_t silo::query_engine::actions::getTupleSize(
+   const std::vector<silo::storage::ColumnMetadata>& metadata_list
+) {
+   size_t size = 0;
+   for (const auto& metadata : metadata_list) {
+      size += getColumnSize(metadata);
+   }
+   return size;
+}
+
+Tuple::Tuple(
+   uint32_t sequence_id,
+   const silo::storage::ColumnPartitionGroup* columns,
+   size_t tuple_size
+)
+    : columns(columns) {
+   data.resize(tuple_size);
+   char* data_pointer = data.data();
+   for (const auto& metadata : columns->metadata) {
+      assignTupleField(&data_pointer, sequence_id, metadata, *columns);
+   }
+}
+
+Tuple::Tuple(const Tuple& other)
+    : columns(other.columns),
+      data(other.data) {}
+
+Tuple::Tuple(Tuple&& other)
+    : columns(other.columns),
+      data(std::move(other.data)) {}
+
+Tuple& Tuple::operator=(const Tuple& other) {
+   this->columns = other.columns;
+   this->data = other.data;
+   return *this;
+};
+
+Tuple& Tuple::operator=(Tuple&& other) {
+   this->columns = other.columns;
+   this->data = std::move(other.data);
+   return *this;
+};
+
+std::map<std::string, json_value_type> Tuple::getFields() const {
+   std::map<std::string, json_value_type> fields;
+   const char* data_pointer = data.data();
+   for (const auto& metadata : columns->metadata) {
+      fields[metadata.name] = tupleFieldToValueType(&data_pointer, metadata, *columns);
+   }
+   return fields;
+}
+
+std::vector<TupleFieldComparator> Tuple::getCompareFields(
+   const std::vector<silo::storage::ColumnMetadata>& columns_metadata,
+   const std::vector<OrderByField>& order_by_fields
+) {
+   std::vector<TupleFieldComparator> tuple_field_comparators;
+   tuple_field_comparators.resize(order_by_fields.size());
+   size_t offset = 0;
+   for (const auto& metadata : columns_metadata) {
+      auto it = std::find_if(
+         order_by_fields.begin(),
+         order_by_fields.end(),
+         [&](const auto& order_by_field) { return metadata.name == order_by_field.name; }
+      );
+      if (it != order_by_fields.end()) {
+         const size_t index = std::distance(order_by_fields.begin(), it);
+         tuple_field_comparators[index] = TupleFieldComparator{offset, metadata, it->ascending};
+      }
+      offset += getColumnSize(metadata);
+   }
+   return tuple_field_comparators;
+}
+
+Tuple::Comparator Tuple::getComparator(
+   const std::vector<silo::storage::ColumnMetadata>& columns_metadata,
+   const std::vector<OrderByField>& order_by_fields
+) {
+   auto tuple_field_comparators =
+      actions::Tuple::getCompareFields(columns_metadata, order_by_fields);
+   return [tuple_field_comparators](const Tuple& tuple1, const Tuple& tuple2) {
+      return tuple1.compareLess(tuple2, tuple_field_comparators);
+   };
+}
+
+bool Tuple::compareLess(const Tuple& other, const std::vector<TupleFieldComparator>& fields) const {
+   for (const auto& field : fields) {
+      auto data_pointer1 = (this->data.data() + field.offset);
+      auto data_pointer2 = (other.data.data() + field.offset);
+      std::strong_ordering compare =
+         compareTupleFields(&data_pointer1, &data_pointer2, field.type, *columns);
+      if (compare != std::strong_ordering::equal) {
+         if (compare == std::strong_ordering::less) {
+            return field.ascending;
+         } else {
+            return !field.ascending;
+         }
+      }
+   }
+   return false;
+}
+
+bool Tuple::operator==(const Tuple& other) const {
+   return this->data == other.data;
+}
+bool Tuple::operator!=(const Tuple& other) const {
+   return !(*this == other);
+}
+
+bool Tuple::operator<(const Tuple& other) const {
+   const char* data_pointer1 = data.data();
+   const char* data_pointer2 = other.data.data();
+   for (const auto& metadata : columns->metadata) {
+      std::strong_ordering compare =
+         compareTupleFields(&data_pointer1, &data_pointer2, metadata, *columns);
+      if (compare != std::strong_ordering::equal) {
+         return compare == std::strong_ordering::less;
+      }
+   }
+   return false;
+}
+
+bool Tuple::operator>(const Tuple& other) const {
+   return (other < *this);
+}
+bool Tuple::operator<=(const Tuple& other) const {
+   return !(other < *this);
+}
+bool Tuple::operator>=(const Tuple& other) const {
+   return !(*this < other);
+}

--- a/src/silo/query_engine/actions/tuple.test.cpp
+++ b/src/silo/query_engine/actions/tuple.test.cpp
@@ -7,17 +7,17 @@ std::pair<silo::storage::ColumnGroup, silo::storage::ColumnPartitionGroup>
 createSinglePartitionColumns() {
    std::pair<silo::storage::ColumnGroup, silo::storage::ColumnPartitionGroup> return_value;
    auto& group = return_value.first;
-   auto& partitionGroup = return_value.second;
+   auto& partition_group = return_value.second;
 
    {
       const std::string string_column_name = "dummy_string_column";
       group.string_columns.emplace(string_column_name, silo::storage::column::StringColumn());
-      partitionGroup.metadata.push_back({string_column_name, silo::config::ColumnType::STRING});
-      partitionGroup.string_columns.emplace(
+      partition_group.metadata.push_back({string_column_name, silo::config::ColumnType::STRING});
+      partition_group.string_columns.emplace(
          string_column_name, group.string_columns.at(string_column_name).createPartition()
       );
-      partitionGroup.string_columns.at(string_column_name).insert("ABCD");
-      partitionGroup.string_columns.at(string_column_name)
+      partition_group.string_columns.at(string_column_name).insert("ABCD");
+      partition_group.string_columns.at(string_column_name)
          .insert(
             "some very long string some very long string some very long string some very long "
             "string "
@@ -25,22 +25,22 @@ createSinglePartitionColumns() {
             "string "
             "some very long string "
          );
-      partitionGroup.string_columns.at(string_column_name).insert("ABCD");
+      partition_group.string_columns.at(string_column_name).insert("ABCD");
    }
    {
       const std::string indexed_string_column_name = "dummy_indexed_string_column";
       group.indexed_string_columns.emplace(
          indexed_string_column_name, silo::storage::column::IndexedStringColumn()
       );
-      partitionGroup.metadata.push_back(
+      partition_group.metadata.push_back(
          {indexed_string_column_name, silo::config::ColumnType::INDEXED_STRING}
       );
-      partitionGroup.indexed_string_columns.emplace(
+      partition_group.indexed_string_columns.emplace(
          indexed_string_column_name,
          group.indexed_string_columns.at(indexed_string_column_name).createPartition()
       );
-      partitionGroup.indexed_string_columns.at(indexed_string_column_name).insert("ABCD");
-      partitionGroup.indexed_string_columns.at(indexed_string_column_name)
+      partition_group.indexed_string_columns.at(indexed_string_column_name).insert("ABCD");
+      partition_group.indexed_string_columns.at(indexed_string_column_name)
          .insert(
             "some very long string some very long string some very long string some very long "
             "string "
@@ -48,42 +48,42 @@ createSinglePartitionColumns() {
             "string "
             "some very long string "
          );
-      partitionGroup.indexed_string_columns.at(indexed_string_column_name).insert("ABCD");
+      partition_group.indexed_string_columns.at(indexed_string_column_name).insert("ABCD");
    }
    {
       const std::string int_column_name = "dummy_int_column";
-      partitionGroup.metadata.push_back({int_column_name, silo::config::ColumnType::INT});
+      partition_group.metadata.push_back({int_column_name, silo::config::ColumnType::INT});
       group.int_columns.emplace(int_column_name, silo::storage::column::IntColumn());
-      partitionGroup.int_columns.emplace(
+      partition_group.int_columns.emplace(
          int_column_name, group.int_columns.at(int_column_name).createPartition()
       );
-      partitionGroup.int_columns.at(int_column_name).insert("42");
-      partitionGroup.int_columns.at(int_column_name).insert("-12389172");
-      partitionGroup.int_columns.at(int_column_name).insert("42");
+      partition_group.int_columns.at(int_column_name).insert("42");
+      partition_group.int_columns.at(int_column_name).insert("-12389172");
+      partition_group.int_columns.at(int_column_name).insert("42");
    }
    {
       const std::string float_column_name = "dummy_float_column";
-      partitionGroup.metadata.push_back({float_column_name, silo::config::ColumnType::FLOAT});
+      partition_group.metadata.push_back({float_column_name, silo::config::ColumnType::FLOAT});
       group.float_columns.emplace(float_column_name, silo::storage::column::FloatColumn());
-      partitionGroup.float_columns.emplace(
+      partition_group.float_columns.emplace(
          float_column_name, group.float_columns.at(float_column_name).createPartition()
       );
-      partitionGroup.float_columns.at(float_column_name).insert("42.1");
-      partitionGroup.float_columns.at(float_column_name).insert("-12389172.24222");
-      partitionGroup.float_columns.at(float_column_name).insert("42.1");
+      partition_group.float_columns.at(float_column_name).insert("42.1");
+      partition_group.float_columns.at(float_column_name).insert("-12389172.24222");
+      partition_group.float_columns.at(float_column_name).insert("42.1");
    }
    {
       const std::string date_column_name = "dummy_date_column";
-      partitionGroup.metadata.push_back({date_column_name, silo::config::ColumnType::DATE});
+      partition_group.metadata.push_back({date_column_name, silo::config::ColumnType::DATE});
       group.date_columns.emplace(date_column_name, silo::storage::column::DateColumn(false));
-      partitionGroup.date_columns.emplace(
+      partition_group.date_columns.emplace(
          date_column_name, group.date_columns.at(date_column_name).createPartition()
       );
-      partitionGroup.date_columns.at(date_column_name)
+      partition_group.date_columns.at(date_column_name)
          .insert(silo::common::stringToDate("2023-01-01"));
-      partitionGroup.date_columns.at(date_column_name)
+      partition_group.date_columns.at(date_column_name)
          .insert(silo::common::stringToDate("2023-01-01"));
-      partitionGroup.date_columns.at(date_column_name)
+      partition_group.date_columns.at(date_column_name)
          .insert(silo::common::stringToDate("2023-01-01"));
    }
 
@@ -95,9 +95,8 @@ using silo::query_engine::actions::TupleFactory;
 
 TEST(Tuple, getsCreatedAndReturnsItsFieldsSuccessfully1) {
    auto columns = createSinglePartitionColumns();
-   std::vector<std::byte> data(silo::query_engine::actions::getTupleSize(columns.second.metadata));
    TupleFactory factory(columns.second, columns.second.metadata);
-   Tuple under_test = factory.allocateOne(0);
+   const Tuple under_test = factory.allocateOne(0);
 
    auto fields = under_test.getFields();
    ASSERT_TRUE(fields.contains("dummy_date_column"));
@@ -128,9 +127,8 @@ TEST(Tuple, getsCreatedAndReturnsItsFieldsSuccessfully1) {
 
 TEST(Tuple, getsCreatedAndReturnsItsFieldsSuccessfully2) {
    auto columns = createSinglePartitionColumns();
-   std::vector<std::byte> data(silo::query_engine::actions::getTupleSize(columns.second.metadata));
    TupleFactory factory(columns.second, columns.second.metadata);
-   Tuple under_test = factory.allocateOne(1);
+   const Tuple under_test = factory.allocateOne(1);
 
    auto fields = under_test.getFields();
    ASSERT_TRUE(fields.contains("dummy_date_column"));
@@ -175,7 +173,6 @@ TEST(Tuple, getsCreatedAndReturnsItsFieldsSuccessfully2) {
 
 TEST(TupleFactory, allocatesOneAllocatesManyEqual) {
    auto columns = createSinglePartitionColumns();
-   std::vector<std::byte> data(silo::query_engine::actions::getTupleSize(columns.second.metadata));
    TupleFactory factory(columns.second, columns.second.metadata);
    Tuple under_test1 = factory.allocateOne(0);
    auto under_test_vector = factory.allocateMany(1);
@@ -186,7 +183,6 @@ TEST(TupleFactory, allocatesOneAllocatesManyEqual) {
 
 TEST(Tuple, equalityOperatorEquatesCorrectly) {
    auto columns = createSinglePartitionColumns();
-   std::vector<std::byte> data(silo::query_engine::actions::getTupleSize(columns.second.metadata));
    TupleFactory factory(columns.second, columns.second.metadata);
    Tuple under_test0a = factory.allocateOne(0);
    Tuple under_test0b = factory.allocateOne(0);
@@ -200,9 +196,8 @@ TEST(Tuple, equalityOperatorEquatesCorrectly) {
    ASSERT_NE(under_test1, under_test2);
 }
 
-TEST(Tuple, comparesFieldsCorrect) {
+TEST(Tuple, comparesFieldsCorrectly) {
    auto columns = createSinglePartitionColumns();
-   std::vector<std::byte> data(silo::query_engine::actions::getTupleSize(columns.second.metadata));
    TupleFactory factory(columns.second, columns.second.metadata);
    Tuple tuple0a = factory.allocateOne(0);
    Tuple tuple0b = factory.allocateOne(0);
@@ -211,7 +206,8 @@ TEST(Tuple, comparesFieldsCorrect) {
 
    std::vector<silo::query_engine::actions::OrderByField> order_by_fields;
    order_by_fields.push_back({"dummy_indexed_string_column", true});
-   Tuple::Comparator under_test = Tuple::getComparator(columns.second.metadata, order_by_fields);
+   const Tuple::Comparator under_test =
+      Tuple::getComparator(columns.second.metadata, order_by_fields);
 
    ASSERT_FALSE(under_test(tuple0a, tuple0b));
    ASSERT_FALSE(under_test(tuple0b, tuple0a));
@@ -253,7 +249,8 @@ TEST(Tuple, comparesFieldsCorrect) {
    ASSERT_FALSE(under_test2(tuple2, tuple1));
 
    order_by_fields.push_back({"dummy_date_column", true});
-   Tuple::Comparator under_test3 = Tuple::getComparator(columns.second.metadata, order_by_fields);
+   const Tuple::Comparator under_test3 =
+      Tuple::getComparator(columns.second.metadata, order_by_fields);
 
    ASSERT_FALSE(under_test3(tuple0a, tuple0b));
    ASSERT_FALSE(under_test3(tuple0b, tuple0a));
@@ -274,7 +271,8 @@ TEST(Tuple, comparesFieldsCorrect) {
    ASSERT_FALSE(under_test3(tuple2, tuple1));
 
    order_by_fields.push_back({"dummy_string_column", false});
-   Tuple::Comparator under_test4 = Tuple::getComparator(columns.second.metadata, order_by_fields);
+   const Tuple::Comparator under_test4 =
+      Tuple::getComparator(columns.second.metadata, order_by_fields);
 
    ASSERT_FALSE(under_test4(tuple0a, tuple0b));
    ASSERT_FALSE(under_test4(tuple0b, tuple0a));

--- a/src/silo/query_engine/actions/tuple.test.cpp
+++ b/src/silo/query_engine/actions/tuple.test.cpp
@@ -1,0 +1,296 @@
+#include "silo/query_engine/actions/tuple.h"
+#include "silo/query_engine/actions/action.h"
+
+#include <gtest/gtest.h>
+
+std::pair<silo::storage::ColumnGroup, silo::storage::ColumnPartitionGroup>
+createSinglePartitionColumns() {
+   std::pair<silo::storage::ColumnGroup, silo::storage::ColumnPartitionGroup> return_value;
+   auto& group = return_value.first;
+   auto& partitionGroup = return_value.second;
+
+   {
+      const std::string string_column_name = "dummy_string_column";
+      group.string_columns.emplace(string_column_name, silo::storage::column::StringColumn());
+      partitionGroup.metadata.push_back({string_column_name, silo::config::ColumnType::STRING});
+      partitionGroup.string_columns.emplace(
+         string_column_name, group.string_columns.at(string_column_name).createPartition()
+      );
+      partitionGroup.string_columns.at(string_column_name).insert("ABCD");
+      partitionGroup.string_columns.at(string_column_name)
+         .insert(
+            "some very long string some very long string some very long string some very long "
+            "string "
+            "some very long string some very long string some very long string some very long "
+            "string "
+            "some very long string "
+         );
+      partitionGroup.string_columns.at(string_column_name).insert("ABCD");
+   }
+   {
+      const std::string indexed_string_column_name = "dummy_indexed_string_column";
+      group.indexed_string_columns.emplace(
+         indexed_string_column_name, silo::storage::column::IndexedStringColumn()
+      );
+      partitionGroup.metadata.push_back(
+         {indexed_string_column_name, silo::config::ColumnType::INDEXED_STRING}
+      );
+      partitionGroup.indexed_string_columns.emplace(
+         indexed_string_column_name,
+         group.indexed_string_columns.at(indexed_string_column_name).createPartition()
+      );
+      partitionGroup.indexed_string_columns.at(indexed_string_column_name).insert("ABCD");
+      partitionGroup.indexed_string_columns.at(indexed_string_column_name)
+         .insert(
+            "some very long string some very long string some very long string some very long "
+            "string "
+            "some very long string some very long string some very long string some very long "
+            "string "
+            "some very long string "
+         );
+      partitionGroup.indexed_string_columns.at(indexed_string_column_name).insert("ABCD");
+   }
+   {
+      const std::string int_column_name = "dummy_int_column";
+      partitionGroup.metadata.push_back({int_column_name, silo::config::ColumnType::INT});
+      group.int_columns.emplace(int_column_name, silo::storage::column::IntColumn());
+      partitionGroup.int_columns.emplace(
+         int_column_name, group.int_columns.at(int_column_name).createPartition()
+      );
+      partitionGroup.int_columns.at(int_column_name).insert("42");
+      partitionGroup.int_columns.at(int_column_name).insert("-12389172");
+      partitionGroup.int_columns.at(int_column_name).insert("42");
+   }
+   {
+      const std::string float_column_name = "dummy_float_column";
+      partitionGroup.metadata.push_back({float_column_name, silo::config::ColumnType::FLOAT});
+      group.float_columns.emplace(float_column_name, silo::storage::column::FloatColumn());
+      partitionGroup.float_columns.emplace(
+         float_column_name, group.float_columns.at(float_column_name).createPartition()
+      );
+      partitionGroup.float_columns.at(float_column_name).insert("42.1");
+      partitionGroup.float_columns.at(float_column_name).insert("-12389172.24222");
+      partitionGroup.float_columns.at(float_column_name).insert("42.1");
+   }
+   {
+      const std::string date_column_name = "dummy_date_column";
+      partitionGroup.metadata.push_back({date_column_name, silo::config::ColumnType::DATE});
+      group.date_columns.emplace(date_column_name, silo::storage::column::DateColumn(false));
+      partitionGroup.date_columns.emplace(
+         date_column_name, group.date_columns.at(date_column_name).createPartition()
+      );
+      partitionGroup.date_columns.at(date_column_name)
+         .insert(silo::common::stringToDate("2023-01-01"));
+      partitionGroup.date_columns.at(date_column_name)
+         .insert(silo::common::stringToDate("2023-01-01"));
+      partitionGroup.date_columns.at(date_column_name)
+         .insert(silo::common::stringToDate("2023-01-01"));
+   }
+
+   return return_value;
+}
+
+using silo::query_engine::actions::Tuple;
+using silo::query_engine::actions::TupleFactory;
+
+TEST(Tuple, getsCreatedAndReturnsItsFieldsSuccessfully1) {
+   auto columns = createSinglePartitionColumns();
+   std::vector<std::byte> data(silo::query_engine::actions::getTupleSize(columns.second.metadata));
+   TupleFactory factory(columns.second, columns.second.metadata);
+   Tuple under_test = factory.allocateOne(0);
+
+   auto fields = under_test.getFields();
+   ASSERT_TRUE(fields.contains("dummy_date_column"));
+   ASSERT_TRUE(fields.at("dummy_date_column").has_value());
+   ASSERT_TRUE(holds_alternative<std::string>(fields.at("dummy_date_column").value()));
+   ASSERT_EQ(get<std::string>(fields.at("dummy_date_column").value()), "2023-01-01");
+
+   ASSERT_TRUE(fields.contains("dummy_float_column"));
+   ASSERT_TRUE(fields.at("dummy_float_column").has_value());
+   ASSERT_TRUE(holds_alternative<double>(fields.at("dummy_float_column").value()));
+   ASSERT_EQ(get<double>(fields.at("dummy_float_column").value()), 42.1);
+
+   ASSERT_TRUE(fields.contains("dummy_int_column"));
+   ASSERT_TRUE(fields.at("dummy_int_column").has_value());
+   ASSERT_TRUE(holds_alternative<int32_t>(fields.at("dummy_int_column").value()));
+   ASSERT_EQ(get<int32_t>(fields.at("dummy_int_column").value()), 42);
+
+   ASSERT_TRUE(fields.contains("dummy_indexed_string_column"));
+   ASSERT_TRUE(fields.at("dummy_indexed_string_column").has_value());
+   ASSERT_TRUE(holds_alternative<std::string>(fields.at("dummy_indexed_string_column").value()));
+   ASSERT_EQ(get<std::string>(fields.at("dummy_indexed_string_column").value()), "ABCD");
+
+   ASSERT_TRUE(fields.contains("dummy_string_column"));
+   ASSERT_TRUE(fields.at("dummy_string_column").has_value());
+   ASSERT_TRUE(holds_alternative<std::string>(fields.at("dummy_string_column").value()));
+   ASSERT_EQ(get<std::string>(fields.at("dummy_string_column").value()), "ABCD");
+}
+
+TEST(Tuple, getsCreatedAndReturnsItsFieldsSuccessfully2) {
+   auto columns = createSinglePartitionColumns();
+   std::vector<std::byte> data(silo::query_engine::actions::getTupleSize(columns.second.metadata));
+   TupleFactory factory(columns.second, columns.second.metadata);
+   Tuple under_test = factory.allocateOne(1);
+
+   auto fields = under_test.getFields();
+   ASSERT_TRUE(fields.contains("dummy_date_column"));
+   ASSERT_TRUE(fields.at("dummy_date_column").has_value());
+   ASSERT_TRUE(holds_alternative<std::string>(fields.at("dummy_date_column").value()));
+   ASSERT_EQ(get<std::string>(fields.at("dummy_date_column").value()), "2023-01-01");
+
+   ASSERT_TRUE(fields.contains("dummy_float_column"));
+   ASSERT_TRUE(fields.at("dummy_float_column").has_value());
+   ASSERT_TRUE(holds_alternative<double>(fields.at("dummy_float_column").value()));
+   ASSERT_EQ(get<double>(fields.at("dummy_float_column").value()), -12389172.24222);
+
+   ASSERT_TRUE(fields.contains("dummy_int_column"));
+   ASSERT_TRUE(fields.at("dummy_int_column").has_value());
+   ASSERT_TRUE(holds_alternative<int32_t>(fields.at("dummy_int_column").value()));
+   ASSERT_EQ(get<int32_t>(fields.at("dummy_int_column").value()), -12389172);
+
+   ASSERT_TRUE(fields.contains("dummy_indexed_string_column"));
+   ASSERT_TRUE(fields.at("dummy_indexed_string_column").has_value());
+   ASSERT_TRUE(holds_alternative<std::string>(fields.at("dummy_indexed_string_column").value()));
+   ASSERT_EQ(
+      get<std::string>(fields.at("dummy_indexed_string_column").value()),
+      "some very long string some very long string some very long string some very long "
+      "string "
+      "some very long string some very long string some very long string some very long "
+      "string "
+      "some very long string "
+   );
+
+   ASSERT_TRUE(fields.contains("dummy_string_column"));
+   ASSERT_TRUE(fields.at("dummy_string_column").has_value());
+   ASSERT_TRUE(holds_alternative<std::string>(fields.at("dummy_string_column").value()));
+   ASSERT_EQ(
+      get<std::string>(fields.at("dummy_string_column").value()),
+      "some very long string some very long string some very long string some very long "
+      "string "
+      "some very long string some very long string some very long string some very long "
+      "string "
+      "some very long string "
+   );
+}
+
+TEST(TupleFactory, allocatesOneAllocatesManyEqual) {
+   auto columns = createSinglePartitionColumns();
+   std::vector<std::byte> data(silo::query_engine::actions::getTupleSize(columns.second.metadata));
+   TupleFactory factory(columns.second, columns.second.metadata);
+   Tuple under_test1 = factory.allocateOne(0);
+   auto under_test_vector = factory.allocateMany(1);
+   ASSERT_EQ(under_test_vector.size(), 1);
+   factory.overwrite(under_test_vector.front(), 0);
+   ASSERT_EQ(under_test1, under_test_vector.front());
+}
+
+TEST(Tuple, equalityOperatorEquatesCorrectly) {
+   auto columns = createSinglePartitionColumns();
+   std::vector<std::byte> data(silo::query_engine::actions::getTupleSize(columns.second.metadata));
+   TupleFactory factory(columns.second, columns.second.metadata);
+   Tuple under_test0a = factory.allocateOne(0);
+   Tuple under_test0b = factory.allocateOne(0);
+   Tuple under_test1 = factory.allocateOne(1);
+   Tuple under_test2 = factory.allocateOne(2);
+   ASSERT_EQ(under_test0a, under_test0b);
+   ASSERT_NE(under_test0a, under_test1);
+   ASSERT_EQ(under_test0a, under_test2);
+   ASSERT_NE(under_test0b, under_test1);
+   ASSERT_EQ(under_test0b, under_test2);
+   ASSERT_NE(under_test1, under_test2);
+}
+
+TEST(Tuple, comparesFieldsCorrect) {
+   auto columns = createSinglePartitionColumns();
+   std::vector<std::byte> data(silo::query_engine::actions::getTupleSize(columns.second.metadata));
+   TupleFactory factory(columns.second, columns.second.metadata);
+   Tuple tuple0a = factory.allocateOne(0);
+   Tuple tuple0b = factory.allocateOne(0);
+   Tuple tuple1 = factory.allocateOne(1);
+   Tuple tuple2 = factory.allocateOne(2);
+
+   std::vector<silo::query_engine::actions::OrderByField> order_by_fields;
+   order_by_fields.push_back({"dummy_indexed_string_column", true});
+   Tuple::Comparator under_test = Tuple::getComparator(columns.second.metadata, order_by_fields);
+
+   ASSERT_FALSE(under_test(tuple0a, tuple0b));
+   ASSERT_FALSE(under_test(tuple0b, tuple0a));
+
+   ASSERT_TRUE(under_test(tuple0a, tuple1));
+   ASSERT_FALSE(under_test(tuple1, tuple0a));
+
+   ASSERT_FALSE(under_test(tuple0a, tuple2));
+   ASSERT_FALSE(under_test(tuple2, tuple0a));
+
+   ASSERT_TRUE(under_test(tuple0b, tuple1));
+   ASSERT_FALSE(under_test(tuple1, tuple0b));
+
+   ASSERT_FALSE(under_test(tuple0b, tuple2));
+   ASSERT_FALSE(under_test(tuple2, tuple0b));
+
+   ASSERT_FALSE(under_test(tuple1, tuple2));
+   ASSERT_TRUE(under_test(tuple2, tuple1));
+
+   order_by_fields.clear();
+   Tuple::Comparator under_test2 = Tuple::getComparator(columns.second.metadata, order_by_fields);
+
+   ASSERT_FALSE(under_test2(tuple0a, tuple0b));
+   ASSERT_FALSE(under_test2(tuple0b, tuple0a));
+
+   ASSERT_FALSE(under_test2(tuple0a, tuple1));
+   ASSERT_FALSE(under_test2(tuple1, tuple0a));
+
+   ASSERT_FALSE(under_test2(tuple0a, tuple2));
+   ASSERT_FALSE(under_test2(tuple2, tuple0a));
+
+   ASSERT_FALSE(under_test2(tuple0b, tuple1));
+   ASSERT_FALSE(under_test2(tuple1, tuple0b));
+
+   ASSERT_FALSE(under_test2(tuple0b, tuple2));
+   ASSERT_FALSE(under_test2(tuple2, tuple0b));
+
+   ASSERT_FALSE(under_test2(tuple1, tuple2));
+   ASSERT_FALSE(under_test2(tuple2, tuple1));
+
+   order_by_fields.push_back({"dummy_date_column", true});
+   Tuple::Comparator under_test3 = Tuple::getComparator(columns.second.metadata, order_by_fields);
+
+   ASSERT_FALSE(under_test3(tuple0a, tuple0b));
+   ASSERT_FALSE(under_test3(tuple0b, tuple0a));
+
+   ASSERT_FALSE(under_test3(tuple0a, tuple1));
+   ASSERT_FALSE(under_test3(tuple1, tuple0a));
+
+   ASSERT_FALSE(under_test3(tuple0a, tuple2));
+   ASSERT_FALSE(under_test3(tuple2, tuple0a));
+
+   ASSERT_FALSE(under_test3(tuple0b, tuple1));
+   ASSERT_FALSE(under_test3(tuple1, tuple0b));
+
+   ASSERT_FALSE(under_test3(tuple0b, tuple2));
+   ASSERT_FALSE(under_test3(tuple2, tuple0b));
+
+   ASSERT_FALSE(under_test3(tuple1, tuple2));
+   ASSERT_FALSE(under_test3(tuple2, tuple1));
+
+   order_by_fields.push_back({"dummy_string_column", false});
+   Tuple::Comparator under_test4 = Tuple::getComparator(columns.second.metadata, order_by_fields);
+
+   ASSERT_FALSE(under_test4(tuple0a, tuple0b));
+   ASSERT_FALSE(under_test4(tuple0b, tuple0a));
+
+   ASSERT_FALSE(under_test4(tuple0a, tuple1));
+   ASSERT_TRUE(under_test4(tuple1, tuple0a));
+
+   ASSERT_FALSE(under_test4(tuple0a, tuple2));
+   ASSERT_FALSE(under_test4(tuple2, tuple0a));
+
+   ASSERT_FALSE(under_test4(tuple0b, tuple1));
+   ASSERT_TRUE(under_test4(tuple1, tuple0b));
+
+   ASSERT_FALSE(under_test4(tuple0b, tuple2));
+   ASSERT_FALSE(under_test4(tuple2, tuple0b));
+
+   ASSERT_TRUE(under_test4(tuple1, tuple2));
+   ASSERT_FALSE(under_test4(tuple2, tuple1));
+}

--- a/src/silo/storage/column_group.cpp
+++ b/src/silo/storage/column_group.cpp
@@ -57,26 +57,27 @@ uint32_t ColumnPartitionGroup::fill(
 }
 
 ColumnPartitionGroup ColumnPartitionGroup::getSubgroup(
-   const std::vector<config::DatabaseMetadata>& fields
+   const std::vector<silo::storage::ColumnMetadata>& fields
 ) const {
    ColumnPartitionGroup result;
-   result.metadata = fields;
+   for (auto& field : fields) {
+      result.metadata.push_back({field.name, field.type});
+   }
 
    for (const auto& item : fields) {
-      const auto column_type = item.getColumnType();
-      if (column_type == silo::config::ColumnType::INDEXED_STRING) {
+      if (item.type == silo::config::ColumnType::INDEXED_STRING) {
          result.indexed_string_columns.insert({item.name, indexed_string_columns.at(item.name)});
-      } else if (column_type == silo::config::ColumnType::STRING) {
+      } else if (item.type == silo::config::ColumnType::STRING) {
          result.string_columns.insert({item.name, string_columns.at(item.name)});
-      } else if (column_type == silo::config::ColumnType::INDEXED_PANGOLINEAGE) {
+      } else if (item.type == silo::config::ColumnType::INDEXED_PANGOLINEAGE) {
          result.pango_lineage_columns.insert({item.name, pango_lineage_columns.at(item.name)});
-      } else if (column_type == silo::config::ColumnType::DATE) {
+      } else if (item.type == silo::config::ColumnType::DATE) {
          result.date_columns.insert({item.name, date_columns.at(item.name)});
-      } else if (column_type == silo::config::ColumnType::INT) {
+      } else if (item.type == silo::config::ColumnType::INT) {
          result.int_columns.insert({item.name, int_columns.at(item.name)});
-      } else if (column_type == silo::config::ColumnType::FLOAT) {
+      } else if (item.type == silo::config::ColumnType::FLOAT) {
          result.float_columns.insert({item.name, float_columns.at(item.name)});
-      } else if (column_type == silo::config::ColumnType::INSERTION) {
+      } else if (item.type == silo::config::ColumnType::INSERTION) {
          result.insertion_columns.insert({item.name, insertion_columns.at(item.name)});
       }
    }

--- a/src/silo_api/database_directory_watcher.cpp
+++ b/src/silo_api/database_directory_watcher.cpp
@@ -20,17 +20,17 @@ namespace {
 
 std::optional<silo::DataVersion> checkValidDataSource(const std::filesystem::path& path) {
    if (!std::filesystem::is_directory(path)) {
-      SPDLOG_INFO("Skipping {} because it is not a directory", path.string());
+      SPDLOG_TRACE("Skipping {} because it is not a directory", path.string());
       return std::nullopt;
    }
    auto data_version = silo::DataVersion::fromString(path.filename().string());
    if (data_version == std::nullopt) {
-      SPDLOG_INFO("Skipping {}. Its name is not a valid data version.", path.string());
+      SPDLOG_TRACE("Skipping {}. Its name is not a valid data version.", path.string());
       return std::nullopt;
    }
    auto data_version_filename = path / "data_version.silo";
    if (!std::filesystem::is_regular_file(data_version_filename)) {
-      SPDLOG_INFO(
+      SPDLOG_TRACE(
          "Skipping {}. it does not contain the data version file {}, which "
          "confirms a finished and valid data source",
          path.string(),
@@ -40,20 +40,20 @@ std::optional<silo::DataVersion> checkValidDataSource(const std::filesystem::pat
    }
    std::ifstream data_version_file(data_version_filename);
    if (!data_version_file) {
-      SPDLOG_INFO("Skipping {}. The data version file could not be opened", path.string());
+      SPDLOG_TRACE("Skipping {}. The data version file could not be opened", path.string());
       return std::nullopt;
    }
    std::string data_version_in_file_string;
    data_version_file >> data_version_in_file_string;
    const auto data_version_in_file = silo::DataVersion::fromString(data_version_in_file_string);
    if (data_version_in_file == std::nullopt) {
-      SPDLOG_INFO(
+      SPDLOG_TRACE(
          "Skipping {}. The data version in data_version.silo could not be parsed", path.string()
       );
       return std::nullopt;
    }
    if (data_version_in_file != data_version) {
-      SPDLOG_INFO(
+      SPDLOG_TRACE(
          "Skipping {}. The data version in data_version.silo is not equal to the directory name",
          path.string()
       );
@@ -65,13 +65,13 @@ std::optional<silo::DataVersion> checkValidDataSource(const std::filesystem::pat
 std::optional<std::pair<std::filesystem::path, silo::DataVersion>> getMostRecentDataDirectory(
    std::filesystem::path path
 ) {
-   SPDLOG_INFO("Scanning path {} for valid data", path.string());
+   SPDLOG_TRACE("Scanning path {} for valid data", path.string());
    std::vector<std::pair<std::filesystem::path, silo::DataVersion>> all_found_data;
    for (const auto& directory_entry : std::filesystem::directory_iterator{path}) {
-      SPDLOG_INFO("Checking directory entry {}", directory_entry.path().string());
+      SPDLOG_TRACE("Checking directory entry {}", directory_entry.path().string());
       auto data_version = checkValidDataSource(directory_entry.path());
       if (data_version.has_value()) {
-         SPDLOG_INFO(
+         SPDLOG_TRACE(
             "Found candidate data source {} with data version {}",
             directory_entry.path().string(),
             data_version->toString()
@@ -80,12 +80,12 @@ std::optional<std::pair<std::filesystem::path, silo::DataVersion>> getMostRecent
       }
    }
    if (all_found_data.empty()) {
-      SPDLOG_INFO("No previous data found, place data in {} for ingestion", path.string());
+      SPDLOG_TRACE("Scan of path {} returned no valid data", path.string());
       return std::nullopt;
    }
    if (all_found_data.size() == 1) {
       const auto& found_data = all_found_data.at(0);
-      SPDLOG_INFO("Using previous data: {}", found_data.first.string());
+      SPDLOG_TRACE("Using previous data: {}", found_data.first.string());
       return found_data;
    }
    auto max_element = std::max_element(
@@ -93,7 +93,7 @@ std::optional<std::pair<std::filesystem::path, silo::DataVersion>> getMostRecent
       all_found_data.end(),
       [](const auto& element1, const auto& element2) { return element1.second < element2.second; }
    );
-   SPDLOG_INFO(
+   SPDLOG_TRACE(
       "Selected database with highest data-version {} in path {} for ingestion",
       max_element->second.toString(),
       max_element->first.string()
@@ -106,10 +106,15 @@ std::optional<std::pair<std::filesystem::path, silo::DataVersion>> getMostRecent
 void silo_api::DatabaseDirectoryWatcher::checkDirectoryForData(Poco::Timer& /*timer*/) {
    auto most_recent_database_state = getMostRecentDataDirectory(path);
 
+   if (most_recent_database_state == std::nullopt) {
+      SPDLOG_INFO("No data found, place data in {} for ingestion", path.string());
+      return;
+   }
+
    {
       const auto fixed_database = database_mutex.getDatabase();
       if (fixed_database.database.getDataVersion() >= most_recent_database_state->second) {
-         SPDLOG_INFO(
+         SPDLOG_TRACE(
             "Do not update data version to {} in path {}. Its version is not newer than the "
             "current version",
             most_recent_database_state->second.toString(),


### PR DESCRIPTION
While Pagination was already possible, the full result still needed to be created first. Now, the details action directly produces sorted data, and only produces as much data as is required. Furthermore this is also multi-threaded