### PR TITLE
refactor: rename "position" in aa_mutations and nuc_mutations to "mutation"

### DIFF
--- a/endToEndTests/test/queries/aaMutDistribution.json
+++ b/endToEndTests/test/queries/aaMutDistribution.json
@@ -13,145 +13,145 @@
   "expectedQueryResult": [
     {
       "count": 37,
-      "position": "T19R",
+      "mutation": "T19R",
       "proportion": 0.3854166666666667,
       "sequenceName": "S"
     },
     {
       "count": 37,
-      "position": "G142D",
+      "mutation": "G142D",
       "proportion": 0.49333333333333335,
       "sequenceName": "S"
     },
     {
       "count": 34,
-      "position": "R158G",
+      "mutation": "R158G",
       "proportion": 0.3655913978494624,
       "sequenceName": "S"
     },
     {
       "count": 34,
-      "position": "G339D",
+      "mutation": "G339D",
       "proportion": 0.3469387755102041,
       "sequenceName": "S"
     },
     {
       "count": 33,
-      "position": "S373P",
+      "mutation": "S373P",
       "proportion": 0.3402061855670103,
       "sequenceName": "S"
     },
     {
       "count": 33,
-      "position": "S375F",
+      "mutation": "S375F",
       "proportion": 0.336734693877551,
       "sequenceName": "S"
     },
     {
       "count": 38,
-      "position": "L452R",
+      "mutation": "L452R",
       "proportion": 0.4318181818181818,
       "sequenceName": "S"
     },
     {
       "count": 32,
-      "position": "S477N",
+      "mutation": "S477N",
       "proportion": 0.34408602150537637,
       "sequenceName": "S"
     },
     {
       "count": 69,
-      "position": "T478K",
+      "mutation": "T478K",
       "proportion": 0.7340425531914894,
       "sequenceName": "S"
     },
     {
       "count": 31,
-      "position": "E484A",
+      "mutation": "E484A",
       "proportion": 0.3333333333333333,
       "sequenceName": "S"
     },
     {
       "count": 31,
-      "position": "Q493R",
+      "mutation": "Q493R",
       "proportion": 0.3333333333333333,
       "sequenceName": "S"
     },
     {
       "count": 30,
-      "position": "Q498R",
+      "mutation": "Q498R",
       "proportion": 0.3225806451612903,
       "sequenceName": "S"
     },
     {
       "count": 41,
-      "position": "N501Y",
+      "mutation": "N501Y",
       "proportion": 0.44086021505376344,
       "sequenceName": "S"
     },
     {
       "count": 30,
-      "position": "Y505H",
+      "mutation": "Y505H",
       "proportion": 0.3225806451612903,
       "sequenceName": "S"
     },
     {
       "count": 98,
-      "position": "D614G",
+      "mutation": "D614G",
       "proportion": 0.98989898989899,
       "sequenceName": "S"
     },
     {
       "count": 37,
-      "position": "H655Y",
+      "mutation": "H655Y",
       "proportion": 0.37373737373737376,
       "sequenceName": "S"
     },
     {
       "count": 34,
-      "position": "N679K",
+      "mutation": "N679K",
       "proportion": 0.34,
       "sequenceName": "S"
     },
     {
       "count": 42,
-      "position": "P681H",
+      "mutation": "P681H",
       "proportion": 0.42,
       "sequenceName": "S"
     },
     {
       "count": 38,
-      "position": "P681R",
+      "mutation": "P681R",
       "proportion": 0.38,
       "sequenceName": "S"
     },
     {
       "count": 31,
-      "position": "N764K",
+      "mutation": "N764K",
       "proportion": 0.32978723404255317,
       "sequenceName": "S"
     },
     {
       "count": 34,
-      "position": "D796Y",
+      "mutation": "D796Y",
       "proportion": 0.3469387755102041,
       "sequenceName": "S"
     },
     {
       "count": 34,
-      "position": "D950N",
+      "mutation": "D950N",
       "proportion": 0.35789473684210527,
       "sequenceName": "S"
     },
     {
       "count": 33,
-      "position": "Q954H",
+      "mutation": "Q954H",
       "proportion": 0.34375,
       "sequenceName": "S"
     },
     {
       "count": 34,
-      "position": "N969K",
+      "mutation": "N969K",
       "proportion": 0.35051546391752575,
       "sequenceName": "S"
     }

--- a/endToEndTests/test/queries/aaMutDistribution_all.json
+++ b/endToEndTests/test/queries/aaMutDistribution_all.json
@@ -12,61 +12,61 @@
   "expectedQueryResult": [
     {
       "count": 46,
-      "position": "R203K",
+      "mutation": "R203K",
       "proportion": 0.46,
       "sequenceName": "N"
     },
     {
       "count": 46,
-      "position": "G204R",
+      "mutation": "G204R",
       "proportion": 0.46,
       "sequenceName": "N"
     },
     {
       "count": 64,
-      "position": "T3255I",
+      "mutation": "T3255I",
       "proportion": 0.6464646464646465,
       "sequenceName": "ORF1a"
     },
     {
       "count": 98,
-      "position": "P314L",
+      "mutation": "P314L",
       "proportion": 0.98989898989899,
       "sequenceName": "ORF1b"
     },
     {
       "count": 37,
-      "position": "G142D",
+      "mutation": "G142D",
       "proportion": 0.49333333333333335,
       "sequenceName": "S"
     },
     {
       "count": 38,
-      "position": "L452R",
+      "mutation": "L452R",
       "proportion": 0.4318181818181818,
       "sequenceName": "S"
     },
     {
       "count": 69,
-      "position": "T478K",
+      "mutation": "T478K",
       "proportion": 0.7340425531914894,
       "sequenceName": "S"
     },
     {
       "count": 41,
-      "position": "N501Y",
+      "mutation": "N501Y",
       "proportion": 0.44086021505376344,
       "sequenceName": "S"
     },
     {
       "count": 98,
-      "position": "D614G",
+      "mutation": "D614G",
       "proportion": 0.98989898989899,
       "sequenceName": "S"
     },
     {
       "count": 42,
-      "position": "P681H",
+      "mutation": "P681H",
       "proportion": 0.42,
       "sequenceName": "S"
     }

--- a/endToEndTests/test/queries/aaMutDistribution_multiple.json
+++ b/endToEndTests/test/queries/aaMutDistribution_multiple.json
@@ -13,187 +13,187 @@
   "expectedQueryResult": [
     {
       "count": 37,
-      "position": "T19R",
+      "mutation": "T19R",
       "proportion": 0.3854166666666667,
       "sequenceName": "S"
     },
     {
       "count": 37,
-      "position": "G142D",
+      "mutation": "G142D",
       "proportion": 0.49333333333333335,
       "sequenceName": "S"
     },
     {
       "count": 34,
-      "position": "R158G",
+      "mutation": "R158G",
       "proportion": 0.3655913978494624,
       "sequenceName": "S"
     },
     {
       "count": 34,
-      "position": "G339D",
+      "mutation": "G339D",
       "proportion": 0.3469387755102041,
       "sequenceName": "S"
     },
     {
       "count": 33,
-      "position": "S373P",
+      "mutation": "S373P",
       "proportion": 0.3402061855670103,
       "sequenceName": "S"
     },
     {
       "count": 33,
-      "position": "S375F",
+      "mutation": "S375F",
       "proportion": 0.336734693877551,
       "sequenceName": "S"
     },
     {
       "count": 38,
-      "position": "L452R",
+      "mutation": "L452R",
       "proportion": 0.4318181818181818,
       "sequenceName": "S"
     },
     {
       "count": 32,
-      "position": "S477N",
+      "mutation": "S477N",
       "proportion": 0.34408602150537637,
       "sequenceName": "S"
     },
     {
       "count": 69,
-      "position": "T478K",
+      "mutation": "T478K",
       "proportion": 0.7340425531914894,
       "sequenceName": "S"
     },
     {
       "count": 31,
-      "position": "E484A",
+      "mutation": "E484A",
       "proportion": 0.3333333333333333,
       "sequenceName": "S"
     },
     {
       "count": 31,
-      "position": "Q493R",
+      "mutation": "Q493R",
       "proportion": 0.3333333333333333,
       "sequenceName": "S"
     },
     {
       "count": 30,
-      "position": "Q498R",
+      "mutation": "Q498R",
       "proportion": 0.3225806451612903,
       "sequenceName": "S"
     },
     {
       "count": 41,
-      "position": "N501Y",
+      "mutation": "N501Y",
       "proportion": 0.44086021505376344,
       "sequenceName": "S"
     },
     {
       "count": 30,
-      "position": "Y505H",
+      "mutation": "Y505H",
       "proportion": 0.3225806451612903,
       "sequenceName": "S"
     },
     {
       "count": 98,
-      "position": "D614G",
+      "mutation": "D614G",
       "proportion": 0.98989898989899,
       "sequenceName": "S"
     },
     {
       "count": 37,
-      "position": "H655Y",
+      "mutation": "H655Y",
       "proportion": 0.37373737373737376,
       "sequenceName": "S"
     },
     {
       "count": 34,
-      "position": "N679K",
+      "mutation": "N679K",
       "proportion": 0.34,
       "sequenceName": "S"
     },
     {
       "count": 42,
-      "position": "P681H",
+      "mutation": "P681H",
       "proportion": 0.42,
       "sequenceName": "S"
     },
     {
       "count": 38,
-      "position": "P681R",
+      "mutation": "P681R",
       "proportion": 0.38,
       "sequenceName": "S"
     },
     {
       "count": 31,
-      "position": "N764K",
+      "mutation": "N764K",
       "proportion": 0.32978723404255317,
       "sequenceName": "S"
     },
     {
       "count": 34,
-      "position": "D796Y",
+      "mutation": "D796Y",
       "proportion": 0.3469387755102041,
       "sequenceName": "S"
     },
     {
       "count": 34,
-      "position": "D950N",
+      "mutation": "D950N",
       "proportion": 0.35789473684210527,
       "sequenceName": "S"
     },
     {
       "count": 33,
-      "position": "Q954H",
+      "mutation": "Q954H",
       "proportion": 0.34375,
       "sequenceName": "S"
     },
     {
       "count": 34,
-      "position": "N969K",
+      "mutation": "N969K",
       "proportion": 0.35051546391752575,
       "sequenceName": "S"
     },
     {
       "count": 34,
-      "position": "P13L",
+      "mutation": "P13L",
       "proportion": 0.3469387755102041,
       "sequenceName": "N"
     },
     {
       "count": 36,
-      "position": "D63G",
+      "mutation": "D63G",
       "proportion": 0.3673469387755102,
       "sequenceName": "N"
     },
     {
       "count": 46,
-      "position": "R203K",
+      "mutation": "R203K",
       "proportion": 0.46,
       "sequenceName": "N"
     },
     {
       "count": 38,
-      "position": "R203M",
+      "mutation": "R203M",
       "proportion": 0.38,
       "sequenceName": "N"
     },
     {
       "count": 46,
-      "position": "G204R",
+      "mutation": "G204R",
       "proportion": 0.46,
       "sequenceName": "N"
     },
     {
       "count": 30,
-      "position": "G215C",
+      "mutation": "G215C",
       "proportion": 0.3,
       "sequenceName": "N"
     },
     {
       "count": 37,
-      "position": "D377Y",
+      "mutation": "D377Y",
       "proportion": 0.38144329896907214,
       "sequenceName": "N"
     }

--- a/endToEndTests/test/queries/nOf_2of3_mutations.json
+++ b/endToEndTests/test/queries/nOf_2of3_mutations.json
@@ -31,42 +31,42 @@
   "expectedQueryResult": [
     {
       "count": 1,
-      "position": "A1-",
+      "mutation": "A1-",
       "proportion": 1
     },
     {
       "count": 1,
-      "position": "T2-",
+      "mutation": "T2-",
       "proportion": 1
     },
     {
       "count": 53,
-      "position": "C241T",
+      "mutation": "C241T",
       "proportion": 1
     },
     {
       "count": 51,
-      "position": "C3037T",
+      "mutation": "C3037T",
       "proportion": 1
     },
     {
       "count": 52,
-      "position": "C14408T",
+      "mutation": "C14408T",
       "proportion": 1
     },
     {
       "count": 53,
-      "position": "A23403G",
+      "mutation": "A23403G",
       "proportion": 1
     },
     {
       "count": 4,
-      "position": "G29868-",
+      "mutation": "G29868-",
       "proportion": 1
     },
     {
       "count": 4,
-      "position": "A29869-",
+      "mutation": "A29869-",
       "proportion": 0.8
     }
   ]

--- a/endToEndTests/test/queries/sequenceStartEndMutations.json
+++ b/endToEndTests/test/queries/sequenceStartEndMutations.json
@@ -24,192 +24,192 @@
   "expectedQueryResult": [
     {
       "count": 42,
-      "position": "A1-",
+      "mutation": "A1-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "C3037T",
+      "mutation": "C3037T",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "C14408T",
+      "mutation": "C14408T",
       "proportion": 1
     },
     {
       "count": 40,
-      "position": "A23403G",
+      "mutation": "A23403G",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "C29870-",
+      "mutation": "C29870-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29871-",
+      "mutation": "A29871-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29872-",
+      "mutation": "A29872-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29873-",
+      "mutation": "A29873-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29874-",
+      "mutation": "A29874-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29875-",
+      "mutation": "A29875-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29876-",
+      "mutation": "A29876-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29877-",
+      "mutation": "A29877-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29878-",
+      "mutation": "A29878-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29879-",
+      "mutation": "A29879-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29880-",
+      "mutation": "A29880-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29881-",
+      "mutation": "A29881-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29882-",
+      "mutation": "A29882-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29883-",
+      "mutation": "A29883-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29884-",
+      "mutation": "A29884-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29885-",
+      "mutation": "A29885-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29886-",
+      "mutation": "A29886-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29887-",
+      "mutation": "A29887-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29888-",
+      "mutation": "A29888-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29889-",
+      "mutation": "A29889-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29890-",
+      "mutation": "A29890-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29891-",
+      "mutation": "A29891-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29892-",
+      "mutation": "A29892-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29893-",
+      "mutation": "A29893-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29894-",
+      "mutation": "A29894-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29895-",
+      "mutation": "A29895-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29896-",
+      "mutation": "A29896-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29897-",
+      "mutation": "A29897-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29898-",
+      "mutation": "A29898-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29899-",
+      "mutation": "A29899-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29900-",
+      "mutation": "A29900-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29901-",
+      "mutation": "A29901-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29902-",
+      "mutation": "A29902-",
       "proportion": 1
     },
     {
       "count": 42,
-      "position": "A29903-",
+      "mutation": "A29903-",
       "proportion": 1
     }
   ]

--- a/include/silo/query_engine/actions/aa_mutations.h
+++ b/include/silo/query_engine/actions/aa_mutations.h
@@ -53,7 +53,7 @@ class AAMutations : public Action {
       AminoAcid::Symbol::Y,  // Tyrosine
    };
 
-   const std::string POSITION_FIELD_NAME = "position";
+   const std::string MUTATION_FIELD_NAME = "mutation";
    const std::string SEQUENCE_FIELD_NAME = "sequenceName";
    const std::string PROPORTION_FIELD_NAME = "proportion";
    const std::string COUNT_FIELD_NAME = "count";

--- a/include/silo/query_engine/actions/nuc_mutations.h
+++ b/include/silo/query_engine/actions/nuc_mutations.h
@@ -38,7 +38,7 @@ class NucMutations : public Action {
       Nucleotide::Symbol::T,
    };
 
-   const std::string POSITION_FIELD_NAME = "position";
+   const std::string MUTATION_FIELD_NAME = "mutation";
    const std::string PROPORTION_FIELD_NAME = "proportion";
    const std::string COUNT_FIELD_NAME = "count";
 

--- a/src/silo/query_engine/actions/aa_mutations.cpp
+++ b/src/silo/query_engine/actions/aa_mutations.cpp
@@ -115,7 +115,7 @@ SymbolMap<AminoAcid, std::vector<uint32_t>> AAMutations::calculateMutationsPerPo
 
 void AAMutations::validateOrderByFields(const Database& /*database*/) const {
    const std::vector<std::string> result_field_names{
-      {POSITION_FIELD_NAME, PROPORTION_FIELD_NAME, COUNT_FIELD_NAME}};
+      {MUTATION_FIELD_NAME, PROPORTION_FIELD_NAME, COUNT_FIELD_NAME}};
 
    for (const OrderByField& field : order_by_fields) {
       CHECK_SILO_QUERY(
@@ -161,7 +161,7 @@ void AAMutations::addMutationsToOutput(
                const std::
                   map<std::string, std::optional<std::variant<std::string, int32_t, double>>>
                      fields{
-                        {POSITION_FIELD_NAME,
+                        {MUTATION_FIELD_NAME,
                          AminoAcid::symbolToChar(symbol_in_reference_genome) +
                             std::to_string(pos + 1) + AminoAcid::symbolToChar(symbol)},
                         {SEQUENCE_FIELD_NAME, sequence_name},

--- a/src/silo/query_engine/actions/nuc_mutations.cpp
+++ b/src/silo/query_engine/actions/nuc_mutations.cpp
@@ -115,7 +115,7 @@ SymbolMap<Nucleotide, std::vector<uint32_t>> NucMutations::calculateMutationsPer
 
 void NucMutations::validateOrderByFields(const Database& /*database*/) const {
    const std::vector<std::string> result_field_names{
-      {POSITION_FIELD_NAME, PROPORTION_FIELD_NAME, COUNT_FIELD_NAME}};
+      {MUTATION_FIELD_NAME, PROPORTION_FIELD_NAME, COUNT_FIELD_NAME}};
 
    for (const OrderByField& field : order_by_fields) {
       CHECK_SILO_QUERY(
@@ -171,7 +171,7 @@ QueryResult NucMutations::execute(
                const std::
                   map<std::string, std::optional<std::variant<std::string, int32_t, double>>>
                      fields{
-                        {POSITION_FIELD_NAME,
+                        {MUTATION_FIELD_NAME,
                          Nucleotide::symbolToChar(symbol_in_reference_genome) +
                             std::to_string(pos + 1) + Nucleotide::symbolToChar(symbol)},
                         {PROPORTION_FIELD_NAME, proportion},


### PR DESCRIPTION
- to be compatible with lapisv1, which also returns mutation,count,proportion
- name represents the value better, since it has also symbols inside. Positions are only numbers.

This change is necessary for: https://github.com/GenSpectrum/LAPIS/issues/206