### PR TITLE
fix: non default unaligned nucleotide sequence prefix

### DIFF
--- a/src/silo/preprocessing/preprocessing_config_reader.cpp
+++ b/src/silo/preprocessing/preprocessing_config_reader.cpp
@@ -33,6 +33,7 @@ struct convert<OptionalPreprocessingConfig> {
          extractStringIfPresent(node, "pangoLineageDefinitionFilename"),
          extractStringIfPresent(node, "referenceGenomeFilename"),
          extractStringIfPresent(node, "nucleotideSequencePrefix"),
+         extractStringIfPresent(node, "unalignedNucleotideSequencePrefix"),
          extractStringIfPresent(node, "genePrefix")
       };
 


### PR DESCRIPTION
Otherwise the genePrefix would be used for the unalignedNucleotideSequencePrefix