### PR TITLE
Optimize bitmaps for more memory-efficiency

### DIFF
--- a/endToEndTests/test/info.test.js
+++ b/endToEndTests/test/info.test.js
@@ -8,7 +8,7 @@ describe('The /info endpoint', () => {
       .expect(200)
       .expect('Content-Type', 'application/json')
       .expect(headerToHaveDataVersion)
-      .expect({ nBitmapsSize: 3898, sequenceCount: 100, totalSize: 26589432 })
+      .expect({ nBitmapsSize: 3898, sequenceCount: 100, totalSize: 26335659 })
       .end(done);
   });
 
@@ -27,15 +27,15 @@ describe('The /info endpoint', () => {
           'bitmapContainerSizeStatistic'
         );
         expect(returnedInfo.bitmapContainerSizePerGenomeSection.bitmapContainerSizeStatistic).to.deep.equal({
-          numberOfArrayContainers: 48524,
+          numberOfArrayContainers: 3065,
           numberOfBitsetContainers: 0,
-          numberOfRunContainers: 284,
-          numberOfValuesStoredInArrayContainers: 66620,
+          numberOfRunContainers: 3,
+          numberOfValuesStoredInArrayContainers: 4377,
           numberOfValuesStoredInBitsetContainers: 0,
-          numberOfValuesStoredInRunContainers: 2875,
-          totalBitmapSizeArrayContainers: 133240,
+          numberOfValuesStoredInRunContainers: 9,
+          totalBitmapSizeArrayContainers: 8754,
           totalBitmapSizeBitsetContainers: 0,
-          totalBitmapSizeRunContainers: 4824,
+          totalBitmapSizeRunContainers: 18,
         });
 
         expect(returnedInfo.bitmapContainerSizePerGenomeSection).to.have.property(
@@ -62,19 +62,19 @@ describe('The /info endpoint', () => {
 
         expect(returnedInfo).to.have.property('bitmapSizePerSymbol');
         expect(returnedInfo.bitmapSizePerSymbol).to.deep.equal({
-          '-': 2661831,
-          'A': 2775910,
+          '-': 2648220,
+          'A': 2635348,
           'B': 2631464,
-          'C': 2725728,
+          'C': 2634362,
           'D': 2631464,
-          'G': 2728118,
+          'G': 2633570,
           'H': 2631464,
           'K': 2631594,
           'M': 2631554,
           'N': 2631464,
           'R': 2631514,
           'S': 2631464,
-          'T': 2791923,
+          'T': 2638765,
           'V': 2631464,
           'W': 2631514,
           'Y': 2631494,

--- a/include/silo/common/aa_symbols.h
+++ b/include/silo/common/aa_symbols.h
@@ -39,7 +39,7 @@ class AminoAcid {
       STOP,  // Stop codon
       X,     // Any amino acid
    };
-   static constexpr uint32_t COUNT = static_cast<uint32_t>(Symbol::X) + 1;
+   static constexpr uint32_t COUNT = 25;
 
    static constexpr std::string_view SYMBOL_NAME = "Amino Acid";
    static constexpr std::string_view SYMBOL_NAME_LOWER_CASE = "amino acid";
@@ -77,6 +77,14 @@ class AminoAcid {
       AminoAcid::Symbol::Y,     // Tyrosine
       AminoAcid::Symbol::STOP,  // Stop codon, Star-character in sequence
    };
+
+   static constexpr std::array<Symbol, 3> INVALID_MUTATION_SYMBOLS{
+      AminoAcid::Symbol::B,  // Aspartic acid or Asparagine
+      AminoAcid::Symbol::Z,  // Glutamine or Glutamic acid
+      AminoAcid::Symbol::X,  // Any amino acid
+   };
+
+   static_assert(INVALID_MUTATION_SYMBOLS.size() + VALID_MUTATION_SYMBOLS.size() == SYMBOLS.size());
 
    static constexpr Symbol SYMBOL_MISSING = Symbol::X;
 

--- a/include/silo/common/nucleotide_symbols.h
+++ b/include/silo/common/nucleotide_symbols.h
@@ -31,7 +31,7 @@ class Nucleotide {
       N,    // any base
    };
 
-   static constexpr uint32_t COUNT = static_cast<uint32_t>(Symbol::N) + 1;
+   static constexpr uint32_t COUNT = 16;
 
    static constexpr std::string_view SYMBOL_NAME = "Nucleotide";
    static constexpr std::string_view SYMBOL_NAME_LOWER_CASE = "nucleotide";
@@ -64,6 +64,22 @@ class Nucleotide {
       Nucleotide::Symbol::G,
       Nucleotide::Symbol::T,
    };
+
+   static constexpr std::array<Symbol, 11> INVALID_MUTATION_SYMBOLS{
+      Nucleotide::Symbol::R,  // A or G
+      Nucleotide::Symbol::Y,  // C or T
+      Nucleotide::Symbol::S,  // G or C
+      Nucleotide::Symbol::W,  // A or T
+      Nucleotide::Symbol::K,  // G or T
+      Nucleotide::Symbol::M,  // A or C
+      Nucleotide::Symbol::B,  // C or G or T
+      Nucleotide::Symbol::D,  // A or G or T
+      Nucleotide::Symbol::H,  // A or C or T
+      Nucleotide::Symbol::V,  // A or C or G
+      Nucleotide::Symbol::N,  // any base
+   };
+
+   static_assert(INVALID_MUTATION_SYMBOLS.size() + VALID_MUTATION_SYMBOLS.size() == SYMBOLS.size());
 
    static constexpr Symbol SYMBOL_MISSING = Symbol::N;
 

--- a/include/silo/query_engine/actions/mutations.h
+++ b/include/silo/query_engine/actions/mutations.h
@@ -47,7 +47,13 @@ class Mutations : public Action {
    static std::unordered_map<std::string, Mutations<SymbolType>::PrefilteredBitmaps>
    preFilterBitmaps(const silo::Database& database, std::vector<OperatorResult>& bitmap_filter);
 
-   static void addMutationsCountsForPosition(
+   static void addPositionToMutationCountsForMixedBitmaps(
+      uint32_t position,
+      const PrefilteredBitmaps& bitmaps_to_evaluate,
+      SymbolMap<SymbolType, std::vector<uint32_t>>& count_of_mutations_per_position
+   );
+
+   static void addPositionToMutationCountsForFullBitmaps(
       uint32_t position,
       const PrefilteredBitmaps& bitmaps_to_evaluate,
       SymbolMap<SymbolType, std::vector<uint32_t>>& count_of_mutations_per_position

--- a/include/silo/storage/database_partition.h
+++ b/include/silo/storage/database_partition.h
@@ -88,10 +88,6 @@ class DatabasePartition {
 
    void validate() const;
 
-   void optimizeBitmaps();
-   void optimizeNucleotideBitmaps();
-   void optimizeAminoAcidBitmaps();
-
    [[nodiscard]] const std::vector<preprocessing::PartitionChunk>& getChunks() const;
 
    void insertColumn(const std::string& name, storage::column::StringColumnPartition& column);

--- a/include/silo/storage/database_partition.h
+++ b/include/silo/storage/database_partition.h
@@ -88,7 +88,9 @@ class DatabasePartition {
 
    void validate() const;
 
-   void flipBitmaps();
+   void optimizeBitmaps();
+   void optimizeNucleotideBitmaps();
+   void optimizeAminoAcidBitmaps();
 
    [[nodiscard]] const std::vector<preprocessing::PartitionChunk>& getChunks() const;
 

--- a/include/silo/storage/position.h
+++ b/include/silo/storage/position.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <fmt/core.h>
+#include <roaring/roaring.hh>
+
+#include "silo/common/aa_symbols.h"
+#include "silo/common/nucleotide_symbols.h"
+#include "silo/common/symbol_map.h"
+
+namespace boost::serialization {
+class access;
+}  // namespace boost::serialization
+
+namespace silo {
+
+template <typename SymbolType>
+class Position {
+   friend class boost::serialization::access;
+
+   template <class Archive>
+   void serialize(Archive& archive, [[maybe_unused]] const uint32_t version) {
+      // clang-format off
+      archive & bitmaps;
+      archive & symbol_whose_bitmap_is_flipped;
+      archive & symbol_whose_bitmap_is_deleted;
+      // clang-format on
+   }
+
+   SymbolMap<SymbolType, roaring::Roaring> bitmaps;
+   std::optional<typename SymbolType::Symbol> symbol_whose_bitmap_is_flipped;
+   std::optional<typename SymbolType::Symbol> symbol_whose_bitmap_is_deleted;
+
+   std::optional<typename SymbolType::Symbol> getHighestCardinalitySymbol(uint32_t sequence_count);
+
+  public:
+   Position() = default;
+
+   static Position<SymbolType> fromInitiallyDeleted(typename SymbolType::Symbol symbol);
+   static Position<SymbolType> fromInitiallyFlipped(typename SymbolType::Symbol symbol);
+
+   void addValues(
+      typename SymbolType::Symbol symbol,
+      const std::vector<uint32_t>& values,
+      size_t current_offset,
+      size_t interval_size
+   );
+
+   std::optional<typename SymbolType::Symbol> flipMostNumerousBitmap(uint32_t sequence_count);
+
+   std::optional<typename SymbolType::Symbol> deleteMostNumerousBitmap(uint32_t sequence_count);
+
+   size_t computeSize() const;
+
+   bool isSymbolFlipped(typename SymbolType::Symbol) const;
+
+   bool isSymbolDeleted(typename SymbolType::Symbol) const;
+   std::optional<typename SymbolType::Symbol> getDeletedSymbol() const;
+
+   const roaring::Roaring* getBitmap(typename SymbolType::Symbol symbol) const;
+};
+
+}  // namespace silo

--- a/include/silo/storage/sequence_store.h
+++ b/include/silo/storage/sequence_store.h
@@ -57,6 +57,8 @@ class SequenceStorePartition {
 
    void fillNBitmaps(const std::vector<std::optional<std::string>>& genomes);
 
+   void optimizeBitmaps();
+
   public:
    explicit SequenceStorePartition(
       const std::vector<typename SymbolType::Symbol>& reference_sequence

--- a/include/silo/storage/sequence_store.h
+++ b/include/silo/storage/sequence_store.h
@@ -14,37 +14,16 @@
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/common/symbol_map.h"
+#include "silo/storage/position.h"
 
 namespace boost::serialization {
 class access;
 }  // namespace boost::serialization
 
 namespace silo {
-class ZstdFastaTableReader;
-
 template <typename SymbolType>
-class Position {
-   friend class boost::serialization::access;
-
-   template <class Archive>
-   void serialize(Archive& archive, [[maybe_unused]] const uint32_t version) {
-      // clang-format off
-      archive & bitmaps;
-      archive & symbol_whose_bitmap_is_flipped;
-      // clang-format on
-   }
-
-   Position() = default;
-
-  public:
-   explicit Position(typename SymbolType::Symbol symbol);
-   explicit Position(std::optional<typename SymbolType::Symbol> symbol);
-
-   SymbolMap<SymbolType, roaring::Roaring> bitmaps;
-   std::optional<typename SymbolType::Symbol> symbol_whose_bitmap_is_flipped;
-
-   std::optional<typename SymbolType::Symbol> flipMostNumerousBitmap(uint32_t sequence_count);
-};
+class Position;
+class ZstdFastaTableReader;
 
 struct SequenceStoreInfo {
    uint32_t sequence_count;

--- a/include/silo/zstdfasta/zstdfasta_table_reader.h
+++ b/include/silo/zstdfasta/zstdfasta_table_reader.h
@@ -52,7 +52,7 @@ class ZstdFastaTableReader {
 
    std::optional<std::string> nextCompressed(std::optional<std::string>& compressed_genome);
 
-   void reset();
+   void loadTable();
 
    void copyTableTo(std::string_view file_name);
 

--- a/src/silo/database.cpp
+++ b/src/silo/database.cpp
@@ -225,7 +225,7 @@ BitmapSizePerSymbol Database::calculateBitmapSizePerSymbol(
          for (const auto& position : seq_store_partition.positions) {
             assert(bitmap_size_per_symbol.size_in_bytes.contains(symbol));
             bitmap_size_per_symbol.size_in_bytes[symbol] +=
-               position.bitmaps.at(symbol).getSizeInBytes();
+               position.getBitmap(symbol)->getSizeInBytes();
          }
       }
       lock.lock();
@@ -270,7 +270,7 @@ BitmapContainerSize Database::calculateBitmapContainerSizePerGenomeSection(
       for (const auto& seq_store_partition : seq_store.partitions) {
          const auto& position = seq_store_partition.positions[position_index];
          for (const auto& genome_symbol : Nucleotide::SYMBOLS) {
-            const auto& bitmap = position.bitmaps.at(genome_symbol);
+            const auto& bitmap = *position.getBitmap(genome_symbol);
 
             roaring_bitmap_statistics(&bitmap.roaring, &statistic);
             addStatisticToBitmapContainerSize(

--- a/src/silo/database.test.cpp
+++ b/src/silo/database.test.cpp
@@ -64,10 +64,10 @@ TEST(DatabaseTest, shouldReturnCorrectDatabaseInfo) {
    const auto simple_info = database.getDatabaseInfo();
 
    EXPECT_EQ(
-      detailed_info.bitmap_size_per_symbol.size_in_bytes.at(silo::Nucleotide::Symbol::A), 2775910
+      detailed_info.bitmap_size_per_symbol.size_in_bytes.at(silo::Nucleotide::Symbol::A), 2635348
    );
    EXPECT_EQ(
-      detailed_info.bitmap_size_per_symbol.size_in_bytes.at(silo::Nucleotide::Symbol::GAP), 2661831
+      detailed_info.bitmap_size_per_symbol.size_in_bytes.at(silo::Nucleotide::Symbol::GAP), 2648220
    );
 
    EXPECT_EQ(
@@ -78,7 +78,7 @@ TEST(DatabaseTest, shouldReturnCorrectDatabaseInfo) {
    EXPECT_EQ(
       detailed_info.bitmap_container_size_per_genome_section.bitmap_container_size_statistic
          .number_of_values_stored_in_run_containers,
-      2875
+      9
    );
    EXPECT_EQ(
       detailed_info.bitmap_container_size_per_genome_section.bitmap_container_size_statistic
@@ -87,18 +87,18 @@ TEST(DatabaseTest, shouldReturnCorrectDatabaseInfo) {
    );
 
    EXPECT_EQ(
-      detailed_info.bitmap_container_size_per_genome_section.total_bitmap_size_computed, 42629964
+      detailed_info.bitmap_container_size_per_genome_section.total_bitmap_size_computed, 42136719
    );
    EXPECT_EQ(
-      detailed_info.bitmap_container_size_per_genome_section.total_bitmap_size_frozen, 21433248
+      detailed_info.bitmap_container_size_per_genome_section.total_bitmap_size_frozen, 21075818
    );
    EXPECT_EQ(
       detailed_info.bitmap_container_size_per_genome_section.bitmap_container_size_statistic
          .total_bitmap_size_array_containers,
-      133240
+      8754
    );
 
-   EXPECT_EQ(simple_info.total_size, 26589432);
+   EXPECT_EQ(simple_info.total_size, 26335659);
    EXPECT_EQ(simple_info.sequence_count, 100);
    EXPECT_EQ(simple_info.n_bitmaps_size, 3898);
 }

--- a/src/silo/preprocessing/preprocessor.cpp
+++ b/src/silo/preprocessing/preprocessor.cpp
@@ -441,36 +441,48 @@ Database Preprocessor::buildDatabase(
                     ++chunk_index) {
                   for (const auto& [nuc_name, reference_sequence] :
                        reference_genomes.raw_nucleotide_sequences) {
-                     SPDLOG_DEBUG(
-                        "build - building sequence store for nucleotide sequence {} and partition "
-                        "{}",
-                        nuc_name,
-                        partition_index
-                     );
+                     {
+                        SPDLOG_DEBUG(
+                           "build - building aligned sequence store for nucleotide sequence {} and "
+                           "partition {}",
+                           nuc_name,
+                           partition_index
+                        );
 
-                     silo::ZstdFastaTableReader sequence_input(
-                        preprocessing_db.getConnection(),
-                        "nuc_" + nuc_name,
-                        reference_sequence,
-                        "sequence",
-                        fmt::format("partition_id = {}", partition_index),
-                        order_by_clause
-                     );
-                     database.partitions[partition_index].nuc_sequences.at(nuc_name).fill(
-                        sequence_input
-                     );
+                        silo::ZstdFastaTableReader sequence_input(
+                           preprocessing_db.getConnection(),
+                           "nuc_" + nuc_name,
+                           reference_sequence,
+                           "sequence",
+                           fmt::format("partition_id = {}", partition_index),
+                           order_by_clause
+                        );
+                        database.partitions[partition_index].nuc_sequences.at(nuc_name).fill(
+                           sequence_input
+                        );
+                     }
 
-                     silo::ZstdFastaTableReader unaligned_sequence_input(
-                        preprocessing_db.getConnection(),
-                        "unaligned_nuc_" + nuc_name,
-                        reference_sequence,
-                        "sequence",
-                        fmt::format("partition_id = {}", partition_index),
-                        order_by_clause
-                     );
-                     database.partitions[partition_index].unaligned_nuc_sequences.at(nuc_name).fill(
-                        unaligned_sequence_input
-                     );
+                     {
+                        SPDLOG_DEBUG(
+                           "build - building unaligned sequence store for nucleotide sequence {} "
+                           "and "
+                           "partition {}",
+                           nuc_name,
+                           partition_index
+                        );
+
+                        silo::ZstdFastaTableReader unaligned_sequence_input(
+                           preprocessing_db.getConnection(),
+                           "unaligned_nuc_" + nuc_name,
+                           reference_sequence,
+                           "sequence",
+                           fmt::format("partition_id = {}", partition_index),
+                           order_by_clause
+                        );
+                        database.partitions[partition_index]
+                           .unaligned_nuc_sequences.at(nuc_name)
+                           .fill(unaligned_sequence_input);
+                     }
                   }
                   for (const auto& [aa_name, reference_sequence] :
                        reference_genomes.raw_aa_sequences) {

--- a/src/silo/preprocessing/preprocessor.cpp
+++ b/src/silo/preprocessing/preprocessor.cpp
@@ -494,7 +494,7 @@ Database Preprocessor::buildDatabase(
                      );
                   }
                }
-               database.partitions.at(partition_index).flipBitmaps();
+               database.partitions.at(partition_index).optimizeBitmaps();
                SPDLOG_INFO("build - finished sequences for partition {}", partition_index);
             }
          }

--- a/src/silo/preprocessing/preprocessor.cpp
+++ b/src/silo/preprocessing/preprocessor.cpp
@@ -494,7 +494,6 @@ Database Preprocessor::buildDatabase(
                      );
                   }
                }
-               database.partitions.at(partition_index).optimizeBitmaps();
                SPDLOG_INFO("build - finished sequences for partition {}", partition_index);
             }
          }

--- a/src/silo/query_engine/actions/fasta.cpp
+++ b/src/silo/query_engine/actions/fasta.cpp
@@ -109,6 +109,7 @@ void addSequencesFromResultTableToJson(
          "TRUE",
          "ORDER BY key"
       );
+      table_reader.loadTable();
       std::optional<std::string> genome_buffer;
 
       const size_t start_of_partition_in_result = results.query_result.size() - number_of_values;

--- a/src/silo/query_engine/actions/fasta_aligned.cpp
+++ b/src/silo/query_engine/actions/fasta_aligned.cpp
@@ -59,21 +59,20 @@ std::string reconstructSequence(
       reconstructed_sequence[position_id] = SymbolType::symbolToChar(symbol);
    }
 
-   tbb::
-      parallel_for(
-         tbb::blocked_range<size_t>(0, sequence_store.positions.size()),
-         [&](const auto local) {
-            for (auto position_id = local.begin(); position_id != local.end(); position_id++) {
-               const Position<SymbolType>& position = sequence_store.positions.at(position_id);
-               for (const auto symbol : SymbolType::SYMBOLS) {
-                  if (symbol != position.symbol_whose_bitmap_is_flipped &&
-                      position.bitmaps.at(symbol).contains(sequence_id)) {
-                     reconstructed_sequence[position_id] = SymbolType::symbolToChar(symbol);
-                  }
+   tbb::parallel_for(
+      tbb::blocked_range<size_t>(0, sequence_store.positions.size()),
+      [&](const auto local) {
+         for (auto position_id = local.begin(); position_id != local.end(); position_id++) {
+            const Position<SymbolType>& position = sequence_store.positions.at(position_id);
+            for (const auto symbol : SymbolType::SYMBOLS) {
+               if (!position.isSymbolFlipped(symbol) && !position.isSymbolDeleted(symbol)
+                   && position.getBitmap(symbol)->contains(sequence_id)) {
+                  reconstructed_sequence[position_id] = SymbolType::symbolToChar(symbol);
                }
             }
          }
-      );
+      }
+   );
 
    for (const size_t position : sequence_store.missing_symbol_bitmaps.at(sequence_id)) {
       reconstructed_sequence[position] = SymbolType::symbolToChar(SymbolType::SYMBOL_MISSING);

--- a/src/silo/query_engine/filter_expressions/aa_symbol_equals.cpp
+++ b/src/silo/query_engine/filter_expressions/aa_symbol_equals.cpp
@@ -7,12 +7,14 @@
 
 #include "silo/common/aa_symbols.h"
 #include "silo/query_engine/filter_expressions/expression.h"
+#include "silo/query_engine/filter_expressions/or.h"
 #include "silo/query_engine/operators/bitmap_selection.h"
 #include "silo/query_engine/operators/complement.h"
 #include "silo/query_engine/operators/index_scan.h"
 #include "silo/query_engine/operators/operator.h"
 #include "silo/query_engine/query_parse_exception.h"
 #include "silo/storage/database_partition.h"
+#include "silo/storage/position.h"
 #include "silo/storage/sequence_store.h"
 
 namespace silo {
@@ -36,7 +38,7 @@ std::string AASymbolEquals::toString(const silo::Database& /*database*/) const {
 }
 
 std::unique_ptr<silo::query_engine::operators::Operator> AASymbolEquals::compile(
-   const silo::Database& /*database*/,
+   const silo::Database& database,
    const silo::DatabasePartition& database_partition,
    Expression::AmbiguityMode /*mode*/
 ) const {
@@ -57,13 +59,29 @@ std::unique_ptr<silo::query_engine::operators::Operator> AASymbolEquals::compile
          position
       );
    }
-   if (aa_store_partition.positions[position].symbol_whose_bitmap_is_flipped == aa_symbol) {
+   if (aa_store_partition.positions[position].isSymbolFlipped(aa_symbol)) {
       return std::make_unique<operators::Complement>(
          std::make_unique<operators::IndexScan>(
             aa_store_partition.getBitmap(position, aa_symbol), database_partition.sequence_count
          ),
          database_partition.sequence_count
       );
+   }
+   if (aa_store_partition.positions[position].isSymbolDeleted(aa_symbol)) {
+      std::vector<AminoAcid::Symbol> symbols =
+         std::vector<AminoAcid::Symbol>(AminoAcid::SYMBOLS.begin(), AminoAcid::SYMBOLS.end());
+      // NOLINTNEXTLINE(bugprone-unused-return-value)
+      (void)std::remove(symbols.begin(), symbols.end(), aa_symbol);
+      std::vector<std::unique_ptr<filter_expressions::Expression>> symbol_filters;
+      std::transform(
+         symbols.begin(),
+         symbols.end(),
+         std::back_inserter(symbol_filters),
+         [&](AminoAcid::Symbol symbol) {
+            return std::make_unique<AASymbolEquals>(aa_sequence_name, position, symbol);
+         }
+      );
+      return Or(std::move(symbol_filters)).compile(database, database_partition, NONE);
    }
    return std::make_unique<operators::IndexScan>(
       aa_store_partition.getBitmap(position, aa_symbol), database_partition.sequence_count

--- a/src/silo/query_engine/filter_expressions/maybe.cpp
+++ b/src/silo/query_engine/filter_expressions/maybe.cpp
@@ -21,7 +21,7 @@ Maybe::Maybe(std::unique_ptr<Expression> child)
     : child(std::move(child)) {}
 
 std::string Maybe::toString(const silo::Database& database) const {
-   return "Maybe ( " + child->toString(database) + ")";
+   return "Maybe (" + child->toString(database) + ")";
 }
 std::unique_ptr<silo::query_engine::operators::Operator> Maybe::compile(
    const silo::Database& database,

--- a/src/silo/query_engine/filter_expressions/nucleotide_symbol_equals.cpp
+++ b/src/silo/query_engine/filter_expressions/nucleotide_symbol_equals.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
 
 #include "silo/common/nucleotide_symbols.h"
@@ -127,6 +128,11 @@ std::unique_ptr<silo::query_engine::operators::Operator> NucleotideSymbolEquals:
          ->compile(database, database_partition, NONE);
    }
    if (nucleotide_symbol == Nucleotide::SYMBOL_MISSING) {
+      SPDLOG_TRACE(
+         "Filtering for '{}' at position {}",
+         Nucleotide::symbolToChar(Nucleotide::SYMBOL_MISSING),
+         position
+      );
       return std::make_unique<operators::BitmapSelection>(
          seq_store_partition.missing_symbol_bitmaps.data(),
          seq_store_partition.missing_symbol_bitmaps.size(),
@@ -134,7 +140,12 @@ std::unique_ptr<silo::query_engine::operators::Operator> NucleotideSymbolEquals:
          position
       );
    }
-   if (seq_store_partition.positions[position].symbol_whose_bitmap_is_flipped == nucleotide_symbol) {
+   if (seq_store_partition.positions[position].isSymbolFlipped(nucleotide_symbol)) {
+      SPDLOG_TRACE(
+         "Filtering for flipped symbol '{}' at position {}",
+         Nucleotide::symbolToChar(nucleotide_symbol),
+         position
+      );
       return std::make_unique<operators::Complement>(
          std::make_unique<operators::IndexScan>(
             seq_store_partition.getBitmap(position, nucleotide_symbol),
@@ -143,6 +154,34 @@ std::unique_ptr<silo::query_engine::operators::Operator> NucleotideSymbolEquals:
          database_partition.sequence_count
       );
    }
+   if (seq_store_partition.positions[position].isSymbolDeleted(nucleotide_symbol)) {
+      SPDLOG_TRACE(
+         "Filtering for deleted symbol '{}' at position {}",
+         Nucleotide::symbolToChar(nucleotide_symbol),
+         position
+      );
+      std::vector<Nucleotide::Symbol> symbols =
+         std::vector<Nucleotide::Symbol>(Nucleotide::SYMBOLS.begin(), Nucleotide::SYMBOLS.end());
+      // NOLINTNEXTLINE(bugprone-unused-return-value)
+      (void)std::remove(symbols.begin(), symbols.end(), nucleotide_symbol);
+      std::vector<std::unique_ptr<filter_expressions::Expression>> symbol_filters;
+      std::transform(
+         symbols.begin(),
+         symbols.end(),
+         std::back_inserter(symbol_filters),
+         [&](Nucleotide::Symbol symbol) {
+            return std::make_unique<NucleotideSymbolEquals>(
+               nuc_sequence_name_or_default, position, symbol
+            );
+         }
+      );
+      return Or(std::move(symbol_filters)).compile(database, database_partition, NONE);
+   }
+   SPDLOG_TRACE(
+      "Filtering for symbol '{}' at position {}",
+      Nucleotide::symbolToChar(nucleotide_symbol),
+      position
+   );
    return std::make_unique<operators::IndexScan>(
       seq_store_partition.getBitmap(position, nucleotide_symbol), database_partition.sequence_count
    );

--- a/src/silo/query_engine/filter_expressions/or.cpp
+++ b/src/silo/query_engine/filter_expressions/or.cpp
@@ -68,8 +68,9 @@ std::unique_ptr<operators::Operator> Or::compile(
             std::back_inserter(filtered_child_operators),
             [&](std::unique_ptr<operators::Operator>& expression) { return std::move(expression); }
          );
+      } else {
+         filtered_child_operators.push_back(std::move(child));
       }
-      filtered_child_operators.push_back(std::move(child));
    }
    if (filtered_child_operators.empty()) {
       return std::make_unique<operators::Empty>(database_partition.sequence_count);

--- a/src/silo/storage/database_partition.cpp
+++ b/src/silo/storage/database_partition.cpp
@@ -154,8 +154,12 @@ void DatabasePartition::validateMetadataColumns() const {
    }
 }
 
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
-void DatabasePartition::flipBitmaps() {
+void DatabasePartition::optimizeBitmaps() {
+   optimizeNucleotideBitmaps();
+   optimizeAminoAcidBitmaps();
+}
+
+void DatabasePartition::optimizeNucleotideBitmaps() {
    for (auto& [_, seq_store] : nuc_sequences) {
       tbb::enumerable_thread_specific<decltype(seq_store.indexing_differences_to_reference_sequence
       )>
@@ -177,21 +181,24 @@ void DatabasePartition::flipBitmaps() {
          }
       }
    }
+}
+
+void DatabasePartition::optimizeAminoAcidBitmaps() {
    for (auto& [_, aa_store] : aa_sequences) {
       tbb::enumerable_thread_specific<decltype(aa_store.indexing_differences_to_reference_sequence)>
-         flipped_bitmaps;
+         index_changes_to_reference;
 
       auto& positions = aa_store.positions;
       tbb::parallel_for(tbb::blocked_range<uint32_t>(0, positions.size()), [&](const auto& local) {
-         auto& local_flipped_bitmaps = flipped_bitmaps.local();
+         auto& local_index_changes = index_changes_to_reference.local();
          for (auto position = local.begin(); position != local.end(); ++position) {
-            auto flipped_symbol = positions[position].deleteMostNumerousBitmap(sequence_count);
-            if (flipped_symbol.has_value()) {
-               local_flipped_bitmaps.emplace_back(position, *flipped_symbol);
+            auto symbol_changed = positions[position].deleteMostNumerousBitmap(sequence_count);
+            if (symbol_changed.has_value()) {
+               local_index_changes.emplace_back(position, *symbol_changed);
             }
          }
       });
-      for (const auto& local : flipped_bitmaps) {
+      for (const auto& local : index_changes_to_reference) {
          for (const auto& element : local) {
             aa_store.indexing_differences_to_reference_sequence.emplace_back(element);
          }

--- a/src/silo/storage/database_partition.cpp
+++ b/src/silo/storage/database_partition.cpp
@@ -154,58 +154,6 @@ void DatabasePartition::validateMetadataColumns() const {
    }
 }
 
-void DatabasePartition::optimizeBitmaps() {
-   optimizeNucleotideBitmaps();
-   optimizeAminoAcidBitmaps();
-}
-
-void DatabasePartition::optimizeNucleotideBitmaps() {
-   for (auto& [_, seq_store] : nuc_sequences) {
-      tbb::enumerable_thread_specific<decltype(seq_store.indexing_differences_to_reference_sequence
-      )>
-         index_changes_to_reference;
-
-      auto& positions = seq_store.positions;
-      tbb::parallel_for(tbb::blocked_range<uint32_t>(0, positions.size()), [&](const auto& local) {
-         auto& local_index_changes = index_changes_to_reference.local();
-         for (auto position = local.begin(); position != local.end(); ++position) {
-            auto symbol_changed = positions[position].deleteMostNumerousBitmap(sequence_count);
-            if (symbol_changed.has_value()) {
-               local_index_changes.emplace_back(position, *symbol_changed);
-            }
-         }
-      });
-      for (const auto& local : index_changes_to_reference) {
-         for (const auto& element : local) {
-            seq_store.indexing_differences_to_reference_sequence.emplace_back(element);
-         }
-      }
-   }
-}
-
-void DatabasePartition::optimizeAminoAcidBitmaps() {
-   for (auto& [_, aa_store] : aa_sequences) {
-      tbb::enumerable_thread_specific<decltype(aa_store.indexing_differences_to_reference_sequence)>
-         index_changes_to_reference;
-
-      auto& positions = aa_store.positions;
-      tbb::parallel_for(tbb::blocked_range<uint32_t>(0, positions.size()), [&](const auto& local) {
-         auto& local_index_changes = index_changes_to_reference.local();
-         for (auto position = local.begin(); position != local.end(); ++position) {
-            auto symbol_changed = positions[position].deleteMostNumerousBitmap(sequence_count);
-            if (symbol_changed.has_value()) {
-               local_index_changes.emplace_back(position, *symbol_changed);
-            }
-         }
-      });
-      for (const auto& local : index_changes_to_reference) {
-         for (const auto& element : local) {
-            aa_store.indexing_differences_to_reference_sequence.emplace_back(element);
-         }
-      }
-   }
-}
-
 const std::vector<preprocessing::PartitionChunk>& DatabasePartition::getChunks() const {
    return chunks;
 }

--- a/src/silo/storage/position.cpp
+++ b/src/silo/storage/position.cpp
@@ -1,0 +1,172 @@
+#include "silo/storage/position.h"
+
+#include <spdlog/spdlog.h>
+
+template <typename SymbolType>
+silo::Position<SymbolType> silo::Position<SymbolType>::fromInitiallyDeleted(
+   typename SymbolType::Symbol symbol
+) {
+   silo::Position<SymbolType> position;
+   position.symbol_whose_bitmap_is_deleted = symbol;
+   return position;
+}
+
+template <typename SymbolType>
+silo::Position<SymbolType> silo::Position<SymbolType>::fromInitiallyFlipped(
+   typename SymbolType::Symbol symbol
+) {
+   silo::Position<SymbolType> position;
+   position.symbol_whose_bitmap_is_flipped = symbol;
+   return position;
+}
+
+template <typename SymbolType>
+void silo::Position<SymbolType>::addValues(
+   typename SymbolType::Symbol symbol,
+   const std::vector<uint32_t>& values,
+   size_t current_offset,
+   size_t interval_size
+) {
+   if (symbol == symbol_whose_bitmap_is_deleted) {
+      return;
+   }
+   if (!values.empty()) {
+      bitmaps[symbol].addMany(values.size(), values.data());
+   }
+   if (symbol == symbol_whose_bitmap_is_flipped) {
+      bitmaps[symbol].flip(current_offset, current_offset + interval_size);
+   }
+}
+
+template <typename SymbolType>
+std::optional<typename SymbolType::Symbol> silo::Position<SymbolType>::getHighestCardinalitySymbol(
+   uint32_t sequence_count
+) {
+   std::optional<typename SymbolType::Symbol> max_symbol = std::nullopt;
+   uint32_t max_count = 0;
+
+   uint32_t count_sum = 0;
+
+   for (const auto& symbol : SymbolType::SYMBOLS) {
+      roaring::Roaring& bitmap = bitmaps[symbol];
+      bitmap.runOptimize();
+      bitmap.shrinkToFit();
+      const uint32_t count =
+         isSymbolFlipped(symbol) ? sequence_count - bitmap.cardinality() : bitmap.cardinality();
+      count_sum += count;
+      if (count > max_count) {
+         max_symbol = symbol;
+         max_count = count;
+      }
+   }
+   if (symbol_whose_bitmap_is_deleted.has_value()) {
+      if (sequence_count - count_sum > max_count) {
+         return symbol_whose_bitmap_is_deleted;
+      }
+   }
+   return max_symbol;
+}
+
+template <typename SymbolType>
+std::optional<typename SymbolType::Symbol> silo::Position<SymbolType>::flipMostNumerousBitmap(
+   uint32_t sequence_count
+) {
+   if (symbol_whose_bitmap_is_deleted.has_value()) {
+      const auto missing_symbol = symbol_whose_bitmap_is_deleted.value();
+      for (const auto& symbol : SymbolType::SYMBOLS) {
+         if (symbol != missing_symbol) {
+            bitmaps[missing_symbol] |= bitmaps.at(symbol);
+         }
+      }
+      bitmaps[missing_symbol].flip(0, sequence_count);
+      bitmaps[missing_symbol].runOptimize();
+      bitmaps[missing_symbol].shrinkToFit();
+      symbol_whose_bitmap_is_deleted = std::nullopt;
+   }
+
+   std::optional<typename SymbolType::Symbol> max_symbol =
+      getHighestCardinalitySymbol(sequence_count);
+
+   if (max_symbol != symbol_whose_bitmap_is_flipped) {
+      if (symbol_whose_bitmap_is_flipped.has_value()) {
+         bitmaps[*symbol_whose_bitmap_is_flipped].flip(0, sequence_count);
+         bitmaps[*symbol_whose_bitmap_is_flipped].runOptimize();
+         bitmaps[*symbol_whose_bitmap_is_flipped].shrinkToFit();
+      }
+      if (max_symbol.has_value()) {
+         bitmaps[*max_symbol].flip(0, sequence_count);
+         bitmaps[*max_symbol].runOptimize();
+         bitmaps[*max_symbol].shrinkToFit();
+      }
+      symbol_whose_bitmap_is_flipped = max_symbol;
+      return symbol_whose_bitmap_is_flipped;
+   }
+   return std::nullopt;
+}
+
+template <typename SymbolType>
+std::optional<typename SymbolType::Symbol> silo::Position<SymbolType>::deleteMostNumerousBitmap(
+   uint32_t sequence_count
+) {
+   if (symbol_whose_bitmap_is_flipped.has_value()) {
+      bitmaps[*symbol_whose_bitmap_is_flipped].flip(0, sequence_count);
+      bitmaps[*symbol_whose_bitmap_is_flipped].runOptimize();
+      bitmaps[*symbol_whose_bitmap_is_flipped].shrinkToFit();
+      symbol_whose_bitmap_is_flipped = std::nullopt;
+   }
+
+   std::optional<typename SymbolType::Symbol> max_symbol =
+      getHighestCardinalitySymbol(sequence_count);
+
+   if (max_symbol != symbol_whose_bitmap_is_deleted) {
+      if (symbol_whose_bitmap_is_deleted.has_value()) {
+         for (const auto& symbol : SymbolType::SYMBOLS) {
+            if (symbol != *symbol_whose_bitmap_is_deleted) {
+               bitmaps[*symbol_whose_bitmap_is_deleted] |= bitmaps.at(symbol);
+            }
+         }
+         bitmaps[*symbol_whose_bitmap_is_deleted].flip(0, sequence_count);
+         bitmaps[*symbol_whose_bitmap_is_deleted].runOptimize();
+         bitmaps[*symbol_whose_bitmap_is_deleted].shrinkToFit();
+      }
+      if (max_symbol.has_value()) {
+         bitmaps[*max_symbol] = roaring::Roaring();
+      }
+      symbol_whose_bitmap_is_deleted = max_symbol;
+      return symbol_whose_bitmap_is_deleted;
+   }
+   return std::nullopt;
+}
+
+template <typename SymbolType>
+size_t silo::Position<SymbolType>::computeSize() const {
+   size_t result = 0;
+   for (const auto symbol : SymbolType::SYMBOLS) {
+      result += bitmaps.at(symbol).getSizeInBytes(false);
+   }
+   return result;
+}
+
+template <typename SymbolType>
+const roaring::Roaring* silo::Position<SymbolType>::getBitmap(typename SymbolType::Symbol symbol
+) const {
+   return &bitmaps.at(symbol);
+}
+
+template <typename SymbolType>
+bool silo::Position<SymbolType>::isSymbolFlipped(typename SymbolType::Symbol symbol) const {
+   return symbol == symbol_whose_bitmap_is_flipped;
+}
+
+template <typename SymbolType>
+bool silo::Position<SymbolType>::isSymbolDeleted(typename SymbolType::Symbol symbol) const {
+   return symbol == symbol_whose_bitmap_is_deleted;
+}
+
+template <typename SymbolType>
+std::optional<typename SymbolType::Symbol> silo::Position<SymbolType>::getDeletedSymbol() const {
+   return symbol_whose_bitmap_is_deleted;
+}
+
+template class silo::Position<silo::Nucleotide>;
+template class silo::Position<silo::AminoAcid>;

--- a/src/silo/storage/position.test.cpp
+++ b/src/silo/storage/position.test.cpp
@@ -11,34 +11,163 @@
 #include "silo/roaring/roaring_serialize.h"
 #include "silo/storage/serialize_optional.h"
 
-void serializeToFile(
-   const std::string& filename,
-   const silo::Position<silo::Nucleotide>& position
-) {
+using silo::Nucleotide;
+using silo::Position;
+
+void serializeToFile(const std::string& filename, const Position<Nucleotide>& position) {
    std::ofstream output_file(filename.c_str(), std::ios::binary);
    ::boost::archive::binary_oarchive output_archive(output_file);
    output_archive << position;
    output_file.close();
 }
 
-void deserializeFromFile(const std::string& filename, silo::Position<silo::Nucleotide>& position) {
+void deserializeFromFile(const std::string& filename, Position<Nucleotide>& position) {
    std::ifstream input_file(filename, std::ios::binary);
    ::boost::archive::binary_iarchive input_archive(input_file);
    input_archive >> position;
    input_file.close();
 }
 
+TEST(Position, flipsMostNumerousCorrectlyFromUnset) {
+   Position<Nucleotide> under_test;
+
+   under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
+   under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
+
+   ASSERT_EQ(*under_test.flipMostNumerousBitmap(5), Nucleotide::Symbol::C);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({0, 4}));
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+
+   ASSERT_EQ(under_test.flipMostNumerousBitmap(5), std::nullopt);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({0, 4}));
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+}
+
+TEST(Position, flipsMostNumerousCorrectlyFromDifferent) {
+   Position<Nucleotide> under_test =
+      Position<Nucleotide>::fromInitiallyFlipped(Nucleotide::Symbol::A);
+
+   under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
+   under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
+
+   ASSERT_EQ(*under_test.flipMostNumerousBitmap(5), Nucleotide::Symbol::C);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({0, 4}));
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+
+   ASSERT_EQ(under_test.flipMostNumerousBitmap(5), std::nullopt);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({0, 4}));
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+}
+
+TEST(Position, flipsMostNumerousCorrectlyFromSame) {
+   Position<Nucleotide> under_test =
+      Position<Nucleotide>::fromInitiallyFlipped(Nucleotide::Symbol::C);
+
+   under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
+   under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
+
+   ASSERT_EQ(under_test.flipMostNumerousBitmap(5), std::nullopt);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({0, 4}));
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+
+   ASSERT_EQ(under_test.flipMostNumerousBitmap(5), std::nullopt);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({0, 4}));
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+}
+
+TEST(Position, deletesMostNumerousCorrectlyFromUnset) {
+   Position<Nucleotide> under_test;
+
+   under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
+   under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
+
+   ASSERT_EQ(*under_test.deleteMostNumerousBitmap(5), Nucleotide::Symbol::C);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+
+   ASSERT_EQ(under_test.deleteMostNumerousBitmap(5), std::nullopt);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+}
+
+TEST(Position, deletesMostNumerousCorrectlyFromDifferent) {
+   Position<Nucleotide> under_test =
+      Position<Nucleotide>::fromInitiallyDeleted(Nucleotide::Symbol::A);
+
+   under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
+   under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
+
+   ASSERT_EQ(*under_test.deleteMostNumerousBitmap(5), Nucleotide::Symbol::C);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+
+   ASSERT_EQ(under_test.deleteMostNumerousBitmap(5), std::nullopt);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+}
+
+TEST(Position, deletesMostNumerousCorrectlyFromSame) {
+   Position<Nucleotide> under_test =
+      Position<Nucleotide>::fromInitiallyDeleted(Nucleotide::Symbol::C);
+
+   under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
+   under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
+
+   ASSERT_EQ(under_test.deleteMostNumerousBitmap(5), std::nullopt);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+
+   ASSERT_EQ(under_test.deleteMostNumerousBitmap(5), std::nullopt);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+}
+
+TEST(Position, deleteFlipInterplay) {
+   Position<Nucleotide> under_test =
+      Position<Nucleotide>::fromInitiallyDeleted(Nucleotide::Symbol::A);
+
+   under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
+   under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({1, 2, 3}));
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring());
+
+   ASSERT_EQ(*under_test.flipMostNumerousBitmap(5), Nucleotide::Symbol::C);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({0, 4}));
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+
+   ASSERT_EQ(*under_test.deleteMostNumerousBitmap(5), Nucleotide::Symbol::C);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+}
+
 TEST(Position, shouldSerializeAndDeserializePositionsWithEmptyOptional) {
    const std::string test_file = "test.bin";
 
-   const silo::Position<silo::Nucleotide> position_with_unset_optional(std::nullopt);
+   const Position<Nucleotide> position_with_unset_optional;
    serializeToFile(test_file, position_with_unset_optional);
 
-   silo::Position<silo::Nucleotide> deserialized_position(std::nullopt);
+   Position<Nucleotide> deserialized_position;
    deserializeFromFile(test_file, deserialized_position);
 
-   EXPECT_FALSE(position_with_unset_optional.symbol_whose_bitmap_is_flipped.has_value());
-   EXPECT_FALSE(deserialized_position.symbol_whose_bitmap_is_flipped.has_value());
+   for (const auto& symbol : Nucleotide::SYMBOLS) {
+      EXPECT_FALSE(position_with_unset_optional.isSymbolFlipped(symbol));
+      EXPECT_FALSE(deserialized_position.isSymbolFlipped(symbol));
+   }
 
    ASSERT_NO_THROW(std::remove(test_file.c_str()));
 }
@@ -46,19 +175,21 @@ TEST(Position, shouldSerializeAndDeserializePositionsWithEmptyOptional) {
 TEST(Position, shouldSerializeAndDeserializePositionWithSetOptional) {
    const std::string test_file = "test.bin";
 
-   silo::Position<silo::Nucleotide> position_with_set_optional(std::nullopt);
-   position_with_set_optional.symbol_whose_bitmap_is_flipped = silo::Nucleotide::Symbol::A;
+   Position<Nucleotide> position_with_set_optional;
    serializeToFile(test_file, position_with_set_optional);
 
-   silo::Position<silo::Nucleotide> deserialized_position(std::nullopt);
+   Position<Nucleotide> deserialized_position;
    deserializeFromFile(test_file, deserialized_position);
 
-   EXPECT_TRUE(deserialized_position.symbol_whose_bitmap_is_flipped.has_value());
-   ASSERT_EQ(
-      position_with_set_optional.symbol_whose_bitmap_is_flipped.value(),
-      // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-      deserialized_position.symbol_whose_bitmap_is_flipped.value()
-   );
+   EXPECT_TRUE(deserialized_position.isSymbolFlipped(Nucleotide::Symbol::A));
+   EXPECT_TRUE(position_with_set_optional.isSymbolFlipped(Nucleotide::Symbol::A));
+
+   for (const auto& symbol : Nucleotide::SYMBOLS) {
+      if (symbol != Nucleotide::Symbol::A) {
+         EXPECT_FALSE(position_with_set_optional.isSymbolFlipped(symbol));
+         EXPECT_FALSE(deserialized_position.isSymbolFlipped(symbol));
+      }
+   }
 
    ASSERT_NO_THROW(std::remove(test_file.c_str()));
 }

--- a/src/silo/storage/position.test.cpp
+++ b/src/silo/storage/position.test.cpp
@@ -28,13 +28,13 @@ void deserializeFromFile(const std::string& filename, Position<Nucleotide>& posi
    input_file.close();
 }
 
-TEST(Position, flipsMostNumerousCorrectlyFromUnset) {
+TEST(Position, flipsMostNumerousCorrectlyFromInitiallyUnoptimized) {
    Position<Nucleotide> under_test;
 
    under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
    under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
 
-   ASSERT_EQ(*under_test.flipMostNumerousBitmap(5), Nucleotide::Symbol::C);
+   ASSERT_EQ(under_test.flipMostNumerousBitmap(5), Nucleotide::Symbol::C);
 
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({0, 4}));
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
@@ -45,14 +45,14 @@ TEST(Position, flipsMostNumerousCorrectlyFromUnset) {
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
 }
 
-TEST(Position, flipsMostNumerousCorrectlyFromDifferent) {
+TEST(Position, flipsMostNumerousCorrectlyFromInitiallyDifferentSymbolFlipped) {
    Position<Nucleotide> under_test =
       Position<Nucleotide>::fromInitiallyFlipped(Nucleotide::Symbol::A);
 
    under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
    under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
 
-   ASSERT_EQ(*under_test.flipMostNumerousBitmap(5), Nucleotide::Symbol::C);
+   ASSERT_EQ(under_test.flipMostNumerousBitmap(5), Nucleotide::Symbol::C);
 
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({0, 4}));
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
@@ -63,7 +63,7 @@ TEST(Position, flipsMostNumerousCorrectlyFromDifferent) {
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
 }
 
-TEST(Position, flipsMostNumerousCorrectlyFromSame) {
+TEST(Position, flipsMostNumerousCorrectlyFromInitiallySameSymbolFlipped) {
    Position<Nucleotide> under_test =
       Position<Nucleotide>::fromInitiallyFlipped(Nucleotide::Symbol::C);
 
@@ -81,60 +81,24 @@ TEST(Position, flipsMostNumerousCorrectlyFromSame) {
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
 }
 
-TEST(Position, deletesMostNumerousCorrectlyFromUnset) {
+TEST(Position, deletesMostNumerousCorrectlyFromInitiallyUnoptimized) {
    Position<Nucleotide> under_test;
 
    under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
    under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
 
-   ASSERT_EQ(*under_test.deleteMostNumerousBitmap(5), Nucleotide::Symbol::C);
+   ASSERT_EQ(under_test.deleteMostNumerousBitmap(5), Nucleotide::Symbol::C);
 
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
 
-   ASSERT_EQ(under_test.deleteMostNumerousBitmap(5), std::nullopt);
-
-   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
-   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
-}
-
-TEST(Position, deletesMostNumerousCorrectlyFromDifferent) {
-   Position<Nucleotide> under_test =
-      Position<Nucleotide>::fromInitiallyDeleted(Nucleotide::Symbol::A);
-
-   under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
-   under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
-
-   ASSERT_EQ(*under_test.deleteMostNumerousBitmap(5), Nucleotide::Symbol::C);
-
-   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
-   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
-
-   ASSERT_EQ(under_test.deleteMostNumerousBitmap(5), std::nullopt);
+   ASSERT_THROW(under_test.deleteMostNumerousBitmap(5), std::runtime_error);
 
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
 }
 
-TEST(Position, deletesMostNumerousCorrectlyFromSame) {
-   Position<Nucleotide> under_test =
-      Position<Nucleotide>::fromInitiallyDeleted(Nucleotide::Symbol::C);
-
-   under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
-   under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
-
-   ASSERT_EQ(under_test.deleteMostNumerousBitmap(5), std::nullopt);
-
-   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
-   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
-
-   ASSERT_EQ(under_test.deleteMostNumerousBitmap(5), std::nullopt);
-
-   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
-   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
-}
-
-TEST(Position, deleteFlipInterplay) {
+TEST(Position, deletesMostNumerousCorrectlyFromInitiallyDifferentSymbolFlipped) {
    Position<Nucleotide> under_test =
       Position<Nucleotide>::fromInitiallyDeleted(Nucleotide::Symbol::A);
 
@@ -144,17 +108,60 @@ TEST(Position, deleteFlipInterplay) {
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({1, 2, 3}));
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring());
 
-   ASSERT_EQ(*under_test.flipMostNumerousBitmap(5), Nucleotide::Symbol::C);
+   ASSERT_THROW(under_test.deleteMostNumerousBitmap(5), std::runtime_error);
+}
 
-   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({0, 4}));
-   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+TEST(Position, deletesMostNumerousCorrectlyFromInitiallySameFlippedSymbol) {
+   Position<Nucleotide> under_test =
+      Position<Nucleotide>::fromInitiallyDeleted(Nucleotide::Symbol::C);
 
-   ASSERT_EQ(*under_test.deleteMostNumerousBitmap(5), Nucleotide::Symbol::C);
+   under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
+   under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
+
+   ASSERT_THROW(under_test.deleteMostNumerousBitmap(5), std::runtime_error);
 
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
    ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
 }
 
+TEST(Position, deletesCorrectlyFromInitiallyDifferentSymbolFlipped) {
+   Position<Nucleotide> under_test =
+      Position<Nucleotide>::fromInitiallyFlipped(Nucleotide::Symbol::A);
+
+   under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
+   under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({1, 2, 3}));
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({1, 2, 3}));
+
+   ASSERT_EQ(under_test.deleteMostNumerousBitmap(5), Nucleotide::Symbol::C);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+}
+
+TEST(Position, flipThenDeleteFromInitiallyDifferentSymbolFlipped) {
+   Position<Nucleotide> under_test =
+      Position<Nucleotide>::fromInitiallyFlipped(Nucleotide::Symbol::A);
+
+   under_test.addValues(Nucleotide::Symbol::C, std::vector<uint32_t>{1, 2, 3}, 0, 5);
+   under_test.addValues(Nucleotide::Symbol::A, std::vector<uint32_t>{0, 4}, 0, 5);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({1, 2, 3}));
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({1, 2, 3}));
+
+   ASSERT_EQ(under_test.flipMostNumerousBitmap(5), Nucleotide::Symbol::C);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring({0, 4}));
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+
+   ASSERT_EQ(under_test.deleteMostNumerousBitmap(5), Nucleotide::Symbol::C);
+
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::C), roaring::Roaring());
+   ASSERT_EQ(*under_test.getBitmap(Nucleotide::Symbol::A), roaring::Roaring({0, 4}));
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST(Position, shouldSerializeAndDeserializePositionsWithEmptyOptional) {
    const std::string test_file = "test.bin";
 
@@ -172,10 +179,11 @@ TEST(Position, shouldSerializeAndDeserializePositionsWithEmptyOptional) {
    ASSERT_NO_THROW(std::remove(test_file.c_str()));
 }
 
-TEST(Position, shouldSerializeAndDeserializePositionWithSetOptional) {
+TEST(Position, shouldSerializeAndDeserializePositionWithFlippedBitmap) {
    const std::string test_file = "test.bin";
 
-   Position<Nucleotide> position_with_set_optional;
+   const Position<Nucleotide> position_with_set_optional =
+      Position<Nucleotide>::fromInitiallyFlipped(Nucleotide::Symbol::A);
    serializeToFile(test_file, position_with_set_optional);
 
    Position<Nucleotide> deserialized_position;
@@ -185,9 +193,36 @@ TEST(Position, shouldSerializeAndDeserializePositionWithSetOptional) {
    EXPECT_TRUE(position_with_set_optional.isSymbolFlipped(Nucleotide::Symbol::A));
 
    for (const auto& symbol : Nucleotide::SYMBOLS) {
+      EXPECT_FALSE(position_with_set_optional.isSymbolDeleted(symbol));
+      EXPECT_FALSE(deserialized_position.isSymbolDeleted(symbol));
       if (symbol != Nucleotide::Symbol::A) {
          EXPECT_FALSE(position_with_set_optional.isSymbolFlipped(symbol));
          EXPECT_FALSE(deserialized_position.isSymbolFlipped(symbol));
+      }
+   }
+
+   ASSERT_NO_THROW(std::remove(test_file.c_str()));
+}
+
+TEST(Position, shouldSerializeAndDeserializePositionWithDeletedBitmap) {
+   const std::string test_file = "test.bin";
+
+   const Position<Nucleotide> position_with_set_optional =
+      Position<Nucleotide>::fromInitiallyDeleted(Nucleotide::Symbol::A);
+   serializeToFile(test_file, position_with_set_optional);
+
+   Position<Nucleotide> deserialized_position;
+   deserializeFromFile(test_file, deserialized_position);
+
+   EXPECT_TRUE(deserialized_position.isSymbolDeleted(Nucleotide::Symbol::A));
+   EXPECT_TRUE(position_with_set_optional.isSymbolDeleted(Nucleotide::Symbol::A));
+
+   for (const auto& symbol : Nucleotide::SYMBOLS) {
+      EXPECT_FALSE(position_with_set_optional.isSymbolFlipped(symbol));
+      EXPECT_FALSE(deserialized_position.isSymbolFlipped(symbol));
+      if (symbol != Nucleotide::Symbol::A) {
+         EXPECT_FALSE(position_with_set_optional.isSymbolDeleted(symbol));
+         EXPECT_FALSE(deserialized_position.isSymbolDeleted(symbol));
       }
    }
 

--- a/src/silo/storage/sequence_store.cpp
+++ b/src/silo/storage/sequence_store.cpp
@@ -24,7 +24,7 @@ silo::SequenceStorePartition<SymbolType>::SequenceStorePartition(
     : reference_sequence(reference_sequence) {
    positions.reserve(reference_sequence.size());
    for (const auto symbol : reference_sequence) {
-      positions.emplace_back(Position<SymbolType>::fromInitiallyDeleted(symbol));
+      positions.emplace_back(Position<SymbolType>::fromInitiallyFlipped(symbol));
    }
 }
 

--- a/src/silo/storage/sequence_store.cpp
+++ b/src/silo/storage/sequence_store.cpp
@@ -33,6 +33,8 @@ template <typename Symbol>
 size_t silo::SequenceStorePartition<Symbol>::fill(ZstdFastaTableReader& input) {
    static constexpr size_t BUFFER_SIZE = 1024;
 
+   input.loadTable();
+
    size_t read_sequences_count = 0;
 
    std::vector<std::optional<std::string>> genome_buffer;

--- a/src/silo/storage/sequence_store.cpp
+++ b/src/silo/storage/sequence_store.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include <oneapi/tbb/blocked_range.h>
+#include <oneapi/tbb/enumerable_thread_specific.h>
 #include <oneapi/tbb/parallel_for.h>
 #include <spdlog/spdlog.h>
 #include <roaring/roaring.hh>
@@ -52,7 +53,14 @@ size_t silo::SequenceStorePartition<Symbol>::fill(ZstdFastaTableReader& input) {
       ++read_sequences_count;
    }
    interpret(genome_buffer);
-   SPDLOG_DEBUG("Sequence store partition info after filling it: {}", getInfo());
+   const SequenceStoreInfo info_before_optimisation = getInfo();
+   optimizeBitmaps();
+
+   SPDLOG_DEBUG(
+      "Sequence store partition info after filling it: {}, and after optimising: {}",
+      info_before_optimisation,
+      getInfo()
+   );
 
    return read_sequences_count;
 }
@@ -177,6 +185,27 @@ void silo::SequenceStorePartition<SymbolType>::fillNBitmaps(
          }
       }
    });
+}
+
+template <typename Symbol>
+void silo::SequenceStorePartition<Symbol>::optimizeBitmaps() {
+   tbb::enumerable_thread_specific<decltype(indexing_differences_to_reference_sequence)>
+      index_changes_to_reference;
+
+   tbb::parallel_for(tbb::blocked_range<uint32_t>(0, positions.size()), [&](const auto& local) {
+      auto& local_index_changes = index_changes_to_reference.local();
+      for (auto position = local.begin(); position != local.end(); ++position) {
+         auto symbol_changed = positions[position].deleteMostNumerousBitmap(sequence_count);
+         if (symbol_changed.has_value()) {
+            local_index_changes.emplace_back(position, *symbol_changed);
+         }
+      }
+   });
+   for (const auto& local : index_changes_to_reference) {
+      for (const auto& element : local) {
+         indexing_differences_to_reference_sequence.emplace_back(element);
+      }
+   }
 }
 
 template <typename SymbolType>

--- a/src/silo/zstdfasta/zstdfasta_table_reader.cpp
+++ b/src/silo/zstdfasta/zstdfasta_table_reader.cpp
@@ -26,8 +26,6 @@ silo::ZstdFastaTableReader::ZstdFastaTableReader(
       order_by_clause(order_by_clause),
       decompressor(std::make_unique<ZstdDecompressor>(compression_dict)) {
    SPDLOG_TRACE("Initializing ZstdFastaTableReader for table {}", table_name);
-   reset();
-   SPDLOG_TRACE("Successfully initialized ZstdFastaTableReader for table {}", table_name);
 }
 
 std::optional<std::string> silo::ZstdFastaTableReader::nextKey() {
@@ -95,7 +93,7 @@ std::string silo::ZstdFastaTableReader::getTableQuery() {
    );
 }
 
-void silo::ZstdFastaTableReader::reset() {
+void silo::ZstdFastaTableReader::loadTable() {
    try {
       query_result = connection.Query(getTableQuery());
    } catch (const std::exception& e) {

--- a/src/silo/zstdfasta/zstdfasta_table_reader.test.cpp
+++ b/src/silo/zstdfasta/zstdfasta_table_reader.test.cpp
@@ -24,6 +24,7 @@ TEST(ZstdFastaTableReader, correctlyReadsZstdFastaTableFromFastaFile) {
    silo::ZstdFastaTable::generate(connection, "test", file_reader, "ACGT");
 
    silo::ZstdFastaTableReader under_test(connection, "test", "ACGT", "sequence", "true", "");
+   under_test.loadTable();
 
    std::optional<std::string> key;
    std::optional<std::string> genome;
@@ -53,6 +54,7 @@ TEST(ZstdFastaTableReader, correctlyReadsZstdFastaTableFromZstdFastaFile) {
    silo::ZstdFastaTable::generate(connection, "test", file_reader, "ACGT");
 
    silo::ZstdFastaTableReader under_test(connection, "test", "ACGT", "sequence", "true", "");
+   under_test.loadTable();
 
    std::optional<std::string> key;
    std::optional<std::string> genome;
@@ -84,6 +86,7 @@ TEST(ZstdFastaTableReader, correctlySortsZstdFastaTableFromFastaFile) {
    silo::ZstdFastaTableReader under_test(
       connection, "test", "ACGT", "sequence", "true", "ORDER BY key desc"
    );
+   under_test.loadTable();
 
    std::optional<std::string> key;
    std::optional<std::string> genome;
@@ -115,6 +118,7 @@ TEST(ZstdFastaTableReader, correctlySortsZstdFastaTableFromZstdFastaFile) {
    silo::ZstdFastaTableReader under_test(
       connection, "test", "ACGT", "sequence", "true", "ORDER BY key desc"
    );
+   under_test.loadTable();
 
    std::optional<std::string> key;
    std::optional<std::string> genome;


### PR DESCRIPTION
The very memory efficient mode is now implemented:
The most numerous bitmap is deleted instead of flipped. When looking up values, all other bitmaps are considered instead.

A good next step would be a hybrid mode, where the deletion is only preferred over flipping, if there is substantial memory gains, as the performance impact is quite high