### PR TITLE
Optimized preprocessing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ concurrency:
 env:
   DOCKER_IMAGE_NAME: ghcr.io/GenSpectrum/LAPIS-SILO
   DOCKER_TEST_IMAGE_NAME: silo/unittests
+  DOCKER_LINTER_IMAGE_NAME: silo/linter
 
 jobs:
   formatting-check:
@@ -47,7 +48,7 @@ jobs:
           context: .
           push: false
           target: linter
-          tags: ${{ env.DOCKER_TEST_IMAGE_NAME }}
+          tags: ${{ env.DOCKER_LINTER_IMAGE_NAME }}
           cache-from: type=gha,scope=${{ github.ref_name }}-linter-image-cache
           cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-linter-image-cache
           file: Dockerfile_linter

--- a/Dockerfile_linter
+++ b/Dockerfile_linter
@@ -19,14 +19,7 @@ RUN pip install conan==2.0.17
 COPY conanfile.py conanprofile.docker ./
 RUN mv conanprofile.docker conanprofile
 
-RUN --mount=type=cache,target=/root/.conan2 \
-    conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build -s build_type=Debug \
-    && cp -R /root/.conan2 /root/.conan2_persisted && cp -R build build_persisted
-
-# Restore the cached directories as the cache mount deletes them.
-# We need this because cache mounts are not cached in GitHub Actions
-# (see https://github.com/docker/build-push-action/issues/716)
-RUN cp -R /root/.conan2_persisted /root/.conan2 && cp -R build_persisted build
+RUN conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build -s build_type=Debug
 
 COPY . ./
 

--- a/include/silo/preprocessing/preprocessing_database.h
+++ b/include/silo/preprocessing/preprocessing_database.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <filesystem>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <duckdb.hpp>
@@ -24,9 +26,11 @@ class PreprocessingDatabase {
    duckdb::Connection connection;
 
   public:
-   PreprocessingDatabase(const std::string& backing_file);
+   PreprocessingDatabase(const std::optional<std::filesystem::path>& backing_file);
 
    duckdb::Connection& getConnection();
+
+   void refreshConnection();
 
    Partitions getPartitionDescriptor();
 

--- a/include/silo/preprocessing/preprocessor.h
+++ b/include/silo/preprocessing/preprocessor.h
@@ -10,6 +10,8 @@ class PangoLineageAliasLookup;
 
 namespace preprocessing {
 
+class SequenceInfo;
+
 class Preprocessor {
    PreprocessingConfig preprocessing_config;
    config::DatabaseConfig database_config;
@@ -24,18 +26,36 @@ class Preprocessor {
    Database preprocess();
 
   private:
-   void buildTablesFromNdjsonInput(
-      const std::filesystem::path& file_name,
-      const ReferenceGenomes& reference_genomes
-   );
+   void buildTablesFromNdjsonInput(const std::filesystem::path& file_name);
    void buildMetadataTableFromFile(const std::filesystem::path& metadata_filename);
 
    void buildPartitioningTable();
    void buildPartitioningTableByColumn(const std::string& partition_by_field);
    void buildEmptyPartitioning();
 
-   void createSequenceViews(const ReferenceGenomes& reference_genomes);
-   void createPartitionedSequenceTables(const ReferenceGenomes& reference_genomes);
+   void createPartitionedSequenceTablesFromNdjson(
+      const std::filesystem::path& file_name,
+      const ReferenceGenomes& reference_genomes
+   );
+   void createAlignedPartitionedSequenceViews(
+      const std::filesystem::path& file_name,
+      const ReferenceGenomes& reference_genomes,
+      const SequenceInfo& sequence_info,
+      const std::string& partition_by_select,
+      const std::string& partition_by_where
+   );
+   void createUnalignedPartitionedSequenceFiles(
+      const std::filesystem::path& file_name,
+      const ReferenceGenomes& reference_genomes,
+      const std::string& partition_by_select,
+      const std::string& partition_by_where
+   );
+   void createUnalignedPartitionedSequenceFile(
+      const std::string& seq_name,
+      const std::string& table_sql
+   );
+
+   void createPartitionedSequenceTablesFromSequenceFiles(const ReferenceGenomes& reference_genomes);
    void createPartitionedTableForSequence(
       const std::string& sequence_name,
       const std::string& reference_sequence,
@@ -49,6 +69,24 @@ class Preprocessor {
       const std::string& order_by_clause,
       const silo::PangoLineageAliasLookup& alias_key,
       const std::filesystem::path& intermediate_results_directory
+   );
+
+   void buildMetadataStore(
+      Database& database,
+      const preprocessing::Partitions& partition_descriptor,
+      const std::string& order_by_clause
+   );
+   void buildNucleotideSequenceStore(
+      Database& database,
+      const preprocessing::Partitions& partition_descriptor,
+      const ReferenceGenomes& reference_genomes,
+      const std::string& order_by_clause
+   );
+   void buildAminoAcidSequenceStore(
+      Database& database,
+      const preprocessing::Partitions& partition_descriptor,
+      const ReferenceGenomes& reference_genomes,
+      const std::string& order_by_clause
    );
 };
 }  // namespace preprocessing

--- a/include/silo/preprocessing/sequence_info.h
+++ b/include/silo/preprocessing/sequence_info.h
@@ -25,7 +25,13 @@ class SequenceInfo {
   public:
    SequenceInfo(const silo::ReferenceGenomes& reference_genomes);
 
-   std::vector<std::string> getSequenceSelects();
+   std::vector<std::string> getAlignedSequenceSelects() const;
+
+   static std::string getNucleotideSequenceSelect(const std::string& seq_name);
+
+   static std::string getUnalignedSequenceSelect(const std::string& seq_name);
+
+   static std::string getAminoAcidSequenceSelect(const std::string& seq_name);
 
    void validate(duckdb::Connection& connection, const std::filesystem::path& input_filename) const;
 };

--- a/include/silo/storage/column/date_column.h
+++ b/include/silo/storage/column/date_column.h
@@ -36,6 +36,8 @@ class DateColumnPartition {
 
    void insertNull();
 
+   void reserve(size_t row_count);
+
    [[nodiscard]] const std::vector<silo::common::Date>& getValues() const;
 };
 

--- a/include/silo/storage/column/float_column.h
+++ b/include/silo/storage/column/float_column.h
@@ -32,6 +32,8 @@ class FloatColumnPartition {
    void insert(const std::string& value);
 
    void insertNull();
+
+   void reserve(size_t row_count);
 };
 
 class FloatColumn {

--- a/include/silo/storage/column/indexed_string_column.h
+++ b/include/silo/storage/column/indexed_string_column.h
@@ -44,6 +44,8 @@ class IndexedStringColumnPartition {
 
    void insertNull();
 
+   void reserve(size_t row_count);
+
    [[nodiscard]] const std::vector<silo::Idx>& getValues() const;
 
    [[nodiscard]] inline std::string lookupValue(Idx id) const { return lookup.getValue(id); }

--- a/include/silo/storage/column/insertion_column.h
+++ b/include/silo/storage/column/insertion_column.h
@@ -54,6 +54,8 @@ class InsertionColumnPartition {
 
    void insertNull();
 
+   void reserve(size_t row_count);
+
    void buildInsertionIndexes();
 
    const std::unordered_map<std::string, insertion::InsertionIndex<SymbolType>>&

--- a/include/silo/storage/column/int_column.h
+++ b/include/silo/storage/column/int_column.h
@@ -32,6 +32,8 @@ class IntColumnPartition {
    void insert(const std::string& value);
 
    void insertNull();
+
+   void reserve(size_t row_count);
 };
 
 class IntColumn {

--- a/include/silo/storage/column/pango_lineage_column.h
+++ b/include/silo/storage/column/pango_lineage_column.h
@@ -55,6 +55,8 @@ class PangoLineageColumnPartition {
 
    void insertNull();
 
+   void reserve(size_t row_count);
+
    std::optional<const roaring::Roaring*> filter(const common::RawPangoLineage& value) const;
 
    std::optional<const roaring::Roaring*> filterIncludingSublineages(

--- a/include/silo/storage/column/string_column.h
+++ b/include/silo/storage/column/string_column.h
@@ -38,6 +38,8 @@ class StringColumnPartition {
 
    void insertNull();
 
+   void reserve(size_t row_count);
+
    [[nodiscard]] std::optional<common::String<silo::common::STRING_SIZE>> embedString(
       const std::string& string
    ) const;

--- a/include/silo/storage/column_group.h
+++ b/include/silo/storage/column_group.h
@@ -102,6 +102,12 @@ class ColumnPartitionGroup {
       const duckdb::Value& value
    );
 
+   void reserveSpaceInColumn(
+      const std::string& column_name,
+      config::ColumnType column_type,
+      size_t row_count
+   );
+
    [[nodiscard]] ColumnPartitionGroup getSubgroup(
       const std::vector<silo::storage::ColumnMetadata>& fields
    ) const;

--- a/include/silo/storage/database_partition.h
+++ b/include/silo/storage/database_partition.h
@@ -59,9 +59,6 @@ class DatabasePartition {
       for(auto& [name, store] : aa_sequences){
          archive & store;
       }
-      for(auto& [name, store] : unaligned_nuc_sequences){
-         archive & store;
-      }
       archive & sequence_count;
       // clang-format on
    }

--- a/include/silo/storage/unaligned_sequence_store.h
+++ b/include/silo/storage/unaligned_sequence_store.h
@@ -15,22 +15,17 @@ class ZstdFastaTableReader;
 class UnalignedSequenceStorePartition {
    friend class boost::serialization::access;
 
-   template <class Archive>
-   void serialize(Archive& archive, [[maybe_unused]] const uint32_t version) {
-      archive & sequence_count;
-   }
+   std::string sql_for_reading_file;
 
   public:
-   std::filesystem::path file_name;
-   std::string& compression_dictionary;
-   uint32_t sequence_count = 0;
+   const std::string& compression_dictionary;
 
    explicit UnalignedSequenceStorePartition(
-      std::filesystem::path file_name,
-      std::string& compression_dictionary
+      std::string sql_for_reading_file,
+      const std::string& compression_dictionary
    );
 
-   size_t fill(silo::ZstdFastaTableReader& input);
+   std::string getReadSQL() const;
 };
 
 class UnalignedSequenceStore {
@@ -39,6 +34,10 @@ class UnalignedSequenceStore {
    std::filesystem::path folder_path;
    std::string compression_dictionary;
 
+  private:
+   std::filesystem::path partitionFilename(size_t partition_id) const;
+
+  public:
    void saveFolder(const std::filesystem::path& save_location) const;
 
    explicit UnalignedSequenceStore(

--- a/include/silo/zstdfasta/zstdfasta_table_reader.h
+++ b/include/silo/zstdfasta/zstdfasta_table_reader.h
@@ -56,6 +56,8 @@ class ZstdFastaTableReader {
 
    void copyTableTo(std::string_view file_name);
 
+   void copyTableToPartitioned(std::string_view file_name, std::string_view partition_key);
+
    size_t lineCount();
 };
 }  // namespace silo

--- a/src/silo/config/database_config.cpp
+++ b/src/silo/config/database_config.cpp
@@ -211,7 +211,7 @@ std::optional<DatabaseMetadata> DatabaseConfig::getMetadata(const std::string& n
 
 void DatabaseConfig::writeConfig(const std::filesystem::path& config_path) const {
    const YAML::Node node = YAML::convert<DatabaseConfig>::encode(*this);
-   SPDLOG_INFO("Writing database config to {}", config_path.string());
+   SPDLOG_DEBUG("Writing database config to {}", config_path.string());
    std::ofstream out_file(config_path);
    out_file << YAML::Dump(node);
 }

--- a/src/silo/preprocessing/metadata_info.cpp
+++ b/src/silo/preprocessing/metadata_info.cpp
@@ -176,7 +176,7 @@ std::vector<std::string> MetadataInfo::getMetadataSelects() const {
    std::vector<std::string> ret;
    ret.reserve(metadata_selects.size());
    for (const auto& [field, select] : metadata_selects) {
-      ret.push_back(fmt::format(R"({} as "{}")", select, field));
+      ret.push_back(fmt::format(R"({} AS "{}")", select, field));
    }
    return ret;
 }

--- a/src/silo/preprocessing/metadata_info.test.cpp
+++ b/src/silo/preprocessing/metadata_info.test.cpp
@@ -46,28 +46,14 @@ TEST(MetadataInfo, isValidMedataFileShouldReturnTrueWithValidMetadataFile) {
       }
    };
 
-   const silo::preprocessing::MetadataInfo fields =
-      silo::preprocessing::MetadataInfo::validateFromMetadataFile(
-         "testBaseData/exampleDataset/small_metadata_set.tsv", valid_config
-      );
-   ASSERT_TRUE(
-      std::find(
-         fields.getMetadataFields().begin(), fields.getMetadataFields().end(), "gisaid_epi_isl"
-      ) != fields.getMetadataFields().end()
-   );
-   ASSERT_TRUE(
-      std::find(
-         fields.getMetadataFields().begin(), fields.getMetadataFields().end(), "pango_lineage"
-      ) != fields.getMetadataFields().end()
-   );
-   ASSERT_TRUE(
-      std::find(fields.getMetadataFields().begin(), fields.getMetadataFields().end(), "date") !=
-      fields.getMetadataFields().end()
-   );
-   ASSERT_TRUE(
-      std::find(fields.getMetadataFields().begin(), fields.getMetadataFields().end(), "country") !=
-      fields.getMetadataFields().end()
-   );
+   const auto fields = silo::preprocessing::MetadataInfo::validateFromMetadataFile(
+                          "testBaseData/exampleDataset/small_metadata_set.tsv", valid_config
+   )
+                          .getMetadataFields();
+   ASSERT_TRUE(std::find(fields.begin(), fields.end(), R"("gisaid_epi_isl")") != fields.end());
+   ASSERT_TRUE(std::find(fields.begin(), fields.end(), R"("pango_lineage")") != fields.end());
+   ASSERT_TRUE(std::find(fields.begin(), fields.end(), R"("date")") != fields.end());
+   ASSERT_TRUE(std::find(fields.begin(), fields.end(), R"("country")") != fields.end());
 }
 
 TEST(MetadataInfo, shouldValidateCorrectNdjsonInputFile) {
@@ -85,26 +71,13 @@ TEST(MetadataInfo, shouldValidateCorrectNdjsonInputFile) {
       }
    };
 
-   const silo::preprocessing::MetadataInfo fields =
-      silo::preprocessing::MetadataInfo::validateFromNdjsonFile(
-         "testBaseData/exampleDatasetAsNdjson/input_file.ndjson", valid_config
-      );
-   ASSERT_TRUE(
-      std::find(
-         fields.getMetadataFields().begin(), fields.getMetadataFields().end(), "gisaid_epi_isl"
-      ) != fields.getMetadataFields().end()
-   );
-   ASSERT_TRUE(
-      std::find(
-         fields.getMetadataFields().begin(), fields.getMetadataFields().end(), "pango_lineage"
-      ) != fields.getMetadataFields().end()
-   );
-   ASSERT_TRUE(
-      std::find(fields.getMetadataFields().begin(), fields.getMetadataFields().end(), "date") !=
-      fields.getMetadataFields().end()
-   );
-   ASSERT_TRUE(
-      std::find(fields.getMetadataFields().begin(), fields.getMetadataFields().end(), "country") !=
-      fields.getMetadataFields().end()
-   );
+   const auto fields = silo::preprocessing::MetadataInfo::validateFromNdjsonFile(
+                          "testBaseData/exampleDatasetAsNdjson/input_file.ndjson", valid_config
+   )
+                          .getMetadataFields();
+
+   ASSERT_TRUE(std::find(fields.begin(), fields.end(), R"("gisaid_epi_isl")") != fields.end());
+   ASSERT_TRUE(std::find(fields.begin(), fields.end(), R"("pango_lineage")") != fields.end());
+   ASSERT_TRUE(std::find(fields.begin(), fields.end(), R"("date")") != fields.end());
+   ASSERT_TRUE(std::find(fields.begin(), fields.end(), R"("country")") != fields.end());
 }

--- a/src/silo/preprocessing/preprocessor.test.cpp
+++ b/src/silo/preprocessing/preprocessor.test.cpp
@@ -112,7 +112,7 @@ TEST_P(PreprocessorTestFixture, shouldProcessDataSetWithMissingSequences) {
 
    const auto database_info = database.getDatabaseInfo();
 
-   EXPECT_GT(database_info.total_size, 0);
+   EXPECT_GT(database_info.total_size, 0UL);
    EXPECT_EQ(database_info.sequence_count, scenario.expected_sequence_count);
 
    const silo::query_engine::QueryEngine query_engine(database);

--- a/src/silo/query_engine/actions/fasta.cpp
+++ b/src/silo/query_engine/actions/fasta.cpp
@@ -62,20 +62,22 @@ std::string getTableQuery(
    const DatabasePartition& database_partition,
    const std::string& key_table_name
 ) {
-   std::vector<std::filesystem::path> file_names;
-   file_names.reserve(sequence_names.size());
+   std::vector<std::filesystem::path> read_file_sqls;
+   read_file_sqls.reserve(sequence_names.size());
    for (const auto& sequence_name : sequence_names) {
-      file_names.emplace_back(database_partition.unaligned_nuc_sequences.at(sequence_name).file_name
+      read_file_sqls.emplace_back(
+         database_partition.unaligned_nuc_sequences.at(sequence_name).getReadSQL()
       );
    }
 
    std::string select_clause;
    std::string table_clause;
    std::string join_clause;
-   for (size_t idx = 0; idx < file_names.size(); idx++) {
-      const auto& file_name = file_names.at(idx);
-      select_clause += fmt::format(", t{0}.sequence as t{0}_sequence", idx);
-      table_clause += fmt::format(", '{}' t{}", file_name.string(), idx);
+   for (size_t idx = 0; idx < read_file_sqls.size(); idx++) {
+      const auto& sql_to_read_file = read_file_sqls.at(idx);
+      select_clause +=
+         fmt::format(", t{0}.unaligned_nuc_{1} as t{0}_sequence", idx, sequence_names.at(idx));
+      table_clause += fmt::format(", ({}) t{}", sql_to_read_file.string(), idx);
       join_clause += fmt::format(" AND key_table.key = t{}.key", idx);
    }
 

--- a/src/silo/storage/column/date_column.cpp
+++ b/src/silo/storage/column/date_column.cpp
@@ -19,6 +19,10 @@ void DateColumnPartition::insertNull() {
    values.push_back(common::NULL_DATE);
 }
 
+void DateColumnPartition::reserve(size_t row_count) {
+   values.reserve(values.size() + row_count);
+}
+
 const std::vector<silo::common::Date>& DateColumnPartition::getValues() const {
    return values;
 }

--- a/src/silo/storage/column/float_column.cpp
+++ b/src/silo/storage/column/float_column.cpp
@@ -25,6 +25,10 @@ void FloatColumnPartition::insertNull() {
    values.push_back(std::nan(""));
 }
 
+void FloatColumnPartition::reserve(size_t row_count) {
+   values.reserve(values.size() + row_count);
+}
+
 FloatColumn::FloatColumn() = default;
 
 FloatColumnPartition& FloatColumn::createPartition() {

--- a/src/silo/storage/column/indexed_string_column.cpp
+++ b/src/silo/storage/column/indexed_string_column.cpp
@@ -34,6 +34,10 @@ void IndexedStringColumnPartition::insertNull() {
    value_ids.push_back(value_id);
 }
 
+void IndexedStringColumnPartition::reserve(size_t row_count) {
+   value_ids.reserve(value_ids.size() + row_count);
+}
+
 const std::vector<silo::Idx>& IndexedStringColumnPartition::getValues() const {
    return this->value_ids;
 }

--- a/src/silo/storage/column/insertion_column.cpp
+++ b/src/silo/storage/column/insertion_column.cpp
@@ -118,6 +118,11 @@ void InsertionColumnPartition<SymbolType>::insertNull() {
 }
 
 template <typename SymbolType>
+void InsertionColumnPartition<SymbolType>::reserve(size_t row_count) {
+   values.reserve(values.size() + row_count);
+}
+
+template <typename SymbolType>
 void InsertionColumnPartition<SymbolType>::buildInsertionIndexes() {
    for (auto& [_, insertion_index] : insertion_indexes) {
       insertion_index.buildIndex();

--- a/src/silo/storage/column/int_column.cpp
+++ b/src/silo/storage/column/int_column.cpp
@@ -25,6 +25,10 @@ void IntColumnPartition::insertNull() {
    values.push_back(INT32_MIN);
 }
 
+void IntColumnPartition::reserve(size_t row_count) {
+   values.reserve(values.size() + row_count);
+}
+
 IntColumn::IntColumn() = default;
 
 IntColumnPartition& IntColumn::createPartition() {

--- a/src/silo/storage/column/pango_lineage_column.cpp
+++ b/src/silo/storage/column/pango_lineage_column.cpp
@@ -37,6 +37,10 @@ void PangoLineageColumnPartition::insertNull() {
    insert({""});
 }
 
+void PangoLineageColumnPartition::reserve(size_t row_count) {
+   value_ids.reserve(value_ids.size() + row_count);
+}
+
 void PangoLineageColumnPartition::insertSublineageValues(
    const common::UnaliasedPangoLineage& value,
    size_t row_number

--- a/src/silo/storage/column/string_column.cpp
+++ b/src/silo/storage/column/string_column.cpp
@@ -23,6 +23,10 @@ void StringColumnPartition::insertNull() {
    values.push_back(tmp);
 }
 
+void StringColumnPartition::reserve(size_t row_count) {
+   values.reserve(values.size() + row_count);
+}
+
 const std::vector<String<STRING_SIZE>>& StringColumnPartition::getValues() const {
    return values;
 }

--- a/src/silo/storage/column_group.cpp
+++ b/src/silo/storage/column_group.cpp
@@ -48,6 +48,11 @@ uint32_t ColumnPartitionGroup::fill(
          result->GetError()
       );
    }
+   const size_t row_count = result->RowCount();
+   for (const auto& item : database_config.schema.metadata) {
+      const auto column_type = item.getColumnType();
+      reserveSpaceInColumn(item.name, column_type, row_count);
+   }
 
    for (auto it = result->begin(); it != result->end(); ++it) {
       size_t column_index = 0;
@@ -127,6 +132,39 @@ void ColumnPartitionGroup::addValueToColumn(
          } else {
             aa_insertion_columns.at(column_name).insert(value.ToString());
          }
+         break;
+   }
+}
+
+void ColumnPartitionGroup::reserveSpaceInColumn(
+   const std::string& column_name,
+   config::ColumnType column_type,
+   size_t row_count
+) {
+   switch (column_type) {
+      case silo::config::ColumnType::INDEXED_STRING:
+         indexed_string_columns.at(column_name).reserve(row_count);
+         break;
+      case silo::config::ColumnType::STRING:
+         string_columns.at(column_name).reserve(row_count);
+         break;
+      case silo::config::ColumnType::INDEXED_PANGOLINEAGE:
+         pango_lineage_columns.at(column_name).reserve(row_count);
+         break;
+      case silo::config::ColumnType::DATE:
+         date_columns.at(column_name).reserve(row_count);
+         break;
+      case silo::config::ColumnType::INT:
+         int_columns.at(column_name).reserve(row_count);
+         break;
+      case silo::config::ColumnType::FLOAT:
+         float_columns.at(column_name).reserve(row_count);
+         break;
+      case silo::config::ColumnType::NUC_INSERTION:
+         nuc_insertion_columns.at(column_name).reserve(row_count);
+         break;
+      case silo::config::ColumnType::AA_INSERTION:
+         aa_insertion_columns.at(column_name).reserve(row_count);
          break;
    }
 }

--- a/src/silo/storage/reference_genomes.test.cpp
+++ b/src/silo/storage/reference_genomes.test.cpp
@@ -9,23 +9,23 @@ TEST(ReferenceGenome, readFromFile) {
    auto under_test =
       silo::ReferenceGenomes::readFromFile("testBaseData/exampleDataset/reference_genomes.json");
 
-   ASSERT_EQ(under_test.nucleotide_sequences.size(), 2);
-   ASSERT_EQ(under_test.aa_sequences.size(), 12);
+   ASSERT_EQ(under_test.nucleotide_sequences.size(), 2UL);
+   ASSERT_EQ(under_test.aa_sequences.size(), 12UL);
 
-   ASSERT_EQ(under_test.nucleotide_sequences.at("main").size(), 29903);
+   ASSERT_EQ(under_test.nucleotide_sequences.at("main").size(), 29903UL);
    ASSERT_EQ(under_test.nucleotide_sequences.at("main").at(0), silo::Nucleotide::Symbol::A);
 
-   ASSERT_EQ(under_test.nucleotide_sequences.at("testSecondSequence").size(), 4);
+   ASSERT_EQ(under_test.nucleotide_sequences.at("testSecondSequence").size(), 4UL);
    ASSERT_EQ(
       under_test.nucleotide_sequences.at("testSecondSequence").at(1), silo::Nucleotide::Symbol::C
    );
 
-   ASSERT_EQ(under_test.aa_sequences.at("S").size(), 1274);
+   ASSERT_EQ(under_test.aa_sequences.at("S").size(), 1274UL);
    ASSERT_EQ(under_test.aa_sequences.at("S").at(3), silo::AminoAcid::Symbol::F);
 
-   ASSERT_EQ(under_test.aa_sequences.at("ORF1a").size(), 4401);
+   ASSERT_EQ(under_test.aa_sequences.at("ORF1a").size(), 4401UL);
    ASSERT_EQ(under_test.aa_sequences.at("ORF1a").at(10), silo::AminoAcid::Symbol::K);
 
-   ASSERT_EQ(under_test.aa_sequences.at("ORF9b").size(), 98);
+   ASSERT_EQ(under_test.aa_sequences.at("ORF9b").size(), 98UL);
    ASSERT_EQ(under_test.aa_sequences.at("ORF9b").at(10), silo::AminoAcid::Symbol::A);
 }

--- a/src/silo/zstdfasta/zstdfasta_table_reader.cpp
+++ b/src/silo/zstdfasta/zstdfasta_table_reader.cpp
@@ -138,6 +138,19 @@ void silo::ZstdFastaTableReader::copyTableTo(std::string_view file_name) {
    }
 }
 
+void silo::ZstdFastaTableReader::copyTableToPartitioned(
+   std::string_view file_name,
+   std::string_view partition_key
+) {
+   query_result =
+      connection.Query(fmt::format("COPY ({}) to '{}' ;", getTableQuery(), file_name, partition_key)
+      );
+   if (query_result->HasError()) {
+      SPDLOG_ERROR("Error when executing SQL " + query_result->GetError());
+      throw preprocessing::PreprocessingException("Error when SQL " + query_result->GetError());
+   }
+}
+
 size_t silo::ZstdFastaTableReader::lineCount() {
    query_result = connection.Query(fmt::format("SELECT COUNT(*) FROM ({})", getTableQuery()));
    if (query_result->HasError()) {

--- a/src/silo_api/api.cpp
+++ b/src/silo_api/api.cpp
@@ -201,16 +201,22 @@ class SiloServer : public Poco::Util::ServerApplication {
       return Application::EXIT_OK;
    };
 
+   silo::Database runPreprocessor(
+      const silo::preprocessing::PreprocessingConfig& preprocessing_config
+   ) {
+      auto database_config = databaseConfig(config());
+
+      auto preprocessor = silo::preprocessing::Preprocessor(preprocessing_config, database_config);
+
+      return preprocessor.preprocess();
+   }
+
    int handlePreprocessing() {
       SPDLOG_INFO("Starting SILO preprocessing");
       try {
          const auto preprocessing_config = preprocessingConfig(config());
-         auto database_config = databaseConfig(config());
 
-         auto preprocessor =
-            silo::preprocessing::Preprocessor(preprocessing_config, database_config);
-
-         auto database = preprocessor.preprocess();
+         auto database = runPreprocessor(preprocessing_config);
 
          database.saveDatabaseState(preprocessing_config.getOutputDirectory());
       } catch (const std::exception& ex) {


### PR DESCRIPTION
Numerous optimizations that lead to both faster and much more memory-efficient preprocessing.

Most importantly, the unaligned sequences are now never held in memory, but directly hive-partitioned by partition_id into intermediate storage location. From there they will be copied to the save location. 

gisaid LAPIS builds now run with ~80 GB in preprocessing.

Various logging improvements during preprocessing