### PR TITLE
ci: cache linter builder and prod builder in github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ concurrency:
 env:
   DOCKER_IMAGE_NAME: ghcr.io/GenSpectrum/LAPIS-SILO
   DOCKER_TEST_IMAGE_NAME: silo/unittests
-  DOCKER_LINTER_IMAGE_NAME: silo/linter
 
 jobs:
   formatting-check:
@@ -36,22 +35,30 @@ jobs:
     name: Build And Run linter
     runs-on: ubuntu-latest
     steps:
-      -
-        uses: actions/checkout@v4
-      -
-        name: Set up Docker Buildx
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Build linter image
+
+      - name: Build linter dependencies image
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: false
+          target: linter_dependencies
+          tags: linter_dependencies
+          file: ./Dockerfile_linter
+          cache-from: type=gha,ref=linter-dependencies-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile_linter') }}
+          cache-to: type=gha,mode=min,ref=linter-dependencies-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile_linter') }}
+
+      - name: Build linter image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile_linter
           target: linter
-          tags: ${{ env.DOCKER_LINTER_IMAGE_NAME }}
-          cache-from: type=gha,scope=${{ github.ref_name }}-linter-image-cache
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-linter-image-cache
-          file: Dockerfile_linter
+          cache-from: type=gha,ref=${{ github.ref_name }}-linter-image-cache
+          cache-to: type=gha,mode=min,ref=${{ github.ref_name }}-linter-image-cache
+          push: false
 
   dockerImage:
     name: Build And Run Unit Tests
@@ -60,33 +67,45 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Build builder image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: dep_builder
+          tags: dep_builder
+          load: true
+          file: ./Dockerfile
+          cache-from: type=gha,ref=builder-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile') }}
+          cache-to: type=gha,mode=min,ref=builder-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile') }}
+
+      - name: Build unit test image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: builder
+          tags: builder
+          load: true
+          cache-from: type=gha,ref=${{ github.ref_name }}-image-cache
+          cache-to: type=gha,mode=min,ref=${{ github.ref_name }}-image-cache
+
+      - name: Run tests
+        uses: addnab/docker-run-action@v3
+        with:
+          image: builder
+          run: ./silo_test
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build unit test image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: false
-          load: true
-          target: builder
-          tags: ${{ env.DOCKER_TEST_IMAGE_NAME }}
-          cache-from: type=gha,scope=${{ github.ref_name }}-image-cache
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-image-cache
-      -
-        name: Run tests
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.DOCKER_TEST_IMAGE_NAME }}
-          run: ./silo_test
-      -
-        name: Docker metadata
+
+      - name: Docker metadata
         id: dockerMetadata
         uses: docker/metadata-action@v5
         with:
@@ -94,8 +113,8 @@ jobs:
           tags: |
             type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-      -
-        name: Build and push production image
+
+      - name: Build and push production image
         if: ${{ github.event_name == 'push' }}
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/cleanUpCaches.yml
+++ b/.github/workflows/cleanUpCaches.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     types:
       - closed
+  delete:
+
 
 # Taken from here: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
 jobs:
@@ -11,6 +13,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Run cleanup tasks of cachesl
+        run: echo "A branch was deleted, or a pull request was closed. Do cleanup caches tasks here."
 
       - name: Cleanup
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,7 @@ WORKDIR /src
 COPY conanfile.py conanprofile.docker ./
 RUN mv conanprofile.docker conanprofile
 
-RUN --mount=type=cache,target=/root/.conan2 \
-    conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build \
-    && cp -R /root/.conan2 /root/.conan2_persisted && cp -R build build_persisted
-
-# Restore the cached directories as the cache mount deletes them.
-# We need this because cache mounts are not cached in GitHub Actions
-# (see https://github.com/docker/build-push-action/issues/716)
-RUN cp -R /root/.conan2_persisted /root/.conan2 && cp -R build_persisted build
+RUN conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build
 
 FROM dep_builder AS builder
 

--- a/Dockerfile_linter
+++ b/Dockerfile_linter
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS linter
+FROM ubuntu:22.04 AS linter_dependencies
 
 WORKDIR /src
 
@@ -20,6 +20,11 @@ COPY conanfile.py conanprofile.docker ./
 RUN mv conanprofile.docker conanprofile
 
 RUN conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build -s build_type=Debug
+
+
+FROM linter_dependencies AS linter
+
+WORKDIR /src
 
 COPY . ./
 


### PR DESCRIPTION
Use a two step approach to build the linter image and the production image. This way we can cache the build of the alpine image and the conan install.