### PR TITLE
README: fix path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ decided for the approach with less maintenance effort, since it will automatical
 
 ### Running SILO locally with CLion
 
-`./run` contains run configurations for CLion that are ready to use.
+`.run` contains run configurations for CLion that are ready to use.
 They assume that you configured CMake in CLion to use `./build` as build directory.
 CLion should be able to detect those files automatically.
 


### PR DESCRIPTION
A small fix; `./.run` would be more consistent but I figured too many dots are just confusing, and the `./` is unnecessary for paths that are not executables.