### PR TITLE
Do not delete bitmaps for now

### DIFF
--- a/endToEndTests/test/info.test.js
+++ b/endToEndTests/test/info.test.js
@@ -9,7 +9,7 @@ describe('The /info endpoint', () => {
       .expect(200)
       .expect('Content-Type', 'application/json')
       .expect(headerToHaveDataVersion)
-      .expect({ nBitmapsSize: 3898, sequenceCount: 100, totalSize: 26335659 });
+      .expect({ nBitmapsSize: 3898, sequenceCount: 100, totalSize: 26589432 });
   });
 
   it('should return detailed info about the current state of the database', { timeout: 5000 }, async () => {
@@ -26,15 +26,15 @@ describe('The /info endpoint', () => {
           'bitmapContainerSizeStatistic'
         );
         expect(returnedInfo.bitmapContainerSizePerGenomeSection.bitmapContainerSizeStatistic).to.deep.equal({
-          numberOfArrayContainers: 3065,
+          numberOfArrayContainers: 48524,
           numberOfBitsetContainers: 0,
-          numberOfRunContainers: 3,
-          numberOfValuesStoredInArrayContainers: 4377,
+          numberOfRunContainers: 284,
+          numberOfValuesStoredInArrayContainers: 66620,
           numberOfValuesStoredInBitsetContainers: 0,
-          numberOfValuesStoredInRunContainers: 9,
-          totalBitmapSizeArrayContainers: 8754,
+          numberOfValuesStoredInRunContainers: 2875,
+          totalBitmapSizeArrayContainers: 133240,
           totalBitmapSizeBitsetContainers: 0,
-          totalBitmapSizeRunContainers: 18,
+          totalBitmapSizeRunContainers: 4824,
         });
 
         expect(returnedInfo.bitmapContainerSizePerGenomeSection).to.have.property(
@@ -61,19 +61,19 @@ describe('The /info endpoint', () => {
 
         expect(returnedInfo).to.have.property('bitmapSizePerSymbol');
         expect(returnedInfo.bitmapSizePerSymbol).to.deep.equal({
-          '-': 2648220,
-          'A': 2635348,
+          '-': 2661831,
+          'A': 2775910,
           'B': 2631464,
-          'C': 2634362,
+          'C': 2725728,
           'D': 2631464,
-          'G': 2633570,
+          'G': 2728118,
           'H': 2631464,
           'K': 2631594,
           'M': 2631554,
           'N': 2631464,
           'R': 2631514,
           'S': 2631464,
-          'T': 2638765,
+          'T': 2791923,
           'V': 2631464,
           'W': 2631514,
           'Y': 2631494,

--- a/src/silo/database.test.cpp
+++ b/src/silo/database.test.cpp
@@ -72,10 +72,10 @@ TEST(DatabaseTest, shouldReturnCorrectDatabaseInfo) {
    const auto simple_info = database.getDatabaseInfo();
 
    EXPECT_EQ(
-      detailed_info.bitmap_size_per_symbol.size_in_bytes.at(silo::Nucleotide::Symbol::A), 2635348
+      detailed_info.bitmap_size_per_symbol.size_in_bytes.at(silo::Nucleotide::Symbol::A), 2775910
    );
    EXPECT_EQ(
-      detailed_info.bitmap_size_per_symbol.size_in_bytes.at(silo::Nucleotide::Symbol::GAP), 2648220
+      detailed_info.bitmap_size_per_symbol.size_in_bytes.at(silo::Nucleotide::Symbol::GAP), 2661831
    );
 
    EXPECT_EQ(
@@ -86,7 +86,7 @@ TEST(DatabaseTest, shouldReturnCorrectDatabaseInfo) {
    EXPECT_EQ(
       detailed_info.bitmap_container_size_per_genome_section.bitmap_container_size_statistic
          .number_of_values_stored_in_run_containers,
-      9
+      2875
    );
    EXPECT_EQ(
       detailed_info.bitmap_container_size_per_genome_section.bitmap_container_size_statistic
@@ -95,18 +95,18 @@ TEST(DatabaseTest, shouldReturnCorrectDatabaseInfo) {
    );
 
    EXPECT_EQ(
-      detailed_info.bitmap_container_size_per_genome_section.total_bitmap_size_computed, 42136719
+      detailed_info.bitmap_container_size_per_genome_section.total_bitmap_size_computed, 42629964
    );
    EXPECT_EQ(
-      detailed_info.bitmap_container_size_per_genome_section.total_bitmap_size_frozen, 21075818
+      detailed_info.bitmap_container_size_per_genome_section.total_bitmap_size_frozen, 21433248
    );
    EXPECT_EQ(
       detailed_info.bitmap_container_size_per_genome_section.bitmap_container_size_statistic
          .total_bitmap_size_array_containers,
-      8754
+      133240
    );
 
-   EXPECT_EQ(simple_info.total_size, 26335659);
+   EXPECT_EQ(simple_info.total_size, 26589432);
    EXPECT_EQ(simple_info.sequence_count, 100);
    EXPECT_EQ(simple_info.n_bitmaps_size, 3898);
 }

--- a/src/silo/storage/sequence_store.cpp
+++ b/src/silo/storage/sequence_store.cpp
@@ -197,7 +197,7 @@ void silo::SequenceStorePartition<Symbol>::optimizeBitmaps() {
    tbb::parallel_for(tbb::blocked_range<uint32_t>(0, positions.size()), [&](const auto& local) {
       auto& local_index_changes = index_changes_to_reference.local();
       for (auto position = local.begin(); position != local.end(); ++position) {
-         auto symbol_changed = positions[position].deleteMostNumerousBitmap(sequence_count);
+         auto symbol_changed = positions[position].flipMostNumerousBitmap(sequence_count);
          if (symbol_changed.has_value()) {
             local_index_changes.emplace_back(position, *symbol_changed);
          }


### PR DESCRIPTION
For now, this will increase preprocessing size. But only after the current maximum spike in memory usage