### PR TITLE
Optional optimization of disjoint Unions under NOf queries

### DIFF
--- a/include/silo/query_engine/filter_expressions/expression.h
+++ b/include/silo/query_engine/filter_expressions/expression.h
@@ -1,9 +1,14 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
+#include <variant>
 
 #include <nlohmann/json_fwd.hpp>
+
+#include "silo/common/aa_symbols.h"
+#include "silo/common/nucleotide_symbols.h"
 
 namespace silo::query_engine::operators {
 struct Operator;
@@ -14,6 +19,12 @@ struct DatabasePartition;
 }  // namespace silo
 
 namespace silo::query_engine::filter_expressions {
+
+struct PositionalFilter {
+   std::optional<std::string> sequence_name;
+   uint32_t position;
+   std::variant<Nucleotide::Symbol, AminoAcid::Symbol> symbol;
+};
 
 struct Expression {
    /// UPPER_BOUND returns the upper bound of sequences matching this expression (i.e. ambiguous
@@ -32,6 +43,14 @@ struct Expression {
       const DatabasePartition& database_partition,
       AmbiguityMode mode
    ) const = 0;
+
+   static std::optional<PositionalFilter> isPositionalFilterForSymbol(
+      const std::unique_ptr<Expression>& expression
+   );
+
+   static std::optional<PositionalFilter> isNegatedPositionalFilterForSymbol(
+      const std::unique_ptr<Expression>& expression
+   );
 };
 
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/include/silo/query_engine/filter_expressions/nof.h
+++ b/include/silo/query_engine/filter_expressions/nof.h
@@ -27,6 +27,7 @@ struct NOf : public Expression {
    std::vector<std::unique_ptr<Expression>> children;
    int number_of_matchers;
    bool match_exactly;
+   bool optimize_disjoint_unions;
 
    std::tuple<
       std::vector<std::unique_ptr<operators::Operator>>,
@@ -49,6 +50,13 @@ struct NOf : public Expression {
       std::vector<std::unique_ptr<Expression>>&& children,
       int number_of_matchers,
       bool match_exactly
+   );
+
+   explicit NOf(
+      std::vector<std::unique_ptr<Expression>>&& children,
+      int number_of_matchers,
+      bool match_exactly,
+      bool optimize_disjoint_unions
    );
 
    std::string toString() const override;

--- a/include/silo/query_engine/operators/intersection.h
+++ b/include/silo/query_engine/operators/intersection.h
@@ -36,6 +36,8 @@ class Intersection : public Operator {
 
    [[nodiscard]] Type type() const override;
 
+   bool isNegatedDisjointUnion() const;
+
    virtual OperatorResult evaluate() const override;
 
    static std::unique_ptr<Operator> negate(std::unique_ptr<Intersection>&& intersection);

--- a/include/silo/query_engine/operators/union.h
+++ b/include/silo/query_engine/operators/union.h
@@ -31,6 +31,8 @@ class Union : public Operator {
 
    [[nodiscard]] Type type() const override;
 
+   bool isDisjointUnion() const;
+
    virtual OperatorResult evaluate() const override;
 
    static std::unique_ptr<Operator> negate(std::unique_ptr<Union>&& union_operator);

--- a/src/silo/query_engine/filter_expressions/expression.cpp
+++ b/src/silo/query_engine/filter_expressions/expression.cpp
@@ -99,4 +99,37 @@ void from_json(const nlohmann::json& json, std::unique_ptr<Expression>& filter) 
    }
 }
 
+std::optional<PositionalFilter> Expression::isPositionalFilterForSymbol(
+   const std::unique_ptr<Expression>& expression
+) {
+   if (dynamic_cast<filter_expressions::SymbolEquals<Nucleotide>*>(expression.get()) != nullptr) {
+      auto* symbol_equals =
+         dynamic_cast<filter_expressions::SymbolEquals<Nucleotide>*>(expression.get());
+      if (symbol_equals->value.has_value()) {
+         return PositionalFilter{
+            symbol_equals->sequence_name, symbol_equals->position_idx, *symbol_equals->value
+         };
+      }
+   } else if (dynamic_cast<filter_expressions::SymbolEquals<AminoAcid>*>(expression.get()) != nullptr) {
+      auto* symbol_equals =
+         dynamic_cast<filter_expressions::SymbolEquals<AminoAcid>*>(expression.get());
+      if (symbol_equals->value.has_value()) {
+         return PositionalFilter{
+            symbol_equals->sequence_name, symbol_equals->position_idx, *symbol_equals->value
+         };
+      }
+   }
+   return std::nullopt;
+}
+
+std::optional<PositionalFilter> Expression::isNegatedPositionalFilterForSymbol(
+   const std::unique_ptr<Expression>& expression
+) {
+   if (dynamic_cast<filter_expressions::Negation*>(expression.get()) != nullptr) {
+      auto* negation = dynamic_cast<filter_expressions::Negation*>(expression.get());
+      return isPositionalFilterForSymbol(negation->child);
+   }
+   return std::nullopt;
+}
+
 }  // namespace silo::query_engine::filter_expressions

--- a/src/silo/query_engine/operators/union.cpp
+++ b/src/silo/query_engine/operators/union.cpp
@@ -1,14 +1,19 @@
 #include "silo/query_engine/operators/union.h"
 
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include <roaring/roaring.hh>
 
+#include "silo/query_engine/filter_expressions/expression.h"
 #include "silo/query_engine/operator_result.h"
 #include "silo/query_engine/operators/complement.h"
 #include "silo/query_engine/operators/operator.h"
+
+using silo::query_engine::filter_expressions::Expression;
+using silo::query_engine::filter_expressions::PositionalFilter;
 
 namespace silo::query_engine::operators {
 
@@ -30,6 +35,42 @@ std::string Union::toString() const {
 
 Type Union::type() const {
    return UNION;
+}
+
+bool Union::isDisjointUnion() const {
+   assert(!children.empty());
+   if (std::any_of(children.begin(), children.end(), [](auto& child) {
+          return child->logicalEquivalent() == std::nullopt;
+       })) {
+      return false;
+   }
+   const std::optional<PositionalFilter> matching_positional_for_all_children =
+      Expression::isPositionalFilterForSymbol(*children.at(0)->logicalEquivalent());
+   if (matching_positional_for_all_children == std::nullopt) {
+      return false;
+   }
+   const auto sequence_name = matching_positional_for_all_children->sequence_name;
+   const uint32_t position = matching_positional_for_all_children->position;
+   const bool is_nucleotide =
+      holds_alternative<Nucleotide::Symbol>(matching_positional_for_all_children->symbol);
+   std::set<Nucleotide::Symbol> nuc_symbols;
+   std::set<AminoAcid::Symbol> aa_symbols;
+   const bool all_positional_filters_for_same_position =
+      std::all_of(children.begin(), children.end(), [&](auto& child) {
+         auto test = Expression::isPositionalFilterForSymbol(*child->logicalEquivalent());
+         if (test == std::nullopt) {
+            return false;
+         }
+         if (holds_alternative<Nucleotide::Symbol>(test->symbol)) {
+            nuc_symbols.insert(std::get<Nucleotide::Symbol>(test->symbol));
+         } else {
+            aa_symbols.insert(std::get<AminoAcid::Symbol>(test->symbol));
+         }
+         return test->sequence_name == sequence_name && test->position == position &&
+                holds_alternative<Nucleotide::Symbol>(test->symbol) == is_nucleotide;
+      });
+   return all_positional_filters_for_same_position &&
+          (nuc_symbols.size() == children.size() || aa_symbols.size() == children.size());
 }
 
 OperatorResult Union::evaluate() const {


### PR DESCRIPTION
Resolves #308 

### Summary
removed filter::toString unneeded parameter
Operator::negate rewrite which reduces the number of required dynamic memory allocations and removes one method per Operator
IndexScan and BitmapFilters now preserve their logically equivalent filter and debug print it
The logical equivalent filter expression are used to detect disjoint unions
disjoint unions under an NOf can be simplified by collapsiong the union to the NOf

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
Only internals changed, no API alteration
- [ ] The implemented feature is covered by an appropriate test.
Only one test for now, hard to test, as the filter optimization requires a database in the backgroud.


Draft PR for now, to test whether this changes the performance on the test suite that @JonasKellerer ran
