### PR TITLE
Refactor query engine utilities

### DIFF
--- a/include/silo/database.h
+++ b/include/silo/database.h
@@ -62,8 +62,6 @@ class Database {
 
    [[nodiscard]] virtual DetailedDatabaseInfo detailedDatabaseInfo() const;
 
-   [[nodiscard]] const PangoLineageAliasLookup& getAliasKey() const;
-
    void setDataVersion(const DataVersion& data_version);
    virtual DataVersion getDataVersion() const;
 

--- a/include/silo/query_engine/filter_expressions/and.h
+++ b/include/silo/query_engine/filter_expressions/and.h
@@ -40,7 +40,7 @@ struct And : public Expression {
   public:
    explicit And(std::vector<std::unique_ptr<Expression>>&& children);
 
-   std::string toString(const silo::Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/date_between.h
+++ b/include/silo/query_engine/filter_expressions/date_between.h
@@ -51,7 +51,7 @@ struct DateBetween : public Expression {
       std::optional<silo::common::Date> date_to
    );
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/exact.h
+++ b/include/silo/query_engine/filter_expressions/exact.h
@@ -23,7 +23,7 @@ class Exact : public Expression {
   public:
    explicit Exact(std::unique_ptr<Expression> child);
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/expression.h
+++ b/include/silo/query_engine/filter_expressions/expression.h
@@ -25,7 +25,7 @@ struct Expression {
    Expression();
    virtual ~Expression() = default;
 
-   virtual std::string toString(const silo::Database& database) const = 0;
+   virtual std::string toString() const = 0;
 
    [[nodiscard]] virtual std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/false.h
+++ b/include/silo/query_engine/filter_expressions/false.h
@@ -23,7 +23,7 @@ namespace silo::query_engine::filter_expressions {
 struct False : public Expression {
    explicit False();
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/float_between.h
+++ b/include/silo/query_engine/filter_expressions/float_between.h
@@ -30,7 +30,7 @@ class FloatBetween : public Expression {
   public:
    explicit FloatBetween(std::string column, std::optional<double> from, std::optional<double> to);
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/float_equals.h
+++ b/include/silo/query_engine/filter_expressions/float_equals.h
@@ -28,7 +28,7 @@ class FloatEquals : public Expression {
   public:
    FloatEquals(std::string column, double value);
 
-   std::string toString(const silo::Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/has_mutation.h
+++ b/include/silo/query_engine/filter_expressions/has_mutation.h
@@ -30,7 +30,7 @@ struct HasMutation : public Expression {
   public:
    explicit HasMutation(std::optional<std::string> sequence_name, uint32_t position_idx);
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/insertion_contains.h
+++ b/include/silo/query_engine/filter_expressions/insertion_contains.h
@@ -36,7 +36,7 @@ struct InsertionContains : public Expression {
       std::string value
    );
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/int_between.h
+++ b/include/silo/query_engine/filter_expressions/int_between.h
@@ -35,7 +35,7 @@ struct IntBetween : public Expression {
       std::optional<uint32_t> to
    );
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/int_equals.h
+++ b/include/silo/query_engine/filter_expressions/int_equals.h
@@ -28,7 +28,7 @@ struct IntEquals : public Expression {
   public:
    explicit IntEquals(std::string column, uint32_t value);
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/maybe.h
+++ b/include/silo/query_engine/filter_expressions/maybe.h
@@ -22,7 +22,7 @@ struct Maybe : public Expression {
 
    explicit Maybe(std::unique_ptr<Expression> child);
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/negation.h
+++ b/include/silo/query_engine/filter_expressions/negation.h
@@ -21,13 +21,15 @@ struct Database;
 namespace silo::query_engine::filter_expressions {
 
 class Negation : public Expression {
+   friend class Expression;
+
   private:
    std::unique_ptr<Expression> child;
 
   public:
    explicit Negation(std::unique_ptr<Expression> child);
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/nof.h
+++ b/include/silo/query_engine/filter_expressions/nof.h
@@ -51,7 +51,7 @@ struct NOf : public Expression {
       bool match_exactly
    );
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/or.h
+++ b/include/silo/query_engine/filter_expressions/or.h
@@ -26,7 +26,7 @@ struct Or : public Expression {
   public:
    Or(std::vector<std::unique_ptr<Expression>>&& children);
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/pango_lineage_filter.h
+++ b/include/silo/query_engine/filter_expressions/pango_lineage_filter.h
@@ -31,7 +31,7 @@ struct PangoLineageFilter : public Expression {
       bool include_sublineages
    );
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/string_equals.h
+++ b/include/silo/query_engine/filter_expressions/string_equals.h
@@ -27,7 +27,7 @@ struct StringEquals : public Expression {
   public:
    explicit StringEquals(std::string column, std::string value);
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/symbol_equals.h
+++ b/include/silo/query_engine/filter_expressions/symbol_equals.h
@@ -36,7 +36,7 @@ struct SymbolEquals : public Expression {
       std::optional<typename SymbolType::Symbol> value
    );
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/filter_expressions/true.h
+++ b/include/silo/query_engine/filter_expressions/true.h
@@ -22,7 +22,7 @@ namespace silo::query_engine::filter_expressions {
 struct True : public Expression {
    explicit True();
 
-   std::string toString(const Database& database) const override;
+   std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<silo::query_engine::operators::Operator> compile(
       const Database& database,

--- a/include/silo/query_engine/operators/bitmap_producer.h
+++ b/include/silo/query_engine/operators/bitmap_producer.h
@@ -26,9 +26,7 @@ class BitmapProducer : public Operator {
 
    virtual std::string toString() const override;
 
-   virtual std::unique_ptr<Operator> copy() const override;
-
-   virtual std::unique_ptr<Operator> negate() const override;
+   static std::unique_ptr<Operator> negate(std::unique_ptr<BitmapProducer>&& bitmap_producer);
 };
 
 }  // namespace silo::query_engine::operators

--- a/include/silo/query_engine/operators/bitmap_selection.h
+++ b/include/silo/query_engine/operators/bitmap_selection.h
@@ -11,13 +11,21 @@ namespace roaring {
 class Roaring;
 }  // namespace roaring
 
+namespace silo::query_engine::filter_expressions {
+class Expression;
+}  // namespace silo::query_engine::filter_expressions
+
 namespace silo::query_engine::operators {
 
 class BitmapSelection : public Operator {
+   friend class Operator;
+
   public:
    enum Comparator { CONTAINS, NOT_CONTAINS };
 
   private:
+   std::optional<std::unique_ptr<silo::query_engine::filter_expressions::Expression>>
+      logical_equivalent;
    const roaring::Roaring* bitmaps;
    uint32_t row_count;
    Comparator comparator;
@@ -25,6 +33,14 @@ class BitmapSelection : public Operator {
 
   public:
    explicit BitmapSelection(
+      const roaring::Roaring* bitmaps,
+      uint32_t row_count,
+      Comparator comparator,
+      uint32_t value
+   );
+
+   explicit BitmapSelection(
+      std::unique_ptr<silo::query_engine::filter_expressions::Expression>&& logical_equivalent,
       const roaring::Roaring* bitmaps,
       uint32_t row_count,
       Comparator comparator,
@@ -39,9 +55,7 @@ class BitmapSelection : public Operator {
 
    virtual std::string toString() const override;
 
-   virtual std::unique_ptr<Operator> copy() const override;
-
-   virtual std::unique_ptr<Operator> negate() const override;
+   static std::unique_ptr<Operator> negate(std::unique_ptr<BitmapSelection>&& bitmap_selection);
 };
 
 }  // namespace silo::query_engine::operators

--- a/include/silo/query_engine/operators/complement.h
+++ b/include/silo/query_engine/operators/complement.h
@@ -11,6 +11,8 @@
 namespace silo::query_engine::operators {
 
 class Complement : public Operator {
+   friend class Operator;
+
    std::unique_ptr<Operator> child;
    uint32_t row_count;
 
@@ -30,9 +32,7 @@ class Complement : public Operator {
 
    virtual std::string toString() const override;
 
-   virtual std::unique_ptr<Operator> copy() const override;
-
-   virtual std::unique_ptr<Operator> negate() const override;
+   static std::unique_ptr<Operator> negate(std::unique_ptr<Complement>&& complement);
 };
 
 }  // namespace silo::query_engine::operators

--- a/include/silo/query_engine/operators/empty.h
+++ b/include/silo/query_engine/operators/empty.h
@@ -24,9 +24,7 @@ class Empty : public Operator {
 
    virtual std::string toString() const override;
 
-   virtual std::unique_ptr<Operator> copy() const override;
-
-   virtual std::unique_ptr<Operator> negate() const override;
+   static std::unique_ptr<Operator> negate(std::unique_ptr<Empty>&& empty);
 };
 
 }  // namespace silo::query_engine::operators

--- a/include/silo/query_engine/operators/full.h
+++ b/include/silo/query_engine/operators/full.h
@@ -23,9 +23,7 @@ class Full : public Operator {
 
    virtual std::string toString() const override;
 
-   virtual std::unique_ptr<Operator> copy() const override;
-
-   virtual std::unique_ptr<Operator> negate() const override;
+   static std::unique_ptr<Operator> negate(std::unique_ptr<Full>&& full_operator);
 };
 
 }  // namespace silo::query_engine::operators

--- a/include/silo/query_engine/operators/index_scan.h
+++ b/include/silo/query_engine/operators/index_scan.h
@@ -11,15 +11,28 @@ namespace roaring {
 class Roaring;
 }  // namespace roaring
 
+namespace silo::query_engine::filter_expressions {
+class Expression;
+}  // namespace silo::query_engine::filter_expressions
+
 namespace silo::query_engine::operators {
 
 class IndexScan : public Operator {
+   friend class Operator;
+
   private:
+   std::optional<std::unique_ptr<query_engine::filter_expressions::Expression>> logical_equivalent;
    const roaring::Roaring* bitmap;
    uint32_t row_count;
 
   public:
    explicit IndexScan(const roaring::Roaring* bitmap, uint32_t row_count);
+
+   explicit IndexScan(
+      std::unique_ptr<query_engine::filter_expressions::Expression>&& logical_equivalent,
+      const roaring::Roaring* bitmap,
+      uint32_t row_count
+   );
 
    ~IndexScan() noexcept override;
 
@@ -29,9 +42,7 @@ class IndexScan : public Operator {
 
    virtual std::string toString() const override;
 
-   virtual std::unique_ptr<Operator> copy() const override;
-
-   virtual std::unique_ptr<Operator> negate() const override;
+   static std::unique_ptr<Operator> negate(std::unique_ptr<IndexScan>&& index_scan);
 };
 
 }  // namespace silo::query_engine::operators

--- a/include/silo/query_engine/operators/intersection.h
+++ b/include/silo/query_engine/operators/intersection.h
@@ -10,12 +10,14 @@
 
 namespace silo::query_engine::filter_expressions {
 class And;
-}
+class NOf;
+}  // namespace silo::query_engine::filter_expressions
 
 namespace silo::query_engine::operators {
 
 class Intersection : public Operator {
    friend class silo::query_engine::filter_expressions::And;
+   friend class silo::query_engine::filter_expressions::NOf;
 
    std::vector<std::unique_ptr<Operator>> children;
    std::vector<std::unique_ptr<Operator>> negated_children;
@@ -30,15 +32,13 @@ class Intersection : public Operator {
 
    ~Intersection() noexcept override;
 
+   virtual std::string toString() const override;
+
    [[nodiscard]] Type type() const override;
 
    virtual OperatorResult evaluate() const override;
 
-   virtual std::string toString() const override;
-
-   virtual std::unique_ptr<Operator> copy() const override;
-
-   virtual std::unique_ptr<Operator> negate() const override;
+   static std::unique_ptr<Operator> negate(std::unique_ptr<Intersection>&& intersection);
 };
 
 }  // namespace silo::query_engine::operators

--- a/include/silo/query_engine/operators/operator.h
+++ b/include/silo/query_engine/operators/operator.h
@@ -1,9 +1,14 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "silo/query_engine/operator_result.h"
+
+namespace silo::query_engine::filter_expressions {
+class Expression;
+}
 
 namespace silo::query_engine::operators {
 
@@ -33,9 +38,9 @@ class Operator {
 
    virtual std::string toString() const = 0;
 
-   virtual std::unique_ptr<Operator> copy() const = 0;
+   virtual std::optional<std::unique_ptr<filter_expressions::Expression>> logicalEquivalent() const;
 
-   virtual std::unique_ptr<Operator> negate() const = 0;
+   static std::unique_ptr<Operator> negate(std::unique_ptr<Operator>&& some_operator);
 };
 
 }  // namespace silo::query_engine::operators

--- a/include/silo/query_engine/operators/range_selection.h
+++ b/include/silo/query_engine/operators/range_selection.h
@@ -34,9 +34,7 @@ class RangeSelection : public Operator {
 
    virtual std::string toString() const override;
 
-   virtual std::unique_ptr<Operator> copy() const override;
-
-   virtual std::unique_ptr<Operator> negate() const override;
+   static std::unique_ptr<Operator> negate(std::unique_ptr<RangeSelection>&& range_selection);
 };
 
 }  // namespace silo::query_engine::operators

--- a/include/silo/query_engine/operators/selection.h
+++ b/include/silo/query_engine/operators/selection.h
@@ -76,9 +76,7 @@ class Selection : public Operator {
 
    virtual std::string toString() const override;
 
-   virtual std::unique_ptr<Operator> copy() const override;
-
-   virtual std::unique_ptr<Operator> negate() const override;
+   static std::unique_ptr<Operator> negate(std::unique_ptr<Selection>&& selection);
 
   private:
    virtual bool matchesPredicates(uint32_t row) const;

--- a/include/silo/query_engine/operators/threshold.h
+++ b/include/silo/query_engine/operators/threshold.h
@@ -35,9 +35,7 @@ class Threshold : public Operator {
 
    virtual std::string toString() const override;
 
-   virtual std::unique_ptr<Operator> copy() const override;
-
-   virtual std::unique_ptr<Operator> negate() const override;
+   static std::unique_ptr<Operator> negate(std::unique_ptr<Threshold>&& threshold);
 };
 
 }  // namespace silo::query_engine::operators

--- a/include/silo/query_engine/operators/union.h
+++ b/include/silo/query_engine/operators/union.h
@@ -10,12 +10,15 @@
 
 namespace silo::query_engine::filter_expressions {
 class Or;
+class NOf;
 }  // namespace silo::query_engine::filter_expressions
 
 namespace silo::query_engine::operators {
 
 class Union : public Operator {
    friend class silo::query_engine::filter_expressions::Or;
+   friend class silo::query_engine::filter_expressions::NOf;
+
    std::vector<std::unique_ptr<Operator>> children;
    uint32_t row_count;
 
@@ -24,15 +27,13 @@ class Union : public Operator {
 
    ~Union() noexcept override;
 
+   virtual std::string toString() const override;
+
    [[nodiscard]] Type type() const override;
 
    virtual OperatorResult evaluate() const override;
 
-   virtual std::string toString() const override;
-
-   virtual std::unique_ptr<Operator> copy() const override;
-
-   virtual std::unique_ptr<Operator> negate() const override;
+   static std::unique_ptr<Operator> negate(std::unique_ptr<Union>&& union_operator);
 };
 
 }  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/filter_expressions/and.cpp
+++ b/src/silo/query_engine/filter_expressions/and.cpp
@@ -33,13 +33,13 @@ using operators::Operator;
 And::And(std::vector<std::unique_ptr<Expression>>&& children)
     : children(std::move(children)) {}
 
-std::string And::toString(const silo::Database& database) const {
+std::string And::toString() const {
    std::vector<std::string> child_strings;
    std::transform(
       children.begin(),
       children.end(),
       std::back_inserter(child_strings),
-      [&](const std::unique_ptr<Expression>& child) { return child->toString(database); }
+      [&](const std::unique_ptr<Expression>& child) { return child->toString(); }
    );
    return "And(" + boost::algorithm::join(child_strings, " & ") + ")";
 }
@@ -134,7 +134,7 @@ std::tuple<OperatorVector, OperatorVector, std::vector<std::unique_ptr<operators
          appendVectorToVector(intersection_child->children, non_negated_child_operators);
          appendVectorToVector(intersection_child->negated_children, negated_child_operators);
       } else if (child->type() == operators::COMPLEMENT) {
-         negated_child_operators.emplace_back(child->negate());
+         negated_child_operators.emplace_back(operators::Operator::negate(std::move(child)));
       } else if (child->type() == operators::SELECTION) {
          auto* selection_child = dynamic_cast<operators::Selection*>(child.get());
          appendVectorToVector<operators::Predicate>(selection_child->predicates, predicates);

--- a/src/silo/query_engine/filter_expressions/date_between.cpp
+++ b/src/silo/query_engine/filter_expressions/date_between.cpp
@@ -30,7 +30,7 @@ DateBetween::DateBetween(
       date_from(date_from),
       date_to(date_to) {}
 
-std::string DateBetween::toString(const silo::Database& /*database*/) const {
+std::string DateBetween::toString() const {
    std::string res = "[Date-between ";
    res +=
       (date_from.has_value() ? silo::common::dateToString(date_from.value()).value_or("")

--- a/src/silo/query_engine/filter_expressions/exact.cpp
+++ b/src/silo/query_engine/filter_expressions/exact.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 
+#include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
 #include "silo/query_engine/filter_expressions/expression.h"
@@ -20,8 +21,8 @@ namespace silo::query_engine::filter_expressions {
 Exact::Exact(std::unique_ptr<Expression> child)
     : child(std::move(child)) {}
 
-std::string Exact::toString(const silo::Database& database) const {
-   return "Exact ( " + child->toString(database) + ")";
+std::string Exact::toString() const {
+   return fmt::format("Exact ({})", child->toString());
 }
 std::unique_ptr<silo::query_engine::operators::Operator> Exact::compile(
    const silo::Database& database,

--- a/src/silo/query_engine/filter_expressions/false.cpp
+++ b/src/silo/query_engine/filter_expressions/false.cpp
@@ -16,7 +16,7 @@ namespace silo::query_engine::filter_expressions {
 
 False::False() = default;
 
-std::string False::toString(const silo::Database& /*database*/) const {
+std::string False::toString() const {
    return "False";
 }
 

--- a/src/silo/query_engine/filter_expressions/float_between.cpp
+++ b/src/silo/query_engine/filter_expressions/float_between.cpp
@@ -24,7 +24,7 @@ FloatBetween::FloatBetween(std::string column, std::optional<double> from, std::
       from(from),
       to(to) {}
 
-std::string FloatBetween::toString(const silo::Database& /*database*/) const {
+std::string FloatBetween::toString() const {
    const auto from_string = from.has_value() ? std::to_string(from.value()) : "unbounded";
    const auto to_string = to.has_value() ? std::to_string(to.value()) : "unbounded";
 

--- a/src/silo/query_engine/filter_expressions/float_equals.cpp
+++ b/src/silo/query_engine/filter_expressions/float_equals.cpp
@@ -25,7 +25,7 @@ FloatEquals::FloatEquals(std::string column, double value)
     : column(std::move(column)),
       value(value) {}
 
-std::string FloatEquals::toString(const silo::Database& /*database*/) const {
+std::string FloatEquals::toString() const {
    return column + " = '" + std::to_string(value) + "'";
 }
 

--- a/src/silo/query_engine/filter_expressions/has_mutation.cpp
+++ b/src/silo/query_engine/filter_expressions/has_mutation.cpp
@@ -31,7 +31,7 @@ HasMutation<SymbolType>::HasMutation(
       position_idx(position_idx) {}
 
 template <typename SymbolType>
-std::string HasMutation<SymbolType>::toString(const silo::Database& /*database*/) const {
+std::string HasMutation<SymbolType>::toString() const {
    const std::string sequence_name_prefix = sequence_name ? sequence_name.value() + ":" : "";
    return sequence_name_prefix + std::to_string(position_idx);
 }

--- a/src/silo/query_engine/filter_expressions/insertion_contains.cpp
+++ b/src/silo/query_engine/filter_expressions/insertion_contains.cpp
@@ -50,7 +50,7 @@ std::string getColumnNamesString(
 }
 
 template <typename SymbolType>
-std::string InsertionContains<SymbolType>::toString(const silo::Database& /*database*/) const {
+std::string InsertionContains<SymbolType>::toString() const {
    const std::string symbol_name = std::string(SymbolType::SYMBOL_NAME);
    const std::string sequence_string = sequence_name
                                           ? "The sequence '" + sequence_name.value() + "'"

--- a/src/silo/query_engine/filter_expressions/int_between.cpp
+++ b/src/silo/query_engine/filter_expressions/int_between.cpp
@@ -24,7 +24,7 @@ IntBetween::IntBetween(std::string column, std::optional<uint32_t> from, std::op
       from(from),
       to(to) {}
 
-std::string IntBetween::toString(const silo::Database& /*database*/) const {
+std::string IntBetween::toString() const {
    const auto from_string = from.has_value() ? std::to_string(from.value()) : "unbounded";
    const auto to_string = to.has_value() ? std::to_string(to.value()) : "unbounded";
 

--- a/src/silo/query_engine/filter_expressions/int_equals.cpp
+++ b/src/silo/query_engine/filter_expressions/int_equals.cpp
@@ -23,7 +23,7 @@ IntEquals::IntEquals(std::string column, uint32_t value)
     : column(std::move(column)),
       value(value) {}
 
-std::string IntEquals::toString(const silo::Database& /*database*/) const {
+std::string IntEquals::toString() const {
    return column + " = '" + std::to_string(value) + "'";
 }
 

--- a/src/silo/query_engine/filter_expressions/maybe.cpp
+++ b/src/silo/query_engine/filter_expressions/maybe.cpp
@@ -20,8 +20,8 @@ namespace silo::query_engine::filter_expressions {
 Maybe::Maybe(std::unique_ptr<Expression> child)
     : child(std::move(child)) {}
 
-std::string Maybe::toString(const silo::Database& database) const {
-   return "Maybe (" + child->toString(database) + ")";
+std::string Maybe::toString() const {
+   return "Maybe (" + child->toString() + ")";
 }
 std::unique_ptr<silo::query_engine::operators::Operator> Maybe::compile(
    const silo::Database& database,

--- a/src/silo/query_engine/filter_expressions/negation.cpp
+++ b/src/silo/query_engine/filter_expressions/negation.cpp
@@ -20,8 +20,8 @@ namespace silo::query_engine::filter_expressions {
 Negation::Negation(std::unique_ptr<Expression> child)
     : child(std::move(child)) {}
 
-std::string Negation::toString(const silo::Database& database) const {
-   return "!(" + child->toString(database) + ")";
+std::string Negation::toString() const {
+   return "!(" + child->toString() + ")";
 }
 
 std::unique_ptr<operators::Operator> Negation::compile(
@@ -30,7 +30,7 @@ std::unique_ptr<operators::Operator> Negation::compile(
    AmbiguityMode mode
 ) const {
    auto child_operator = child->compile(database, database_partition, invertMode(mode));
-   return child_operator->negate();
+   return operators::Operator::negate(std::move(child_operator));
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/src/silo/query_engine/filter_expressions/or.cpp
+++ b/src/silo/query_engine/filter_expressions/or.cpp
@@ -27,13 +27,13 @@ using OperatorVector = std::vector<std::unique_ptr<operators::Operator>>;
 Or::Or(std::vector<std::unique_ptr<Expression>>&& children)
     : children(std::move(children)) {}
 
-std::string Or::toString(const silo::Database& database) const {
+std::string Or::toString() const {
    std::vector<std::string> child_strings;
    std::transform(
       children.begin(),
       children.end(),
       std::back_inserter(child_strings),
-      [&](const std::unique_ptr<Expression>& child) { return child->toString(database); }
+      [&](const std::unique_ptr<Expression>& child) { return child->toString(); }
    );
    return "Or(" + boost::algorithm::join(child_strings, " | ") + ")";
 }

--- a/src/silo/query_engine/filter_expressions/pango_lineage_filter.cpp
+++ b/src/silo/query_engine/filter_expressions/pango_lineage_filter.cpp
@@ -26,7 +26,7 @@ PangoLineageFilter::PangoLineageFilter(
       lineage(std::move(lineage)),
       include_sublineages(include_sublineages) {}
 
-std::string PangoLineageFilter::toString(const silo::Database& /*database*/) const {
+std::string PangoLineageFilter::toString() const {
    std::string res = lineage;
    if (include_sublineages) {
       res += "*";

--- a/src/silo/query_engine/filter_expressions/string_equals.cpp
+++ b/src/silo/query_engine/filter_expressions/string_equals.cpp
@@ -26,7 +26,7 @@ StringEquals::StringEquals(std::string column, std::string value)
     : column(std::move(column)),
       value(std::move(value)) {}
 
-std::string StringEquals::toString(const silo::Database& /*database*/) const {
+std::string StringEquals::toString() const {
    return column + " = '" + value + "'";
 }
 

--- a/src/silo/query_engine/filter_expressions/true.cpp
+++ b/src/silo/query_engine/filter_expressions/true.cpp
@@ -17,7 +17,7 @@ namespace silo::query_engine::filter_expressions {
 
 True::True() = default;
 
-std::string True::toString(const silo::Database& /*database*/) const {
+std::string True::toString() const {
    return "True";
 }
 

--- a/src/silo/query_engine/operators/bitmap_producer.cpp
+++ b/src/silo/query_engine/operators/bitmap_producer.cpp
@@ -26,12 +26,9 @@ OperatorResult BitmapProducer::evaluate() const {
    return producer();
 }
 
-std::unique_ptr<Operator> BitmapProducer::copy() const {
-   return std::make_unique<BitmapProducer>(producer, row_count);
-}
-
-std::unique_ptr<Operator> BitmapProducer::negate() const {
-   return std::make_unique<Complement>(copy(), row_count);
+std::unique_ptr<Operator> BitmapProducer::negate(std::unique_ptr<BitmapProducer>&& bitmap_producer
+) {
+   return std::make_unique<Complement>(std::move(bitmap_producer), bitmap_producer->row_count);
 }
 
 }  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/bitmap_producer.test.cpp
+++ b/src/silo/query_engine/operators/bitmap_producer.test.cpp
@@ -20,10 +20,11 @@ TEST(OperatorBitmapProducer, evaluateShouldReturnCorrectValuesWhenNegated) {
    const roaring::Roaring test_bitmap({1, 2, 3});
    const uint32_t row_count = 5;
 
-   const auto under_test =
-      BitmapProducer([&]() { return OperatorResult(test_bitmap); }, row_count).negate();
+   auto under_test =
+      std::make_unique<BitmapProducer>([&]() { return OperatorResult(test_bitmap); }, row_count);
+   const auto negated = BitmapProducer::negate(std::move(under_test));
 
-   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring({0, 4}));
+   ASSERT_EQ(*negated->evaluate(), roaring::Roaring({0, 4}));
 }
 
 TEST(OperatorBitmapProducer, correctTypeInfo) {

--- a/src/silo/query_engine/operators/bitmap_selection.test.cpp
+++ b/src/silo/query_engine/operators/bitmap_selection.test.cpp
@@ -17,11 +17,11 @@ TEST(OperatorBitmapSelection, containsCheckShouldReturnCorrectValues) {
       roaring::Roaring({2, 4}),
    }});
 
-   const BitmapSelection under_test(
+   auto under_test = std::make_unique<BitmapSelection>(
       test_bitmaps.data(), test_bitmaps.size(), BitmapSelection::CONTAINS, 2
    );
-   ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({0, 2, 7}));
-   auto negated = under_test.negate();
+   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring({0, 2, 7}));
+   auto negated = BitmapSelection::negate(std::move(under_test));
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring({1, 3, 4, 5, 6}));
 }
 
@@ -37,11 +37,11 @@ TEST(OperatorBitmapSelection, notContainsCheckShouldReturnCorrectValues) {
       roaring::Roaring({2, 4}),
    }});
 
-   const BitmapSelection under_test(
+   auto under_test = std::make_unique<BitmapSelection>(
       test_bitmaps.data(), test_bitmaps.size(), BitmapSelection::NOT_CONTAINS, 2
    );
-   ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({1, 3, 4, 5, 6}));
-   auto negated = under_test.negate();
+   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring({1, 3, 4, 5, 6}));
+   auto negated = BitmapSelection::negate(std::move(under_test));
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring({0, 2, 7}));
 }
 
@@ -57,11 +57,11 @@ TEST(OperatorBitmapSelection, correctTypeInfo) {
       roaring::Roaring({2, 4}),
    }});
 
-   const BitmapSelection under_test(
+   auto under_test = std::make_unique<BitmapSelection>(
       test_bitmaps.data(), test_bitmaps.size(), BitmapSelection::NOT_CONTAINS, 2
    );
 
-   ASSERT_EQ(under_test.type(), silo::query_engine::operators::BITMAP_SELECTION);
-   auto negated = under_test.negate();
+   ASSERT_EQ(under_test->type(), silo::query_engine::operators::BITMAP_SELECTION);
+   auto negated = BitmapSelection::negate(std::move(under_test));
    ASSERT_EQ(negated->type(), silo::query_engine::operators::BITMAP_SELECTION);
 }

--- a/src/silo/query_engine/operators/complement.cpp
+++ b/src/silo/query_engine/operators/complement.cpp
@@ -9,6 +9,8 @@
 #include "silo/query_engine/operators/intersection.h"
 #include "silo/query_engine/operators/operator.h"
 
+using silo::query_engine::operators::Operator;
+
 namespace silo::query_engine::operators {
 
 Complement::Complement(std::unique_ptr<Operator> child, uint32_t row_count)
@@ -27,7 +29,7 @@ std::unique_ptr<Complement> Complement::fromDeMorgan(
    OperatorVector negated_child_operators;
    for (auto& disjunction_child : disjunction) {
       if (disjunction_child->type() == operators::COMPLEMENT) {
-         negated_child_operators.emplace_back(disjunction_child->negate());
+         negated_child_operators.emplace_back(Operator::negate(std::move(disjunction_child)));
       } else {
          non_negated_child_operators.push_back(std::move(disjunction_child));
       }
@@ -53,12 +55,8 @@ OperatorResult Complement::evaluate() const {
    return result;
 }
 
-std::unique_ptr<Operator> Complement::copy() const {
-   return std::make_unique<Complement>(child->copy(), row_count);
-}
-
-std::unique_ptr<Operator> Complement::negate() const {
-   return child->copy();
+std::unique_ptr<Operator> Complement::negate(std::unique_ptr<Complement>&& complement) {
+   return std::move(complement->child);
 }
 
 }  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/complement.test.cpp
+++ b/src/silo/query_engine/operators/complement.test.cpp
@@ -1,8 +1,9 @@
 #include "silo/query_engine/operators/complement.h"
-#include "silo/query_engine/operators/index_scan.h"
 
 #include <gtest/gtest.h>
 #include <roaring/roaring.hh>
+
+#include "silo/query_engine/operators/index_scan.h"
 
 using silo::query_engine::operators::Complement;
 using silo::query_engine::operators::IndexScan;

--- a/src/silo/query_engine/operators/empty.cpp
+++ b/src/silo/query_engine/operators/empty.cpp
@@ -25,12 +25,8 @@ OperatorResult Empty::evaluate() const {
    return OperatorResult();
 }
 
-std::unique_ptr<Operator> Empty::copy() const {
-   return std::make_unique<Empty>(row_count);
-}
-
-std::unique_ptr<Operator> Empty::negate() const {
-   return std::make_unique<Full>(row_count);
+std::unique_ptr<Operator> Empty::negate(std::unique_ptr<Empty>&& empty) {
+   return std::make_unique<Full>(empty->row_count);
 }
 
 }  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/full.cpp
+++ b/src/silo/query_engine/operators/full.cpp
@@ -27,12 +27,8 @@ OperatorResult Full::evaluate() const {
    return result;
 }
 
-std::unique_ptr<Operator> Full::copy() const {
-   return std::make_unique<Full>(row_count);
-}
-
-std::unique_ptr<Operator> Full::negate() const {
-   return std::make_unique<Empty>(row_count);
+std::unique_ptr<Operator> Full::negate(std::unique_ptr<Full>&& full) {
+   return std::make_unique<Empty>(full->row_count);
 }
 
 }  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/index_scan.test.cpp
+++ b/src/silo/query_engine/operators/index_scan.test.cpp
@@ -3,6 +3,11 @@
 #include <gtest/gtest.h>
 #include <roaring/roaring.hh>
 
+#include "silo/query_engine/filter_expressions/false.h"
+#include "silo/query_engine/filter_expressions/true.h"
+
+using silo::query_engine::filter_expressions::False;
+using silo::query_engine::filter_expressions::True;
 using silo::query_engine::operators::IndexScan;
 
 TEST(OperatorIndexScan, evaluateShouldReturnCorrectValues) {
@@ -17,4 +22,16 @@ TEST(OperatorIndexScan, correctTypeInfo) {
    const IndexScan under_test(&test_bitmap, 5);
 
    ASSERT_EQ(under_test.type(), silo::query_engine::operators::INDEX_SCAN);
+}
+
+TEST(OperatorIndexScan, correctLogicalEquivalent) {
+   const roaring::Roaring test_bitmap({1, 2, 3, 4, 5});
+   const IndexScan under_test(std::make_unique<True>(), &test_bitmap, 5);
+
+   ASSERT_EQ(under_test.toString(), "IndexScan(Logical Equivalent: True, Cardinality: 5)");
+
+   const roaring::Roaring test_bitmap2({});
+   const IndexScan under_test2(std::make_unique<False>(), &test_bitmap, 5);
+
+   ASSERT_EQ(under_test2.toString(), "IndexScan(Logical Equivalent: False, Cardinality: 5)");
 }

--- a/src/silo/query_engine/operators/intersection.cpp
+++ b/src/silo/query_engine/operators/intersection.cpp
@@ -59,6 +59,8 @@ Type Intersection::type() const {
    return INTERSECTION;
 }
 
+namespace {
+
 OperatorResult intersectTwo(OperatorResult first, OperatorResult second) {
    OperatorResult result;
    if (first.isMutable()) {
@@ -72,6 +74,8 @@ OperatorResult intersectTwo(OperatorResult first, OperatorResult second) {
    }
    return result;
 }
+
+}  // namespace
 
 OperatorResult Intersection::evaluate() const {
    std::vector<OperatorResult> children_bm;
@@ -126,28 +130,9 @@ OperatorResult Intersection::evaluate() const {
    return result;
 }
 
-std::unique_ptr<Operator> Intersection::copy() const {
-   std::vector<std::unique_ptr<Operator>> children_copy;
-   std::transform(
-      children.begin(),
-      children.end(),
-      std::back_inserter(children_copy),
-      [](const auto& child) { return child->copy(); }
-   );
-   std::vector<std::unique_ptr<Operator>> negated_children_copy;
-   std::transform(
-      negated_children.begin(),
-      negated_children.end(),
-      std::back_inserter(negated_children_copy),
-      [](const auto& child) { return child->copy(); }
-   );
-   return std::make_unique<Intersection>(
-      std::move(children_copy), std::move(negated_children_copy), row_count
-   );
-}
-
-std::unique_ptr<Operator> Intersection::negate() const {
-   return std::make_unique<Complement>(this->copy(), row_count);
+std::unique_ptr<Operator> Intersection::negate(std::unique_ptr<Intersection>&& intersection) {
+   const uint32_t row_count = intersection->row_count;
+   return std::make_unique<Complement>(std::move(intersection), row_count);
 }
 
 }  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/operator.cpp
+++ b/src/silo/query_engine/operators/operator.cpp
@@ -1,9 +1,76 @@
 #include "silo/query_engine/operators/operator.h"
 
+#include "silo/query_engine/filter_expressions/expression.h"
+#include "silo/query_engine/filter_expressions/symbol_equals.h"
+#include "silo/query_engine/operators/bitmap_producer.h"
+#include "silo/query_engine/operators/bitmap_selection.h"
+#include "silo/query_engine/operators/complement.h"
+#include "silo/query_engine/operators/empty.h"
+#include "silo/query_engine/operators/full.h"
+#include "silo/query_engine/operators/index_scan.h"
+#include "silo/query_engine/operators/intersection.h"
+#include "silo/query_engine/operators/range_selection.h"
+#include "silo/query_engine/operators/selection.h"
+#include "silo/query_engine/operators/threshold.h"
+#include "silo/query_engine/operators/union.h"
+
 namespace silo::query_engine::operators {
 
 Operator::Operator() = default;
 
 Operator::~Operator() noexcept = default;
+
+std::unique_ptr<Operator> Operator::negate(std::unique_ptr<Operator>&& some_operator) {
+   switch (some_operator->type()) {
+      case EMPTY: {
+         auto* empty = dynamic_cast<Empty*>(some_operator.release());
+         return Empty::negate(std::unique_ptr<Empty>(empty));
+      }
+      case FULL: {
+         auto* full = dynamic_cast<Full*>(some_operator.release());
+         return Full::negate(std::unique_ptr<Full>(full));
+      }
+      case INDEX_SCAN: {
+         auto* index_scan = dynamic_cast<IndexScan*>(some_operator.release());
+         return IndexScan::negate(std::unique_ptr<IndexScan>(index_scan));
+      }
+      case INTERSECTION: {
+         auto* intersection = dynamic_cast<Intersection*>(some_operator.release());
+         return Intersection::negate(std::unique_ptr<Intersection>(intersection));
+      }
+      case COMPLEMENT: {
+         auto* complement = dynamic_cast<Complement*>(some_operator.release());
+         return Complement::negate(std::unique_ptr<Complement>(complement));
+      }
+      case RANGE_SELECTION: {
+         auto* range_selection = dynamic_cast<RangeSelection*>(some_operator.release());
+         return RangeSelection::negate(std::unique_ptr<RangeSelection>(range_selection));
+      }
+      case SELECTION: {
+         auto* selection = dynamic_cast<Selection*>(some_operator.release());
+         return Selection::negate(std::unique_ptr<Selection>(selection));
+      }
+      case BITMAP_SELECTION: {
+         auto* bitmap_selection = dynamic_cast<BitmapSelection*>(some_operator.release());
+         return BitmapSelection::negate(std::unique_ptr<BitmapSelection>(bitmap_selection));
+      }
+      case THRESHOLD: {
+         auto* threshold = dynamic_cast<Threshold*>(some_operator.release());
+         return Threshold::negate(std::unique_ptr<Threshold>(threshold));
+      }
+      case UNION: {
+         auto* union_operator = dynamic_cast<Union*>(some_operator.release());
+         return Union::negate(std::unique_ptr<Union>(union_operator));
+      }
+      case BITMAP_PRODUCER: {
+         auto* bitmap_producer = dynamic_cast<BitmapProducer*>(some_operator.release());
+         return BitmapProducer::negate(std::unique_ptr<BitmapProducer>(bitmap_producer));
+      }
+   }
+}
+
+std::optional<std::unique_ptr<filter_expressions::Expression>> Operator::logicalEquivalent() const {
+   return std::nullopt;
+}
 
 }  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/range_selection.cpp
+++ b/src/silo/query_engine/operators/range_selection.cpp
@@ -47,14 +47,12 @@ OperatorResult RangeSelection::evaluate() const {
    return result;
 }
 
-std::unique_ptr<Operator> RangeSelection::copy() const {
-   return std::make_unique<RangeSelection>(std::vector<Range>(ranges), row_count);
-}
-
-std::unique_ptr<Operator> RangeSelection::negate() const {
+std::unique_ptr<Operator> RangeSelection::negate(std::unique_ptr<RangeSelection>&& range_selection
+) {
+   const uint32_t row_count = range_selection->row_count;
    std::vector<Range> new_ranges;
    uint32_t last_to = 0;
-   for (const auto& current : ranges) {
+   for (const auto& current : range_selection->ranges) {
       if (last_to != current.start) {
          new_ranges.emplace_back(last_to, current.start);
       }

--- a/src/silo/query_engine/operators/range_selection.test.cpp
+++ b/src/silo/query_engine/operators/range_selection.test.cpp
@@ -11,9 +11,9 @@ TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValues) {
    );
    const uint32_t row_count = 8;
 
-   const RangeSelection under_test(std::move(test_ranges), row_count);
-   ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({0, 1, 3, 4}));
-   auto negated = under_test.negate();
+   auto under_test = std::make_unique<RangeSelection>(std::move(test_ranges), row_count);
+   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring({0, 1, 3, 4}));
+   auto negated = RangeSelection::negate(std::move(under_test));
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring({2, 5, 6, 7}));
 }
 
@@ -21,9 +21,9 @@ TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValuesEmptyDatabase) {
    std::vector<RangeSelection::Range> test_ranges;
    const uint32_t row_count = 0;
 
-   const RangeSelection under_test(std::move(test_ranges), row_count);
-   ASSERT_EQ(*under_test.evaluate(), roaring::Roaring());
-   auto negated = under_test.negate();
+   auto under_test = std::make_unique<RangeSelection>(std::move(test_ranges), row_count);
+   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring());
+   auto negated = RangeSelection::negate(std::move(under_test));
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring());
 }
 
@@ -33,9 +33,9 @@ TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValuesEmptyRanges) {
    );
    const uint32_t row_count = 9;
 
-   const RangeSelection under_test(std::move(test_ranges), row_count);
-   ASSERT_EQ(*under_test.evaluate(), roaring::Roaring());
-   auto negated = under_test.negate();
+   auto under_test = std::make_unique<RangeSelection>(std::move(test_ranges), row_count);
+   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring());
+   auto negated = RangeSelection::negate(std::move(under_test));
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring({0, 1, 2, 3, 4, 5, 6, 7, 8}));
 }
 
@@ -44,9 +44,9 @@ TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValuesFullRange) {
    std::vector<RangeSelection::Range> test_ranges({{RangeSelection::Range{0, 8}}});
    const uint32_t row_count = 8;
 
-   const RangeSelection under_test(std::move(test_ranges), row_count);
-   ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({0, 1, 2, 3, 4, 5, 6, 7}));
-   auto negated = under_test.negate();
+   auto under_test = std::make_unique<RangeSelection>(std::move(test_ranges), row_count);
+   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring({0, 1, 2, 3, 4, 5, 6, 7}));
+   auto negated = RangeSelection::negate(std::move(under_test));
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring());
 }
 
@@ -56,9 +56,9 @@ TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValuesMeetingRanges) {
    );
    const uint32_t row_count = 9;
 
-   const RangeSelection under_test(std::move(test_ranges), row_count);
-   ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({0, 1, 2, 3}));
-   auto negated = under_test.negate();
+   auto under_test = std::make_unique<RangeSelection>(std::move(test_ranges), row_count);
+   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring({0, 1, 2, 3}));
+   auto negated = RangeSelection::negate(std::move(under_test));
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring({4, 5, 6, 7, 8}));
 }
 
@@ -68,9 +68,9 @@ TEST(OperatorRangeSelection, returnsCorrectTypeInfo) {
    );
    const uint32_t row_count = 8;
 
-   const RangeSelection under_test(std::move(test_ranges), row_count);
+   auto under_test = std::make_unique<RangeSelection>(std::move(test_ranges), row_count);
 
-   ASSERT_EQ(under_test.type(), silo::query_engine::operators::RANGE_SELECTION);
-   auto negated = under_test.negate();
+   ASSERT_EQ(under_test->type(), silo::query_engine::operators::RANGE_SELECTION);
+   auto negated = RangeSelection::negate(std::move(under_test));
    ASSERT_EQ(negated->type(), silo::query_engine::operators::RANGE_SELECTION);
 }

--- a/src/silo/query_engine/operators/selection.test.cpp
+++ b/src/silo/query_engine/operators/selection.test.cpp
@@ -11,14 +11,13 @@ TEST(OperatorSelection, equalsShouldReturnCorrectValues) {
    const std::vector<int32_t> test_column({{0, 1, 4, 4, 4, 1, 1, 1, 1, 1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection under_test(
-
+   auto under_test = std::make_unique<Selection>(
       std::make_unique<CompareToValueSelection<int32_t>>(test_column, Comparator::EQUALS, 1),
       row_count
    );
 
-   ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({1, 5, 6, 7, 8, 9}));
-   auto negated = under_test.negate();
+   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring({1, 5, 6, 7, 8, 9}));
+   auto negated = Selection::negate(std::move(under_test));
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring({0, 2, 3, 4}));
 }
 
@@ -26,14 +25,13 @@ TEST(OperatorSelection, notEqualsShouldReturnCorrectValues) {
    const std::vector<int32_t> test_column({{0, 1, 4, 4, 4, 1, 1, 1, 1, 1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection under_test(
-
+   auto under_test = std::make_unique<Selection>(
       std::make_unique<CompareToValueSelection<int32_t>>(test_column, Comparator::NOT_EQUALS, 1),
       row_count
    );
 
-   ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({0, 2, 3, 4}));
-   auto negated = under_test.negate();
+   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring({0, 2, 3, 4}));
+   auto negated = Selection::negate(std::move(under_test));
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring({1, 5, 6, 7, 8, 9}));
 }
 
@@ -41,13 +39,13 @@ TEST(OperatorSelection, lessShouldReturnCorrectValues) {
    const std::vector<int32_t> test_column({{0, 1, 4, 4, 4, 1, 1, 1, 1, 1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection under_test(
+   auto under_test = std::make_unique<Selection>(
       std::make_unique<CompareToValueSelection<int32_t>>(test_column, Comparator::LESS, 1),
       row_count
    );
 
-   ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({0}));
-   auto negated = under_test.negate();
+   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring({0}));
+   auto negated = Selection::negate(std::move(under_test));
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring({1, 2, 3, 4, 5, 6, 7, 8, 9}));
 }
 
@@ -55,15 +53,15 @@ TEST(OperatorSelection, lessOrEqualsShouldReturnCorrectValues) {
    const std::vector<int32_t> test_column({{0, 1, 4, 4, 4, 1, 1, 1, 1, 1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection under_test(
+   auto under_test = std::make_unique<Selection>(
       std::make_unique<CompareToValueSelection<int32_t>>(
          test_column, Comparator::LESS_OR_EQUALS, 1
       ),
       row_count
    );
 
-   ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({0, 1, 5, 6, 7, 8, 9}));
-   auto negated = under_test.negate();
+   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring({0, 1, 5, 6, 7, 8, 9}));
+   auto negated = Selection::negate(std::move(under_test));
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring({2, 3, 4}));
 }
 
@@ -71,16 +69,15 @@ TEST(OperatorSelection, higherOrEqualsShouldReturnCorrectValues) {
    const std::vector<int32_t> test_column({{0, 1, 4, 4, 4, 1, 1, 1, 1, 1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection under_test(
-
+   auto under_test = std::make_unique<Selection>(
       std::make_unique<CompareToValueSelection<int32_t>>(
          test_column, Comparator::HIGHER_OR_EQUALS, 1
       ),
       row_count
    );
 
-   ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({1, 2, 3, 4, 5, 6, 7, 8, 9}));
-   auto negated = under_test.negate();
+   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring({1, 2, 3, 4, 5, 6, 7, 8, 9}));
+   auto negated = Selection::negate(std::move(under_test));
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring({0}));
 }
 
@@ -88,14 +85,13 @@ TEST(OperatorSelection, higherShouldReturnCorrectValues) {
    const std::vector<int32_t> test_column({{0, 1, 4, 4, 4, 1, 1, 1, 1, 1}});
    const uint32_t row_count = test_column.size();
 
-   const Selection under_test(
-
+   auto under_test = std::make_unique<Selection>(
       std::make_unique<CompareToValueSelection<int32_t>>(test_column, Comparator::HIGHER, 1),
       row_count
    );
 
-   ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({2, 3, 4}));
-   auto negated = under_test.negate();
+   ASSERT_EQ(*under_test->evaluate(), roaring::Roaring({2, 3, 4}));
+   auto negated = Selection::negate(std::move(under_test));
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring({0, 1, 5, 6, 7, 8, 9}));
 }
 
@@ -104,7 +100,6 @@ TEST(OperatorSelection, correctWithNegativeNumbers) {
    const uint32_t row_count = test_column.size();
 
    const Selection under_test(
-
       std::make_unique<CompareToValueSelection<int32_t>>(test_column, Comparator::EQUALS, -1),
       row_count
    );
@@ -117,7 +112,6 @@ TEST(OperatorSelection, returnsCorrectTypeInfo) {
    const uint32_t row_count = test_column.size();
 
    const Selection under_test(
-
       std::make_unique<CompareToValueSelection<int32_t>>(test_column, Comparator::EQUALS, -1),
       row_count
    );

--- a/src/silo/query_engine/operators/threshold.cpp
+++ b/src/silo/query_engine/operators/threshold.cpp
@@ -137,32 +137,8 @@ OperatorResult Threshold::evaluate() const {
    return OperatorResult(std::move(partition_bitmaps.back()));
 }
 
-std::unique_ptr<Operator> Threshold::copy() const {
-   std::vector<std::unique_ptr<Operator>> children_copy;
-   std::transform(
-      non_negated_children.begin(),
-      non_negated_children.end(),
-      std::back_inserter(children_copy),
-      [](const auto& child) { return child->copy(); }
-   );
-   std::vector<std::unique_ptr<Operator>> negated_children_copy;
-   std::transform(
-      negated_children.begin(),
-      negated_children.end(),
-      std::back_inserter(negated_children_copy),
-      [](const auto& child) { return child->copy(); }
-   );
-   return std::make_unique<Threshold>(
-      std::move(children_copy),
-      std::move(negated_children_copy),
-      number_of_matchers,
-      match_exactly,
-      row_count
-   );
-}
-
-std::unique_ptr<Operator> Threshold::negate() const {
-   return std::make_unique<Complement>(this->copy(), row_count);
+std::unique_ptr<Operator> Threshold::negate(std::unique_ptr<Threshold>&& threshold) {
+   return std::make_unique<Complement>(std::move(threshold), threshold->row_count);
 }
 
 }  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/union.cpp
+++ b/src/silo/query_engine/operators/union.cpp
@@ -44,19 +44,8 @@ OperatorResult Union::evaluate() const {
    return OperatorResult(roaring::Roaring::fastunion(union_tmp.size(), union_tmp.data()));
 }
 
-std::unique_ptr<Operator> Union::copy() const {
-   std::vector<std::unique_ptr<Operator>> children_copy;
-   std::transform(
-      children.begin(),
-      children.end(),
-      std::back_inserter(children_copy),
-      [](const auto& child) { return child->copy(); }
-   );
-   return std::make_unique<Union>(std::move(children_copy), row_count);
-}
-
-std::unique_ptr<Operator> Union::negate() const {
-   return std::make_unique<Complement>(this->copy(), row_count);
+std::unique_ptr<Operator> Union::negate(std::unique_ptr<Union>&& union_operator) {
+   return std::make_unique<Complement>(std::move(union_operator), union_operator->row_count);
 }
 
 }  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/query_engine.cpp
+++ b/src/silo/query_engine/query_engine.cpp
@@ -25,7 +25,7 @@ QueryEngine::QueryEngine(const silo::Database& database)
 QueryResult QueryEngine::executeQuery(const std::string& query_string) const {
    Query query(query_string);
 
-   SPDLOG_DEBUG("Parsed query: {}", query.filter->toString(database));
+   SPDLOG_DEBUG("Parsed query: {}", query.filter->toString());
 
    std::vector<std::string> compiled_queries(database.partitions.size());
    std::vector<silo::query_engine::OperatorResult> partition_filters(database.partitions.size());


### PR DESCRIPTION
### Summary
Just Refactoring query engine utilities:
clearer Operator::negate and Expression::toString, logical Equvalents for debug printing/logging for the Leaf Operators IndexScan and BitmapSelection

## PR Checklist
~~- [X] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [X] The implemented feature is covered by an appropriate test.~~
Just internal refactoring