### PR TITLE
refactor: factorize Dot symbol_equals into named struct instead of abusing std::optional

### DIFF
--- a/include/silo/query_engine/filter_expressions/symbol_equals.h
+++ b/include/silo/query_engine/filter_expressions/symbol_equals.h
@@ -25,15 +25,33 @@ class Operator;
 namespace silo::query_engine::filter_expressions {
 
 template <typename SymbolType>
+class SymbolOrDot {
+   std::optional<typename SymbolType::Symbol> value;
+
+   SymbolOrDot() = default;
+
+  public:
+   static SymbolOrDot<SymbolType> dot();
+
+   SymbolOrDot(typename SymbolType::Symbol symbol);
+
+   typename SymbolType::Symbol getSymbolOrReplaceDotWith(
+      typename SymbolType::Symbol replace_dot_with
+   ) const;
+
+   char asChar() const;
+};
+
+template <typename SymbolType>
 struct SymbolEquals : public Expression {
    std::optional<std::string> sequence_name;
    uint32_t position_idx;
-   std::optional<typename SymbolType::Symbol> value;
+   SymbolOrDot<SymbolType> value;
 
    explicit SymbolEquals(
       std::optional<std::string> sequence_name,
       uint32_t position_idx,
-      std::optional<typename SymbolType::Symbol> value
+      SymbolOrDot<SymbolType> value
    );
 
    std::string toString() const override;

--- a/src/silo/common/aa_symbols.cpp
+++ b/src/silo/common/aa_symbols.cpp
@@ -63,8 +63,6 @@ char AminoAcid::symbolToChar(AminoAcid::Symbol symbol) {
 
 std::optional<AminoAcid::Symbol> AminoAcid::charToSymbol(char character) {
    switch (character) {
-      case '.':
-         return std::nullopt;
       case '-':
          return AminoAcid::Symbol::GAP;
       case 'A':
@@ -116,7 +114,6 @@ std::optional<AminoAcid::Symbol> AminoAcid::charToSymbol(char character) {
       case '*':
          return AminoAcid::Symbol::STOP;
       default:
-         // TODO(#342): Revisit charToSymbol, so that illegal characters are not the same as '.'.
          return std::nullopt;
    }
 }

--- a/src/silo/common/nucleotide_symbols.cpp
+++ b/src/silo/common/nucleotide_symbols.cpp
@@ -45,8 +45,6 @@ char Nucleotide::symbolToChar(Nucleotide::Symbol symbol) {
 
 std::optional<Nucleotide::Symbol> Nucleotide::charToSymbol(char character) {
    switch (character) {
-      case '.':
-         return std::nullopt;
       case '-':
          return Symbol::GAP;
       case 'A':
@@ -81,7 +79,6 @@ std::optional<Nucleotide::Symbol> Nucleotide::charToSymbol(char character) {
       case 'N':
          return Symbol::N;
       default:
-         // TODO(#342): Revisit charToSymbol, so that illegal characters are not the same as '.'.
          return std::nullopt;
    }
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #342

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
