### PR TITLE
fix: specify namespace fmt in calls to format_to

### DIFF
--- a/include/silo/database_info.h
+++ b/include/silo/database_info.h
@@ -23,7 +23,7 @@ template <>
 struct [[maybe_unused]] fmt::formatter<silo::DatabaseInfo> : fmt::formatter<std::string> {
    [[maybe_unused]] static auto format(silo::DatabaseInfo database_info, format_context& ctx)
       -> decltype(ctx.out()) {
-      return format_to(
+      return fmt::format_to(
          ctx.out(),
          "sequence count: {}, total size: {}, N bitmaps size: {}",
          database_info.sequence_count,

--- a/src/silo/config/database_config.cpp
+++ b/src/silo/config/database_config.cpp
@@ -234,7 +234,7 @@ DatabaseConfig DatabaseConfigReader::readConfig(const std::filesystem::path& con
    const silo::config::DatabaseConfig& database_config,
    fmt::format_context& ctx
 ) -> decltype(ctx.out()) {
-   return format_to(
+   return fmt::format_to(
       ctx.out(),
       "{{ default_nucleotide_sequence: '{}', schema: {} }}",
       database_config.default_nucleotide_sequence,
@@ -246,7 +246,7 @@ DatabaseConfig DatabaseConfigReader::readConfig(const std::filesystem::path& con
    const silo::config::DatabaseSchema& database_schema,
    fmt::format_context& ctx
 ) -> decltype(ctx.out()) {
-   return format_to(
+   return fmt::format_to(
       ctx.out(),
       "{{ instance_name: '{}', primary_key: '{}', partition_by: {}, date_to_sort_by: {}, metadata: "
       "[{}] }}",
@@ -263,7 +263,7 @@ DatabaseConfig DatabaseConfigReader::readConfig(const std::filesystem::path& con
    const silo::config::DatabaseMetadata& database_metadata,
    fmt::format_context& ctx
 ) -> decltype(ctx.out()) {
-   return format_to(
+   return fmt::format_to(
       ctx.out(),
       "{{ name: '{}', type: '{}', generate_index: {} }}",
       database_metadata.name,
@@ -278,19 +278,19 @@ DatabaseConfig DatabaseConfigReader::readConfig(const std::filesystem::path& con
 ) -> decltype(ctx.out()) {
    switch (value_type) {
       case silo::config::ValueType::STRING:
-         return format_to(ctx.out(), "string");
+         return fmt::format_to(ctx.out(), "string");
       case silo::config::ValueType::DATE:
-         return format_to(ctx.out(), "date");
+         return fmt::format_to(ctx.out(), "date");
       case silo::config::ValueType::PANGOLINEAGE:
-         return format_to(ctx.out(), "pango_lineage");
+         return fmt::format_to(ctx.out(), "pango_lineage");
       case silo::config::ValueType::INT:
-         return format_to(ctx.out(), "int");
+         return fmt::format_to(ctx.out(), "int");
       case silo::config::ValueType::FLOAT:
-         return format_to(ctx.out(), "float");
+         return fmt::format_to(ctx.out(), "float");
       case silo::config::ValueType::NUC_INSERTION:
-         return format_to(ctx.out(), "insertion");
+         return fmt::format_to(ctx.out(), "insertion");
       case silo::config::ValueType::AA_INSERTION:
-         return format_to(ctx.out(), "aaInsertion");
+         return fmt::format_to(ctx.out(), "aaInsertion");
    }
-   return format_to(ctx.out(), "unknown");
+   return fmt::format_to(ctx.out(), "unknown");
 }

--- a/src/silo/preprocessing/preprocessing_config.cpp
+++ b/src/silo/preprocessing/preprocessing_config.cpp
@@ -119,7 +119,7 @@ std::filesystem::path PreprocessingConfig::getGeneFilenameNoExtension(std::strin
    const silo::preprocessing::PreprocessingConfig& preprocessing_config,
    fmt::format_context& ctx
 ) -> decltype(ctx.out()) {
-   return format_to(
+   return fmt::format_to(
       ctx.out(),
       "{{ input directory: '{}', pango_lineage_definition_file: {}, output_directory: '{}', "
       "metadata_file: '{}', reference_genome_file: '{}',  gene_file_prefix: '{}',  "

--- a/src/silo/storage/sequence_store.cpp
+++ b/src/silo/storage/sequence_store.cpp
@@ -71,7 +71,7 @@ size_t silo::SequenceStorePartition<SymbolType>::fill(ZstdFastaTableReader& inpu
    silo::SequenceStoreInfo sequence_store_info,
    fmt::format_context& ctx
 ) -> decltype(ctx.out()) {
-   return format_to(
+   return fmt::format_to(
       ctx.out(),
       "SequenceStoreInfo[sequence count: {}, size: {}, N bitmaps size: {}]",
       sequence_store_info.sequence_count,


### PR DESCRIPTION
This broke compatibility with a late 2023 Ubuntu (23.10).
