### PR TITLE
feat: improve validation error message of some actions on orderByFields

### DIFF
--- a/src/silo/query_engine/actions/action.cpp
+++ b/src/silo/query_engine/actions/action.cpp
@@ -217,6 +217,10 @@ void from_json(const nlohmann::json& json, std::unique_ptr<Action>& action) {
       throw QueryParseException(expression_type + " is not a valid action");
    }
 
+   CHECK_SILO_QUERY(
+      !json.contains("orderByFields") || json["orderByFields"].is_array(),
+      "orderByFields must be an array."
+   )
    auto order_by_fields = json.contains("orderByFields")
                              ? json["orderByFields"].get<std::vector<OrderByField>>()
                              : std::vector<OrderByField>();

--- a/src/silo/query_engine/actions/fasta.cpp
+++ b/src/silo/query_engine/actions/fasta.cpp
@@ -47,7 +47,9 @@ void Fasta::validateOrderByFields(const Database& database) const {
             std::find(sequence_names.begin(), sequence_names.end(), field.name) !=
                std::end(sequence_names),
          fmt::format(
+            "OrderByField {} is not contained in the result of this operation. "
             "The only fields returned by the Fasta action are {} and {}",
+            field.name,
             fmt::join(sequence_names, ","),
             primary_key_field
          )

--- a/src/silo/query_engine/actions/fasta_aligned.cpp
+++ b/src/silo/query_engine/actions/fasta_aligned.cpp
@@ -33,7 +33,9 @@ void FastaAligned::validateOrderByFields(const Database& database) const {
             std::find(sequence_names.begin(), sequence_names.end(), field.name) !=
                std::end(sequence_names),
          fmt::format(
+            "OrderByField {} is not contained in the result of this operation. "
             "The only fields returned by the FastaAligned action are {} and {}",
+            field.name,
             fmt::join(sequence_names, ","),
             primary_key_field
          )

--- a/src/silo/query_engine/actions/insertions.cpp
+++ b/src/silo/query_engine/actions/insertions.cpp
@@ -8,6 +8,7 @@
 #include <variant>
 #include <vector>
 
+#include <fmt/format.h>
 #include <boost/container_hash/hash.hpp>
 #include <nlohmann/json.hpp>
 
@@ -53,7 +54,12 @@ void InsertionAggregation<SymbolType>::validateOrderByFields(const Database& /*d
             result_field_names.end(),
             [&](const std::string& result_field) { return result_field == field.name; }
          ),
-         "OrderByField " + field.name + " is not contained in the result of this operation."
+         fmt::format(
+            "OrderByField {} is not contained in the result of this operation. "
+            "Allowed values are {}.",
+            field.name,
+            fmt::join(result_field_names, ", ")
+         )
       )
    }
 }

--- a/src/silo/query_engine/actions/mutations.cpp
+++ b/src/silo/query_engine/actions/mutations.cpp
@@ -8,6 +8,7 @@
 #include <variant>
 #include <vector>
 
+#include <fmt/format.h>
 #include <oneapi/tbb/blocked_range.h>
 #include <oneapi/tbb/parallel_for.h>
 #include <nlohmann/json.hpp>
@@ -176,7 +177,12 @@ void Mutations<SymbolType>::validateOrderByFields(const Database& /*database*/) 
             result_field_names.end(),
             [&](const std::string& result_field) { return result_field == field.name; }
          ),
-         "OrderByField " + field.name + " is not contained in the result of this operation."
+         fmt::format(
+            "OrderByField {} is not contained in the result of this operation. "
+            "Allowed values are {}.",
+            field.name,
+            fmt::join(result_field_names, ", ")
+         )
       )
    }
 }


### PR DESCRIPTION
related to https://github.com/GenSpectrum/LAPIS/issues/710

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
Actually one would need to do the same for `Aggregated` and `Details`, too. But this is supposed to be a quick fix and there we have a dynamic list that wasn't that easy to get into an error message.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [ ] The implemented feature is covered by an appropriate test.
