### PR TITLE
Testing environment improvements

### DIFF
--- a/src/main.test.cpp
+++ b/src/main.test.cpp
@@ -2,10 +2,19 @@
 #include <gtest/gtest.h>
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/spdlog.h>
+#include <filesystem>
 
 #include "silo/common/log.h"
 
 int main(int argc, char* argv[]) {
+   try {
+      if (!std::filesystem::exists("testBaseData/exampleDataset")) {
+         throw std::runtime_error("must be run in root of repository");
+      }
+   } catch (std::exception& e) {
+      SPDLOG_ERROR(e.what());
+      return 1;
+   }
    spdlog::set_level(spdlog::level::info);
    spdlog::null_logger_mt(silo::PERFORMANCE_LOGGER_NAME);
    ::testing::InitGoogleMock(&argc, argv);

--- a/testBaseData/.gitignore
+++ b/testBaseData/.gitignore
@@ -1,0 +1,3 @@
+/exampleDataset/testBaseData/
+/exampleDataset/test*/
+/tmp/


### PR DESCRIPTION
- Ignore directories generated by the preprocessing for tests, and running the test runner

- Make silo_test check that it's running in the project root. While one can deduce the reasons for tests failing by looking at exceptions and drawing the right conclusions, this can easily be overlooked and other people may assume the test has to run from the subdir and run into the same as me.

