### PR TITLE
feat: have structured and destructured insertion in insertions response

### DIFF
--- a/endToEndTests/test/queries/aaInsertionsAction.json
+++ b/endToEndTests/test/queries/aaInsertionsAction.json
@@ -4,7 +4,7 @@
     "action": {
       "type": "AminoAcidInsertions",
       "column": "aminoAcidInsertions",
-      "orderByFields": ["insertions", "position"]
+      "orderByFields": ["insertion", "position"]
     },
     "filterExpression": {
       "type": "True"
@@ -12,33 +12,38 @@
   },
   "expectedQueryResult": [
     {
-      "count": 5,
-      "insertions": "EPE",
-      "position": 214,
-      "sequenceName": "S"
-    },
-    {
       "count": 1,
-      "insertions": "F",
+      "insertedSymbols": "F",
+      "insertion": "ins_ORF1a:3602:F",
       "position": 3602,
       "sequenceName": "ORF1a"
     },
     {
       "count": 1,
-      "insertions": "IV",
+      "insertedSymbols": "T",
+      "insertion": "ins_S:143:T",
+      "position": 143,
+      "sequenceName": "S"
+    },
+    {
+      "count": 1,
+      "insertedSymbols": "IV",
+      "insertion": "ins_S:210:IV",
       "position": 210,
       "sequenceName": "S"
     },
     {
-      "count": 1,
-      "insertions": "SGE",
-      "position": 247,
+      "count": 5,
+      "insertedSymbols": "EPE",
+      "insertion": "ins_S:214:EPE",
+      "position": 214,
       "sequenceName": "S"
     },
     {
       "count": 1,
-      "insertions": "T",
-      "position": 143,
+      "insertedSymbols": "SGE",
+      "insertion": "ins_S:247:SGE",
+      "position": 247,
       "sequenceName": "S"
     }
   ]

--- a/endToEndTests/test/queries/aaInsertionsActionAndFilter.json
+++ b/endToEndTests/test/queries/aaInsertionsActionAndFilter.json
@@ -4,7 +4,7 @@
     "action": {
       "type": "AminoAcidInsertions",
       "column": "aminoAcidInsertions",
-      "orderByFields": ["insertions", "position"]
+      "orderByFields": ["insertedSymbols", "position"]
     },
     "filterExpression": {
       "type": "AminoAcidInsertionContains",
@@ -17,7 +17,8 @@
   "expectedQueryResult": [
     {
       "count": 5,
-      "insertions": "EPE",
+      "insertedSymbols": "EPE",
+      "insertion": "ins_S:214:EPE",
       "position": 214,
       "sequenceName": "S"
     }

--- a/endToEndTests/test/queries/aaInsertionsActionOneSequence.json
+++ b/endToEndTests/test/queries/aaInsertionsActionOneSequence.json
@@ -4,7 +4,7 @@
     "action": {
       "type": "AminoAcidInsertions",
       "column": "aminoAcidInsertions",
-      "orderByFields": ["insertions", "position"],
+      "orderByFields": ["insertedSymbols", "position"],
       "sequenceName": "S"
     },
     "filterExpression": {
@@ -14,25 +14,29 @@
   "expectedQueryResult": [
     {
       "count": 5,
-      "insertions": "EPE",
+      "insertedSymbols": "EPE",
+      "insertion": "ins_S:214:EPE",
       "position": 214,
       "sequenceName": "S"
     },
     {
       "count": 1,
-      "insertions": "IV",
+      "insertedSymbols": "IV",
+      "insertion": "ins_S:210:IV",
       "position": 210,
       "sequenceName": "S"
     },
     {
       "count": 1,
-      "insertions": "SGE",
+      "insertedSymbols": "SGE",
+      "insertion": "ins_S:247:SGE",
       "position": 247,
       "sequenceName": "S"
     },
     {
       "count": 1,
-      "insertions": "T",
+      "insertedSymbols": "T",
+      "insertion": "ins_S:143:T",
       "position": 143,
       "sequenceName": "S"
     }

--- a/endToEndTests/test/queries/insertionsAction.json
+++ b/endToEndTests/test/queries/insertionsAction.json
@@ -4,7 +4,7 @@
     "action": {
       "type": "Insertions",
       "column": "nucleotideInsertions",
-      "orderByFields": ["insertions", "position"]
+      "orderByFields": ["insertion"]
     },
     "filterExpression": {
       "type": "True"
@@ -13,25 +13,29 @@
   "expectedQueryResult": [
     {
       "count": 1,
-      "insertions": "CAGAA",
+      "insertedSymbols": "CAGAA",
+      "insertion": "ins_main:22204:CAGAA",
       "position": 22204,
       "sequenceName": "main"
     },
     {
+      "count": 1,
+      "insertedSymbols": "GCTGGT",
+      "insertion": "ins_main:22339:GCTGGT",
+      "position": 22339,
+      "sequenceName": "main"
+    },
+    {
       "count": 17,
-      "insertions": "CCC",
+      "insertedSymbols": "CCC",
+      "insertion": "ins_main:25701:CCC",
       "position": 25701,
       "sequenceName": "main"
     },
     {
       "count": 1,
-      "insertions": "GCTGGT",
-      "position": 22339,
-      "sequenceName": "main"
-    },
-    {
-      "count": 1,
-      "insertions": "TAT",
+      "insertedSymbols": "TAT",
+      "insertion": "ins_main:5959:TAT",
       "position": 5959,
       "sequenceName": "main"
     }

--- a/endToEndTests/test/queries/insertionsAction.json
+++ b/endToEndTests/test/queries/insertionsAction.json
@@ -14,28 +14,28 @@
     {
       "count": 1,
       "insertedSymbols": "CAGAA",
-      "insertion": "ins_main:22204:CAGAA",
+      "insertion": "ins_22204:CAGAA",
       "position": 22204,
       "sequenceName": "main"
     },
     {
       "count": 1,
       "insertedSymbols": "GCTGGT",
-      "insertion": "ins_main:22339:GCTGGT",
+      "insertion": "ins_22339:GCTGGT",
       "position": 22339,
       "sequenceName": "main"
     },
     {
       "count": 17,
       "insertedSymbols": "CCC",
-      "insertion": "ins_main:25701:CCC",
+      "insertion": "ins_25701:CCC",
       "position": 25701,
       "sequenceName": "main"
     },
     {
       "count": 1,
       "insertedSymbols": "TAT",
-      "insertion": "ins_main:5959:TAT",
+      "insertion": "ins_5959:TAT",
       "position": 5959,
       "sequenceName": "main"
     }

--- a/endToEndTests/test/queries/insertionsActionAndFilter.json
+++ b/endToEndTests/test/queries/insertionsActionAndFilter.json
@@ -16,7 +16,7 @@
     {
       "count": 1,
       "insertedSymbols": "GCTGGT",
-      "insertion": "ins_main:22339:GCTGGT",
+      "insertion": "ins_22339:GCTGGT",
       "position": 22339,
       "sequenceName": "main"
     }

--- a/endToEndTests/test/queries/insertionsActionAndFilter.json
+++ b/endToEndTests/test/queries/insertionsActionAndFilter.json
@@ -15,7 +15,8 @@
   "expectedQueryResult": [
     {
       "count": 1,
-      "insertions": "GCTGGT",
+      "insertedSymbols": "GCTGGT",
+      "insertion": "ins_main:22339:GCTGGT",
       "position": 22339,
       "sequenceName": "main"
     }

--- a/include/silo/query_engine/actions/insertions.h
+++ b/include/silo/query_engine/actions/insertions.h
@@ -65,6 +65,7 @@ class InsertionAggregation : public Action {
    void addAggregatedInsertionsToInsertionCounts(
       std::vector<QueryResultEntry>& output,
       const std::string& sequence_name,
+      bool show_sequence_in_response,
       const PrefilteredBitmaps& prefiltered_bitmaps
    ) const;
 

--- a/include/silo/query_engine/actions/insertions.h
+++ b/include/silo/query_engine/actions/insertions.h
@@ -36,7 +36,8 @@ namespace silo::query_engine::actions {
 template <typename SymbolType>
 class InsertionAggregation : public Action {
    static constexpr std::string_view POSITION_FIELD_NAME = "position";
-   static constexpr std::string_view INSERTION_FIELD_NAME = "insertions";
+   static constexpr std::string_view INSERTED_SYMBOLS_FIELD_NAME = "insertedSymbols";
+   static constexpr std::string_view INSERTION_FIELD_NAME = "insertion";
    static constexpr std::string_view SEQUENCE_FIELD_NAME = "sequenceName";
    static constexpr std::string_view COUNT_FIELD_NAME = "count";
 

--- a/src/silo/query_engine/actions/insertions.cpp
+++ b/src/silo/query_engine/actions/insertions.cpp
@@ -44,7 +44,8 @@ void InsertionAggregation<SymbolType>::validateOrderByFields(const Database& /*d
       {std::string{POSITION_FIELD_NAME},
        std::string{INSERTION_FIELD_NAME},
        std::string{SEQUENCE_FIELD_NAME},
-       std::string{COUNT_FIELD_NAME}}
+       std::string{COUNT_FIELD_NAME},
+       std::string{INSERTED_SYMBOLS_FIELD_NAME}}
    };
 
    for (const OrderByField& field : order_by_fields) {
@@ -220,8 +221,16 @@ void InsertionAggregation<SymbolType>::addAggregatedInsertionsToInsertionCounts(
       const std::map<std::string, std::optional<std::variant<std::string, int32_t, double>>> fields{
          {std::string(POSITION_FIELD_NAME),
           static_cast<int32_t>(position_and_insertion.position_idx)},
+         {std::string(INSERTED_SYMBOLS_FIELD_NAME),
+          std::string(position_and_insertion.insertion_value)},
          {std::string(SEQUENCE_FIELD_NAME), sequence_name},
-         {std::string(INSERTION_FIELD_NAME), std::string(position_and_insertion.insertion_value)},
+         {std::string(INSERTION_FIELD_NAME),
+          fmt::format(
+             "ins_{}:{}:{}",
+             sequence_name,
+             position_and_insertion.position_idx,
+             position_and_insertion.insertion_value
+          )},
          {std::string(COUNT_FIELD_NAME), static_cast<int32_t>(count)}
       };
       output.push_back({fields});


### PR DESCRIPTION
As discussed in planning this morning. Resolves [bug in LAPIS](https://github.com/GenSpectrum/LAPIS/issues/710) where insertions were not filterable (as they were only added in LAPIS, not already present in SILO)