### PR TITLE
fix: always build dependency image for amd64 platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           tags: ${{ steps.dockerMetadata.outputs.tags }}
           cache-from: type=gha,ref=builder-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile') }}
           cache-to: type=gha,mode=min,ref=builder-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile') }}
-          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: linux/amd64,linux/arm64
 
   dockerImageUnitTests:
     name: Build Docker Image and Run Unit Tests


### PR DESCRIPTION
The current ci only built the arm images on merge to main... but the cache hit check is not platform aware, so it did not rebuild the image for the new platform. Instead of adding a more complicated dependency, also non main ci pipelines will now build ARM *only for the dependency image*.
The good thing, is that this means, that the merge to main then hits the cache and is quicker.