### PR TITLE
fix: add missing sequenceName field to mutation action "orderBy"

### DIFF
--- a/src/silo/query_engine/actions/mutations.cpp
+++ b/src/silo/query_engine/actions/mutations.cpp
@@ -172,6 +172,7 @@ void Mutations<SymbolType>::validateOrderByFields(const Database& /*database*/) 
        MUTATION_TO_FIELD_NAME,
        POSITION_FIELD_NAME,
        PROPORTION_FIELD_NAME,
+       SEQUENCE_FIELD_NAME,
        COUNT_FIELD_NAME}
    };
 


### PR DESCRIPTION
### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted or there is an issue to do so.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
