### PR TITLE
add .dir-locals.el for project-specific Emacs settings

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,6 @@
+;; The 'nil' configuration applies to all modes.
+((nil . ((indent-tabs-mode . nil)
+         (tab-width . 2) ;; used by what?
+         (js-indent-level . 2)
+         (c-basic-offset . 3)
+         )))


### PR DESCRIPTION
### Summary

This adds Emacs configuration specific to this project. Emacs automatically reads this file when editing source files in this repository and indentation settings are then automatically correct.

I don't think this needs documentation, it's used automatically for Emacs users (it asks to confirm using the file on first use), and other users don't care.

## PR Checklist

- [ ] ~~All necessary documentation has been adapted or there is an issue to do so.~~
- [ ] ~~The implemented feature is covered by an appropriate test.~~
