### PR TITLE
Runtime Config

### DIFF
--- a/include/silo_api/runtime_config.h
+++ b/include/silo_api/runtime_config.h
@@ -3,12 +3,25 @@
 #include <filesystem>
 #include <optional>
 
+#include <Poco/Util/AbstractConfiguration.h>
+
+#include "silo/preprocessing/preprocessing_config.h"
+
 namespace silo_api {
 
-struct RuntimeConfig {
-   std::optional<std::filesystem::path> data_directory;
+static const std::string DATA_DIRECTORY_OPTION = "dataDirectory";
+static const std::string MAX_CONNECTIONS_OPTION = "maxQueuedHttpConnections";
+static const std::string PARALLEL_THREADS_OPTION = "threadsForHttpConnections";
+static const std::string PORT_OPTION = "port";
 
-   static RuntimeConfig readFromFile(const std::filesystem::path& config_path);
+struct RuntimeConfig {
+   std::filesystem::path data_directory = silo::preprocessing::DEFAULT_OUTPUT_DIRECTORY.directory;
+   int32_t max_connections = 64;
+   int32_t parallel_threads = 4;
+   uint16_t port = 8081;
+
+   void overwriteFromFile(const std::filesystem::path& config_path);
+   void overwriteFromCommandLineArguments(const Poco::Util::AbstractConfiguration& config);
 };
 
 }  // namespace silo_api

--- a/include/silo_api/runtime_config.h
+++ b/include/silo_api/runtime_config.h
@@ -9,10 +9,14 @@
 
 namespace silo_api {
 
-static const std::string DATA_DIRECTORY_OPTION = "dataDirectory";
-static const std::string MAX_CONNECTIONS_OPTION = "maxQueuedHttpConnections";
-static const std::string PARALLEL_THREADS_OPTION = "threadsForHttpConnections";
-static const std::string PORT_OPTION = "port";
+const std::string DATA_DIRECTORY_OPTION = "dataDirectory";
+const std::string DATA_DIRECTORY_ENV_OPTION = "SILO_DATA_DIRECTORY";
+const std::string MAX_CONNECTIONS_OPTION = "maxQueuedHttpConnections";
+const std::string MAX_CONNECTIONS_ENV_OPTION = "SILO_MAX_QUEUED_HTTP_CONNECTIONS";
+const std::string PARALLEL_THREADS_OPTION = "threadsForHttpConnections";
+const std::string PARALLEL_THREADS_ENV_OPTION = "SILO_THREADS_FOR_HTTP_CONNECTIONS";
+const std::string PORT_OPTION = "port";
+const std::string PORT_ENV_OPTION = "SILO_PORT";
 
 struct RuntimeConfig {
    std::filesystem::path data_directory = silo::preprocessing::DEFAULT_OUTPUT_DIRECTORY.directory;
@@ -21,6 +25,7 @@ struct RuntimeConfig {
    uint16_t port = 8081;
 
    void overwriteFromFile(const std::filesystem::path& config_path);
+   void overwriteFromEnvironmentVariables();
    void overwriteFromCommandLineArguments(const Poco::Util::AbstractConfiguration& config);
 };
 

--- a/src/silo_api/api.cpp
+++ b/src/silo_api/api.cpp
@@ -216,6 +216,7 @@ class SiloServer : public Poco::Util::ServerApplication {
       if (std::filesystem::exists("./runtime_config.yaml")) {
          runtime_config.overwriteFromFile("./runtime_config.yaml");
       }
+      runtime_config.overwriteFromEnvironmentVariables();
       runtime_config.overwriteFromCommandLineArguments(config());
 
       silo_api::DatabaseMutex database_mutex;

--- a/src/silo_api/runtime_config.cpp
+++ b/src/silo_api/runtime_config.cpp
@@ -6,34 +6,75 @@
 #include <spdlog/spdlog.h>
 #include <yaml-cpp/yaml.h>
 
-namespace YAML {
-
-template <>
-struct convert<silo_api::RuntimeConfig> {
-   static bool decode(const Node& node, silo_api::RuntimeConfig& config) {
-      config = silo_api::RuntimeConfig{
-         node["dataDirectory"]
-            ? std::optional<std::filesystem::path>(node["dataDirectory"].as<std::string>())
-            : std::nullopt
-      };
-
-      return true;
-   }
-};
-
-}  // namespace YAML
-
 namespace silo_api {
 
-RuntimeConfig RuntimeConfig::readFromFile(const std::filesystem::path& config_path) {
+void RuntimeConfig::overwriteFromFile(const std::filesystem::path& config_path) {
    SPDLOG_INFO("Reading runtime config from {}", config_path.string());
 
    try {
-      return YAML::LoadFile(config_path.string()).as<RuntimeConfig>();
+      YAML::Node node = YAML::LoadFile(config_path.string());
+      if (node[DATA_DIRECTORY_OPTION]) {
+         SPDLOG_DEBUG(
+            "Using dataDirectory passed via config file: {}",
+            node[DATA_DIRECTORY_OPTION].as<std::string>()
+         );
+         data_directory = node[DATA_DIRECTORY_OPTION].as<std::string>();
+      }
+      if (node[MAX_CONNECTIONS_OPTION]) {
+         SPDLOG_DEBUG(
+            "Using maximum queued http connections passed via config file: {}",
+            node[MAX_CONNECTIONS_OPTION].as<int32_t>()
+         );
+         max_connections = node[MAX_CONNECTIONS_OPTION].as<int32_t>();
+      }
+      if (node[PARALLEL_THREADS_OPTION]) {
+         SPDLOG_DEBUG(
+            "Using parallel threads for accepting http connections as passed via config file: {}",
+            node[PARALLEL_THREADS_OPTION].as<int32_t>()
+         );
+         parallel_threads = node[PARALLEL_THREADS_OPTION].as<int32_t>();
+      }
+      if (node[PORT_OPTION]) {
+         SPDLOG_DEBUG("Using port passed via config file: {}", node[PORT_OPTION].as<uint16_t>());
+         port = node[PORT_OPTION].as<uint16_t>();
+      }
    } catch (const YAML::Exception& e) {
       throw std::runtime_error(
          "Failed to read runtime config from " + config_path.string() + ": " + std::string(e.what())
       );
+   }
+}
+
+void RuntimeConfig::overwriteFromCommandLineArguments(
+   const Poco::Util::AbstractConfiguration& config
+) {
+   if (config.hasProperty(DATA_DIRECTORY_OPTION)) {
+      SPDLOG_DEBUG(
+         "Using dataDirectory passed via command line argument: {}",
+         config.getString(DATA_DIRECTORY_OPTION)
+      );
+      data_directory = config.getString(DATA_DIRECTORY_OPTION);
+   }
+   if (config.hasProperty(MAX_CONNECTIONS_OPTION)) {
+      SPDLOG_DEBUG(
+         "Using maximum queued http connections passed via command line argument: {}",
+         config.getInt(MAX_CONNECTIONS_OPTION)
+      );
+      max_connections = config.getInt(MAX_CONNECTIONS_OPTION);
+   }
+   if (config.hasProperty(PARALLEL_THREADS_OPTION)) {
+      SPDLOG_DEBUG(
+         "Using parallel threads for accepting http connections as passed via command line "
+         "argument: {}",
+         config.getInt(PARALLEL_THREADS_OPTION)
+      );
+      parallel_threads = config.getInt(PARALLEL_THREADS_OPTION);
+   }
+   if (config.hasProperty(PORT_OPTION)) {
+      SPDLOG_DEBUG(
+         "Using port passed via command line argument: {}", config.getString(PORT_OPTION)
+      );
+      port = config.getUInt(PORT_OPTION);
    }
 }
 

--- a/src/silo_api/runtime_config.cpp
+++ b/src/silo_api/runtime_config.cpp
@@ -3,8 +3,10 @@
 #include <stdexcept>
 #include <string>
 
+#include <Poco/Environment.h>
 #include <spdlog/spdlog.h>
 #include <yaml-cpp/yaml.h>
+#include <boost/lexical_cast.hpp>
 
 namespace silo_api {
 
@@ -42,6 +44,39 @@ void RuntimeConfig::overwriteFromFile(const std::filesystem::path& config_path) 
       throw std::runtime_error(
          "Failed to read runtime config from " + config_path.string() + ": " + std::string(e.what())
       );
+   }
+}
+
+void RuntimeConfig::overwriteFromEnvironmentVariables() {
+   if (Poco::Environment::has(DATA_DIRECTORY_ENV_OPTION)) {
+      SPDLOG_DEBUG(
+         "Using dataDirectory passed via environment variable: {}",
+         Poco::Environment::get(DATA_DIRECTORY_ENV_OPTION)
+      );
+      data_directory = Poco::Environment::get(DATA_DIRECTORY_ENV_OPTION);
+   }
+   if (Poco::Environment::has(MAX_CONNECTIONS_ENV_OPTION)) {
+      SPDLOG_DEBUG(
+         "Using maximum queued http connections passed via environment variable: {}",
+         Poco::Environment::get(MAX_CONNECTIONS_ENV_OPTION)
+      );
+      max_connections =
+         boost::lexical_cast<int>(Poco::Environment::get(MAX_CONNECTIONS_ENV_OPTION));
+   }
+   if (Poco::Environment::has(PARALLEL_THREADS_ENV_OPTION)) {
+      SPDLOG_DEBUG(
+         "Using parallel threads for accepting http connections as passed via environment "
+         "variable: {}",
+         Poco::Environment::get(PARALLEL_THREADS_ENV_OPTION)
+      );
+      parallel_threads =
+         boost::lexical_cast<int>(Poco::Environment::get(PARALLEL_THREADS_ENV_OPTION));
+   }
+   if (Poco::Environment::has(PORT_ENV_OPTION)) {
+      SPDLOG_DEBUG(
+         "Using port passed via environment variable: {}", Poco::Environment::get(PORT_ENV_OPTION)
+      );
+      port = boost::lexical_cast<uint16_t>(Poco::Environment::get(PORT_ENV_OPTION));
    }
 }
 

--- a/src/silo_api/runtime_config.test.cpp
+++ b/src/silo_api/runtime_config.test.cpp
@@ -3,8 +3,8 @@
 #include <gtest/gtest.h>
 
 TEST(RuntimeConfig, shouldReadConfig) {
-   const auto result =
-      silo_api::RuntimeConfig::readFromFile("./testBaseData/test_runtime_config.yaml");
+   silo_api::RuntimeConfig runtime_config;
+   runtime_config.overwriteFromFile("./testBaseData/test_runtime_config.yaml");
 
-   ASSERT_EQ(result.data_directory, std::filesystem::path("test/directory"));
+   ASSERT_EQ(runtime_config.data_directory, std::filesystem::path("test/directory"));
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
feat: tidying up CLI and file configuration for runtime config. Added option for specifying the port

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

The port on which SILO listens to requests should be able to be specified.

Furthermore, I edited the way the configs are parsed such that there is a default `RuntimeConfig` (default constructor), which has 2 member functions for overwriting its values from 1. the config file and 2. the CLI arguments


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
