### PR TITLE
chore(ci): Add opencontainers.image.source label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,3 +25,6 @@ HEALTHCHECK --start-period=20s CMD curl --fail --silent localhost:8081/info | jq
 EXPOSE 8081
 
 ENTRYPOINT ["./siloApi"]
+
+LABEL org.opencontainers.image.source="https://github.com/GenSpectrum/LAPIS-SILO"
+LABEL org.opencontainers.image.description="Sequence Indexing engine for Large Order of genomic data"


### PR DESCRIPTION
This helps downstream users, e.g. by allowing them to enable dependabot to create update PRs.

See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file?learn=dependency_version_updates&learnProduct=code-security#docker