### PR TITLE
feat: add number of partitions to /info

### DIFF
--- a/endToEndTests/test/info.test.js
+++ b/endToEndTests/test/info.test.js
@@ -9,7 +9,7 @@ describe('The /info endpoint', () => {
       .expect(200)
       .expect('Content-Type', 'application/json')
       .expect(headerToHaveDataVersion)
-      .expect({ nBitmapsSize: 3898, sequenceCount: 100, totalSize: 26589464 });
+      .expect({ nBitmapsSize: 3898, sequenceCount: 100, totalSize: 26589464, numberOfPartitions: 11 });
   });
 
   it('should return detailed info about the current state of the database', { timeout: 5000 }, async () => {

--- a/include/silo/database_info.h
+++ b/include/silo/database_info.h
@@ -15,6 +15,7 @@ struct DatabaseInfo {
    uint32_t sequence_count;
    uint64_t total_size;
    size_t n_bitmaps_size;
+   uint64_t number_of_partitions;
 };
 
 }  // namespace silo

--- a/src/silo/database.cpp
+++ b/src/silo/database.cpp
@@ -146,7 +146,8 @@ DatabaseInfo Database::getDatabaseInfo() const {
    return DatabaseInfo{
       .sequence_count = sequence_count,
       .total_size = total_size,
-      .n_bitmaps_size = nucleotide_symbol_n_bitmaps_size
+      .n_bitmaps_size = nucleotide_symbol_n_bitmaps_size,
+      .number_of_partitions = partitions.size()
    };
 }
 

--- a/src/silo/database.test.cpp
+++ b/src/silo/database.test.cpp
@@ -42,6 +42,7 @@ TEST(DatabaseTest, shouldBuildDatabaseWithoutErrors) {
 
    EXPECT_GT(simple_database_info.total_size, 0);
    EXPECT_EQ(simple_database_info.sequence_count, 100);
+   EXPECT_EQ(simple_database_info.number_of_partitions, 11);
 }
 
 TEST(DatabaseTest, shouldSuccessfullyBuildDatabaseWithoutPartitionBy) {
@@ -69,6 +70,7 @@ TEST(DatabaseTest, shouldSuccessfullyBuildDatabaseWithoutPartitionBy) {
 
    EXPECT_GT(simple_database_info.total_size, 0);
    EXPECT_EQ(simple_database_info.sequence_count, 100);
+   EXPECT_EQ(simple_database_info.number_of_partitions, 1);
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
@@ -138,4 +140,5 @@ TEST(DatabaseTest, shouldSaveAndReloadDatabaseWithoutErrors) {
    EXPECT_GT(simple_database_info.total_size, 0);
    EXPECT_EQ(simple_database_info.sequence_count, 100);
    EXPECT_GT(simple_database_info.n_bitmaps_size, 0);
+   EXPECT_EQ(simple_database_info.number_of_partitions, 11);
 }

--- a/src/silo_api/info_handler.cpp
+++ b/src/silo_api/info_handler.cpp
@@ -19,7 +19,8 @@ void to_json(nlohmann::json& json, const DatabaseInfo& databaseInfo) {
    json = nlohmann::json{
       {"sequenceCount", databaseInfo.sequence_count},
       {"totalSize", databaseInfo.total_size},
-      {"nBitmapsSize", databaseInfo.n_bitmaps_size}
+      {"nBitmapsSize", databaseInfo.n_bitmaps_size},
+      {"numberOfPartitions", databaseInfo.number_of_partitions}
    };
 }
 

--- a/src/silo_api/request_handler_factory.test.cpp
+++ b/src/silo_api/request_handler_factory.test.cpp
@@ -78,7 +78,10 @@ TEST_F(RequestHandlerTestFixture, handlesGetInfoRequest) {
    processRequest();
 
    EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_OK);
-   EXPECT_EQ(response.out_stream.str(), R"({"nBitmapsSize":3,"sequenceCount":1,"totalSize":2})");
+   EXPECT_EQ(
+      response.out_stream.str(),
+      R"({"nBitmapsSize":3,"numberOfPartitions":0,"sequenceCount":1,"totalSize":2})"
+   );
    EXPECT_EQ(response.get("data-version"), "1234");
 }
 


### PR DESCRIPTION
### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

Now returns the number of partitions in the info call:
```
{
  "nBitmapsSize": 3898,
  "numberOfPartitions": 11,
  "sequenceCount": 100,
  "totalSize": 26589464
}
``` 

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted or there is an issue to do so.~~ (There are no docs for this)
- [x] The implemented feature is covered by an appropriate test.
