### PR TITLE
chore: fixed the commitlint checks to not only run when changing from draft to read_for_review

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,12 +3,16 @@ name: Commitlint
 on:
   pull_request:
     types:
+      - opened
+      - reopened
+      - synchronize
       - ready_for_review
 
 jobs:
   commitlint:
     name: Lint commit messages
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
commitlint before only ran when changing the status from draft to ready. The trigger should still contain all types of commits or pr opening, but then only run the job if it is not a draft PR

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~- [ ] All necessary documentation has been adapted or there is an issue to do so.~
~~- [ ] The implemented feature is covered by an appropriate test.~~
