### PR TITLE
fix: allow insertions that start at 0

### DIFF
--- a/src/silo/query_engine/filter_expressions/insertion_contains.cpp
+++ b/src/silo/query_engine/filter_expressions/insertion_contains.cpp
@@ -118,8 +118,8 @@ void from_json(const nlohmann::json& json, std::unique_ptr<InsertionContains<Sym
       "The field 'position' is required in an InsertionContains expression"
    )
    CHECK_SILO_QUERY(
-      json["position"].is_number_unsigned() && (json["position"].get<uint32_t>() > 0),
-      "The field 'position' in an InsertionContains expression needs to be a positive number (> 0)"
+      json["position"].is_number_unsigned(),
+      "The field 'position' in an InsertionContains expression needs to be an unsigned integer"
    )
    CHECK_SILO_QUERY(
       !json.contains("sequenceName") || json["sequenceName"].is_string(),

--- a/src/silo/storage/sequence_store.cpp
+++ b/src/silo/storage/sequence_store.cpp
@@ -89,11 +89,6 @@ InsertionEntry parseInsertion(const std::string& value) {
    try {
       if (position_and_insertion.size() == 2) {
          const auto position = boost::lexical_cast<uint32_t>(position_and_insertion[0]);
-         if (position == 0) {
-            const std::string message =
-               "Positions are 1-indexed, position of 0 not allowed in insertion: " + value;
-            throw silo::preprocessing::PreprocessingException(message);
-         }
          const auto& insertion = position_and_insertion[1];
          return {.position_idx = position, .insertion = insertion};
       }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
SILO preprocessing aborts after insertions refactoring. Both for loculus and GenSpectrum. This has for now been pinned to an exception that is thrown when insertions with a position of 0 are encountered. It is also a bug that it aborts instead of throwing the appropriate exception #448 

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~- [ ] All necessary documentation has been adapted or there is an issue to do so.~
~- [ ] The implemented feature is covered by an appropriate test.~
