### PR TITLE
fix: Remove incorrect compile flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 set(CMAKE_CXX_FLAGS "-Wall")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -static-libstdc++ -static-libgcc")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 # Work-around only for MacOS
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #448

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
Remove incorrect flags: `set(CMAKE_CXX_FLAGS_RELEASE "[...] -static-libstdc++ -static-libgcc")`

These should instead be declared as

`target_link_options(siloApi PUBLIC  -static-libstdc++ -static-libgcc)`

because `CMAKE_CXX_FLAGS..` are used for the compilation of every unit (.cpp) file. This links standard library code into the output multiple times.

But having that compilation flag is also not desirable, as the tbb's shard object (.so) file is itself linked against shared libgcc and libstdc++ as verified by

```
> ldd libtbb.so
	linux-vdso.so.1 (0x00007fffcbca7000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fc3db913000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fc3db8f3000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fc3db6ca000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fc3dbba2000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fc3db5e3000)
```

And using different standard libraries (statically linked in our code, shared in tbb dependency) leads to problems as pointed out by `man gcc`
>        -static-libgcc
>
>           ...   
>
>           There are several situations in which an application should use the shared libgcc instead of the static version.  The most common of these is when
>           the application wishes to throw and catch exceptions across different shared libraries.  In that case, each of the libraries as well as the
>           application itself should use the shared libgcc.

.. and as observed in #448 


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
