### PR TITLE
build: do not build intermediary silo library (libsilo.a)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,11 +56,8 @@ include_directories(SYSTEM
 
 file(GLOB_RECURSE SRC_TEST "src/*.test.cpp")
 
-file(GLOB_RECURSE SRC_SILO_LIB "src/silo/*.cpp")
-list(REMOVE_ITEM SRC_SILO_LIB ${SRC_TEST})
-
-file(GLOB_RECURSE SRC_SILO_API "src/silo_api/*.cpp")
-list(REMOVE_ITEM SRC_SILO_API ${SRC_TEST})
+file(GLOB_RECURSE SRC_SILO "src/*.cpp")
+list(REMOVE_ITEM SRC_SILO ${SRC_TEST})
 
 # ---------------------------------------------------------------------------
 # Linter
@@ -82,9 +79,9 @@ endif ()
 # Targets
 # ---------------------------------------------------------------------------
 
-add_library(silo ${SRC_SILO_LIB})
+add_executable(siloApi src/silo_api/api.cpp ${SRC_SILO})
 target_link_libraries(
-        silo
+        siloApi
         PUBLIC
         ${Boost_LIBRARIES}
         ${duckdb_LIBRARIES}
@@ -94,10 +91,10 @@ target_link_libraries(
         TBB::tbb
         ${yaml-cpp_LIBRARIES}
         zstd::libzstd_static
+        Poco::Net
+        Poco::Util
+        Poco::JSON
 )
-
-add_executable(siloApi src/silo_api/api.cpp ${SRC_SILO_API})
-target_link_libraries(siloApi PUBLIC silo Poco::Net Poco::Util Poco::JSON nlohmann_json::nlohmann_json ${spdlog_LIBRARIES})
 
 # ---------------------------------------------------------------------------
 # Tests
@@ -107,12 +104,26 @@ enable_testing()
 find_package(GTest REQUIRED)
 include_directories(${GTest_INCLUDE_DIRS})
 
-set(SRC_SILO_API_WITHOUT_MAIN ${SRC_SILO_API})
-list(REMOVE_ITEM SRC_SILO_API_WITHOUT_MAIN "${CMAKE_SOURCE_DIR}/src/silo_api/api.cpp")
+set(SRC_SILO_WITHOUT_MAIN ${SRC_SILO})
+list(REMOVE_ITEM SRC_SILO_WITHOUT_MAIN "${CMAKE_SOURCE_DIR}/src/silo_api/api.cpp")
 
-add_executable(silo_test ${SRC_TEST} ${SRC_SILO_API_WITHOUT_MAIN})
-
+add_executable(silo_test ${SRC_TEST} ${SRC_SILO_WITHOUT_MAIN})
 if (NOT GTest_LIBRARIES)
     set(GTest_LIBRARIES gtest gmock)
 endif ()
-target_link_libraries(silo_test ${GTest_LIBRARIES} silo Poco::Net Poco::Util Poco::JSON nlohmann_json::nlohmann_json)
+target_link_libraries(
+        silo_test
+        ${GTest_LIBRARIES}
+        ${Boost_LIBRARIES}
+        ${duckdb_LIBRARIES}
+        nlohmann_json::nlohmann_json
+        ${roaring_LIBRARIES}
+        ${spdlog_LIBRARIES}
+        TBB::tbb
+        ${yaml-cpp_LIBRARIES}
+        zstd::libzstd_static
+        Poco::Net
+        Poco::Util
+        Poco::JSON
+        nlohmann_json::nlohmann_json
+)


### PR DESCRIPTION

### Summary

Creating the .a and then unpacking it again for linking has a high
cost: around 3-3.5 seconds on the server I use: rebuild times when all
source files are in in the ccache drops from 5.5-6.5 to 2.4-2.6
seconds. Rebuild when src/silo/storage/sequence_store.cpp needs
compilation drops from 14.5-15.3 to 11.1-11.8 seconds. Separately
running `ar x ../build/libsilo.a` costs ~0.5 and `ar q my.a *.o` ~1.6
seconds.

We are not making use of libsilo.a, thus remove it.

## PR Checklist

- ~[] All necessary documentation has been adapted or there is an issue to do so.~
- ~[] The implemented feature is covered by an appropriate test.~
