### PR TITLE
fix: erroneous file created during unit tests should not leak

### DIFF
--- a/testBaseData/numericNames/preprocessing_config.yaml
+++ b/testBaseData/numericNames/preprocessing_config.yaml
@@ -1,4 +1,3 @@
 inputDirectory: "testBaseData/numericNames"
 ndjsonInputFilename: "input_file.ndjson"
 referenceGenomeFilename: "reference_genomes.json"
-preprocessingDatabaseLocation: "debug.duckdb"


### PR DESCRIPTION

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
One can persist the duckdb database that is used during preprocessing for debugging purposes. I didn't remove this option in one of the unit tests. Because the unit tests are run from the repository's root directory, this debug file was also created in that location. This is now removed.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
