### PR TITLE
feat: allow null for sequenceName in insertion contains queries

### DIFF
--- a/include/silo/query_engine/query_parse_sequence_name.h
+++ b/include/silo/query_engine/query_parse_sequence_name.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "silo/database.h"
+
+namespace silo {
+
+template <typename SymbolType>
+std::string validateSequenceName(std::string sequence_name, const silo::Database& database) {
+   CHECK_SILO_QUERY(
+      database.getSequenceStores<SymbolType>().contains(sequence_name),
+      fmt::format(
+         "Database does not contain the {} Sequence with name: '{}'",
+         SymbolType::SYMBOL_NAME,
+         sequence_name
+      )
+   );
+   return sequence_name;
+}
+
+template <typename SymbolType>
+std::string validateSequenceNameOrGetDefault(
+   std::optional<std::string> sequence_name,
+   const silo::Database& database
+) {
+   if (sequence_name.has_value()) {
+      return validateSequenceName<SymbolType>(sequence_name.value(), database);
+   }
+
+   CHECK_SILO_QUERY(
+      database.getDefaultSequenceName<SymbolType>().has_value(),
+      "The database has no default " + std::string(SymbolType::SYMBOL_NAME_LOWER_CASE) +
+         " sequence name"
+   );
+
+   const auto default_sequence_name = database.getDefaultSequenceName<SymbolType>().value();
+   return validateSequenceName<SymbolType>(default_sequence_name, database);
+}
+
+}  // namespace silo

--- a/include/silo/test/query_fixture.test.h
+++ b/include/silo/test/query_fixture.test.h
@@ -58,11 +58,20 @@ namespace silo::test {
                                                                                                    \
    TEST_P(TEST_SUITE_NAME##FixtureAlias, testQuery) {                                              \
       const auto scenario = GetParam();                                                            \
-      const auto result = query_engine.executeQuery(nlohmann::to_string(scenario.query));          \
-      const auto actual = nlohmann::json(result.query_result);                                     \
-      ASSERT_EQ(actual, scenario.expected_query_result);                                           \
+      if (!scenario.expected_error_message.empty()) {                                              \
+         try {                                                                                     \
+            const auto result = query_engine.executeQuery(nlohmann::to_string(scenario.query));    \
+            FAIL() << "Expected an error in test case, but noting was thrown";                     \
+         } catch (const std::exception& e) {                                                       \
+            EXPECT_EQ(std::string(e.what()), scenario.expected_error_message);                     \
+         }                                                                                         \
+      } else {                                                                                     \
+         const auto result = query_engine.executeQuery(nlohmann::to_string(scenario.query));       \
+         const auto actual = nlohmann::json(result.query_result);                                  \
+         ASSERT_EQ(actual, scenario.expected_query_result);                                        \
+      }                                                                                            \
    }                                                                                               \
-   }  // namespace
+   }  // namespace                                                                                  \
 
 struct QueryTestData {
    const std::vector<nlohmann::json> ndjson_input_data;
@@ -75,6 +84,7 @@ struct QueryTestScenario {
    std::string name;
    nlohmann::json query;
    nlohmann::json expected_query_result;
+   std::string expected_error_message;
 };
 
 std::string printScenarioName(const ::testing::TestParamInfo<QueryTestScenario>& scenario);

--- a/src/silo/test/amino_acid_insertion_contains.test.cpp
+++ b/src/silo/test/amino_acid_insertion_contains.test.cpp
@@ -1,0 +1,102 @@
+#include <nlohmann/json.hpp>
+
+#include <optional>
+
+#include "silo/test/query_fixture.test.h"
+
+using silo::ReferenceGenomes;
+using silo::config::DatabaseConfig;
+using silo::config::ValueType;
+using silo::test::QueryTestData;
+using silo::test::QueryTestScenario;
+
+nlohmann::json createDataWithAminoAcidInsertions(
+   const std::string& primaryKey,
+   const nlohmann::json& aminoAcidInsertions
+) {
+   return {
+      {"metadata", {{"primaryKey", primaryKey}}},
+      {"alignedNucleotideSequences", {{"segment1", nullptr}, {"segment2", nullptr}}},
+      {"unalignedNucleotideSequences", {{"segment1", nullptr}, {"segment2", nullptr}}},
+      {"alignedAminoAcidSequences", {{"gene1", nullptr}, {"gene2", nullptr}}},
+      {"nucleotideInsertions", {{"segment1", {}}, {"segment2", {}}}},
+      {"aminoAcidInsertions", aminoAcidInsertions}
+   };
+}
+
+const std::vector<nlohmann::json> DATA = {
+   createDataWithAminoAcidInsertions("id_0", {{"gene1", {"123:A"}}, {"gene2", {}}}),
+   createDataWithAminoAcidInsertions("id_1", {{"gene1", {"123:A"}}, {"gene2", {}}}),
+   createDataWithAminoAcidInsertions("id_2", {{"gene1", {"234:BB"}}, {"gene2", {}}}),
+   createDataWithAminoAcidInsertions("id_3", {{"gene1", {"123:CCC"}}, {"gene2", {}}}),
+};
+
+const auto DATABASE_CONFIG = DatabaseConfig{
+   .default_nucleotide_sequence = "segment1",
+   .schema =
+      {.instance_name = "dummy name",
+       .metadata = {{.name = "primaryKey", .type = ValueType::STRING}},
+       .primary_key = "primaryKey"}
+};
+
+const auto REFERENCE_GENOMES = ReferenceGenomes{
+   {{"segment1", "A"}, {"segment2", "T"}},
+   {{"gene1", "*"}, {"gene2", "*"}},
+};
+
+const QueryTestData TEST_DATA{
+   .ndjson_input_data = {DATA},
+   .database_config = DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES
+};
+
+nlohmann::json createAminoAcidInsertionContainsQuery(
+   const nlohmann::json& sequenceName,
+   int position,
+   const std::string& insertedSymbols
+) {
+   return {
+      {"action", {{"type", "Details"}}},
+      {"filterExpression",
+       {{"type", "AminoAcidInsertionContains"},
+        {"position", position},
+        {"value", insertedSymbols},
+        {"sequenceName", sequenceName}}}
+   };
+}
+
+nlohmann::json createAminoAcidInsertionContainsQueryWithEmptySequenceName(
+   int position,
+   const std::string& insertedSymbols
+) {
+   return {
+      {"action", {{"type", "Details"}}},
+      {"filterExpression",
+       {
+          {"type", "AminoAcidInsertionContains"},
+          {"position", position},
+          {"value", insertedSymbols},
+       }}
+   };
+}
+
+const QueryTestScenario AMINO_ACID_INSERTION_CONTAINS_SCENARIO = {
+   .name = "aminoAcidInsertionContains",
+   .query = createAminoAcidInsertionContainsQuery("gene1", 123, "A"),
+   .expected_query_result = nlohmann::json({{{"primaryKey", "id_0"}}, {{"primaryKey", "id_1"}}})
+};
+
+const QueryTestScenario AMINO_ACID_INSERTION_CONTAINS_WITH_NULL_SEGMENT_SCENARIO = {
+   .name = "aminoAcidInsertionWithNullSegment",
+   .query = createAminoAcidInsertionContainsQueryWithEmptySequenceName(123, "A"),
+   .expected_error_message = "The database has no default amino acid sequence name",
+};
+
+QUERY_TEST(
+   AminoAcidInsertionContainsTest,
+   TEST_DATA,
+   ::testing::Values(
+      AMINO_ACID_INSERTION_CONTAINS_SCENARIO,
+      AMINO_ACID_INSERTION_CONTAINS_WITH_NULL_SEGMENT_SCENARIO
+   )
+);

--- a/src/silo/test/insertion_contains.test.cpp
+++ b/src/silo/test/insertion_contains.test.cpp
@@ -1,0 +1,110 @@
+#include <nlohmann/json.hpp>
+
+#include <optional>
+
+#include "silo/test/query_fixture.test.h"
+
+using silo::ReferenceGenomes;
+using silo::config::DatabaseConfig;
+using silo::config::ValueType;
+using silo::test::QueryTestData;
+using silo::test::QueryTestScenario;
+
+nlohmann::json createDataWithNucleotideInsertions(
+   const std::string& primaryKey,
+   const nlohmann::json& nucleotideInsertions
+) {
+   return {
+      {"metadata", {{"primaryKey", primaryKey}}},
+      {"alignedNucleotideSequences", {{"segment1", nullptr}, {"segment2", nullptr}}},
+      {"unalignedNucleotideSequences", {{"segment1", nullptr}, {"segment2", nullptr}}},
+      {"alignedAminoAcidSequences", {{"gene1", nullptr}}},
+      {"nucleotideInsertions", nucleotideInsertions},
+      {"aminoAcidInsertions", {{"gene1", {}}}}
+   };
+}
+
+const std::vector<nlohmann::json> DATA = {
+   createDataWithNucleotideInsertions("id_0", {{"segment1", {"123:A"}}, {"segment2", {}}}),
+   createDataWithNucleotideInsertions("id_1", {{"segment1", {"123:A"}}, {"segment2", {}}}),
+   createDataWithNucleotideInsertions("id_2", {{"segment1", {"234:TT"}}, {"segment2", {}}}),
+   createDataWithNucleotideInsertions("id_3", {{"segment1", {"123:CCC"}}, {"segment2", {}}}),
+};
+
+const auto DATABASE_CONFIG = DatabaseConfig{
+   .default_nucleotide_sequence = "segment1",
+   .schema =
+      {.instance_name = "dummy name",
+       .metadata = {{.name = "primaryKey", .type = ValueType::STRING}},
+       .primary_key = "primaryKey"}
+};
+
+const auto REFERENCE_GENOMES = ReferenceGenomes{
+   {{"segment1", "A"}, {"segment2", "T"}},
+   {{"gene1", "*"}},
+};
+
+const QueryTestData TEST_DATA{
+   .ndjson_input_data = {DATA},
+   .database_config = DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES
+};
+
+nlohmann::json createInsertionContainsQuery(
+   const nlohmann::json& sequenceName,
+   int position,
+   const std::string& insertedSymbols
+) {
+   return {
+      {"action", {{"type", "Details"}}},
+      {"filterExpression",
+       {{"type", "InsertionContains"},
+        {"position", position},
+        {"value", insertedSymbols},
+        {"sequenceName", sequenceName}}}
+   };
+}
+
+nlohmann::json createInsertionContainsQueryWithEmptySequenceName(
+   int position,
+   const std::string& insertedSymbols
+) {
+   return {
+      {"action", {{"type", "Details"}}},
+      {"filterExpression",
+       {
+          {"type", "InsertionContains"},
+          {"position", position},
+          {"value", insertedSymbols},
+       }}
+   };
+}
+
+const QueryTestScenario INSERTION_CONTAINS_SCENARIO = {
+   .name = "insertionContains",
+   .query = createInsertionContainsQuery("segment1", 123, "A"),
+   .expected_query_result = nlohmann::json({{{"primaryKey", "id_0"}}, {{"primaryKey", "id_1"}}})
+};
+
+const QueryTestScenario INSERTION_CONTAINS_WITH_EMPTY_SEGMENT_SCENARIO = {
+   .name = "insertionContainsWithNullSegmentDefaultsToDefaultSegment",
+   .query = createInsertionContainsQueryWithEmptySequenceName(123, "A"),
+   .expected_query_result = nlohmann::json({{{"primaryKey", "id_0"}}, {{"primaryKey", "id_1"}}})
+};
+
+const QueryTestScenario INSERTION_CONTAINS_WITH_UNKNOWN_SEGMENT_SCENARIO = {
+   .name = "insertionContainsWithUnknownSegment",
+   .query = createInsertionContainsQuery("unknownSegmentName", 123, "A"),
+   .expected_error_message =
+      "Database does not contain the Nucleotide Sequence with name: 'unknownSegmentName'"
+};
+
+QUERY_TEST(
+   InsertionContainsTest,
+   TEST_DATA,
+   ::testing::Values(
+      INSERTION_CONTAINS_SCENARIO,
+      INSERTION_CONTAINS_WITH_EMPTY_SEGMENT_SCENARIO,
+      INSERTION_CONTAINS_WITH_UNKNOWN_SEGMENT_SCENARIO
+   )
+);


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
Fixes the error, that users could not pass `segmentName: null` or `segmentName: ""` in `insertion_contains` queries. This is necessary for nucleotide insertion queries. https://github.com/GenSpectrum/LAPIS/issues/806 is related to this.

Do we want to treat an empty string the same as passing null? (Currently I have implemented it like it, but we don't have to.

Additionally, we can now test that a query throws an error.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [x] The implemented feature is covered by an appropriate test.
