### PR TITLE
fix: insertions being added at wrong index for large files

### DIFF
--- a/include/silo/common/table_reader.h
+++ b/include/silo/common/table_reader.h
@@ -29,6 +29,7 @@ class TableReader {
    std::unique_ptr<duckdb::MaterializedQueryResult> query_result;
    std::unique_ptr<duckdb::DataChunk> current_chunk;
    size_t current_row;
+   size_t current_row_in_chunk;
 
    std::optional<std::string> nextKey();
 

--- a/src/silo/common/table_reader.cpp
+++ b/src/silo/common/table_reader.cpp
@@ -31,7 +31,7 @@ std::optional<std::string> silo::TableReader::nextKey() {
       return std::nullopt;
    }
 
-   return current_chunk->GetValue(0, current_row).GetValue<std::string>();
+   return current_chunk->GetValue(0, current_row_in_chunk).GetValue<std::string>();
 }
 
 void silo::TableReader::read() {
@@ -40,7 +40,7 @@ void silo::TableReader::read() {
    while (nextKey()) {
       for (size_t column_idx = 0; column_idx < column_functions.size(); column_idx++) {
          column_functions.at(column_idx)
-            .function(current_row, current_chunk->GetValue(column_idx + 1, current_row));
+            .function(current_row, current_chunk->GetValue(column_idx + 1, current_row_in_chunk));
       }
       advanceRow();
    }
@@ -81,6 +81,7 @@ void silo::TableReader::loadTable() {
    }
    current_chunk = query_result->Fetch();
    current_row = 0;
+   current_row_in_chunk = 0;
 
    while (current_chunk && current_chunk->size() == 0) {
       current_chunk = query_result->Fetch();
@@ -89,8 +90,9 @@ void silo::TableReader::loadTable() {
 
 void silo::TableReader::advanceRow() {
    current_row++;
-   if (current_row == current_chunk->size()) {
-      current_row = 0;
+   current_row_in_chunk++;
+   if (current_row_in_chunk == current_chunk->size()) {
+      current_row_in_chunk = 0;
       current_chunk = query_result->Fetch();
       while (current_chunk && current_chunk->size() == 0) {
          current_chunk = query_result->Fetch();


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves https://github.com/GenSpectrum/cov-spectrum-website/issues/992

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

SILO was adding insertions at the wrong positions for large input files.


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
