### PR TITLE
fix: more efficient ndjson emptiness check

### DIFF
--- a/src/silo/preprocessing/metadata_info.cpp
+++ b/src/silo/preprocessing/metadata_info.cpp
@@ -91,7 +91,7 @@ bool MetadataInfo::isNdjsonFileEmpty(const std::filesystem::path& ndjson_file) {
 
    auto result = connection.Query(fmt::format(
       "SELECT COUNT(*) "
-      "FROM read_json_auto(\"{}\");",
+      "FROM (SELECT * FROM read_json_auto(\"{}\") LIMIT 1);",
       ndjson_file.string()
    ));
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves issue where SILO occasionally uses a lot more memory for preprocessing since 0.2.3

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

Before we did a `COUNT(*)` on the entire file, which is costly. Now we do the `COUNT(*)` only on the first row of the file.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
