### PR TITLE
refactor: lambda-callbacks instead of fill columns

### DIFF
--- a/include/silo/common/table_reader.h
+++ b/include/silo/common/table_reader.h
@@ -13,9 +13,16 @@
 
 namespace silo {
 
-struct ColumnFunction {
+class ColumnFunction {
+   friend class TableReader;
    std::string column_name;
    std::function<void(size_t, const duckdb::Value&)> function;
+
+  public:
+   ColumnFunction(
+      std::string column_name,
+      std::function<void(size_t, const duckdb::Value&)> function
+   );
 };
 
 class TableReader {
@@ -31,12 +38,6 @@ class TableReader {
    size_t current_row;
    size_t current_row_in_chunk;
 
-   std::optional<std::string> nextKey();
-
-   std::string getTableQuery();
-
-   void advanceRow();
-
   public:
    explicit TableReader(
       duckdb::Connection& connection,
@@ -47,7 +48,14 @@ class TableReader {
       std::string_view order_by_clause
    );
 
-   void read();
+   size_t read();
+
+  private:
+   std::optional<std::string> nextKey();
+
+   std::string getTableQuery();
+
+   void advanceRow();
 
    void loadTable();
 };

--- a/include/silo/storage/column_group.h
+++ b/include/silo/storage/column_group.h
@@ -81,13 +81,6 @@ class ColumnPartitionGroup {
    std::map<std::string, storage::column::DateColumnPartition&> date_columns;
    std::map<std::string, storage::column::PangoLineageColumnPartition&> pango_lineage_columns;
 
-   uint32_t fill(
-      duckdb::Connection& connection,
-      uint32_t partition_id,
-      const std::string& order_by_clause,
-      const silo::config::DatabaseConfig& database_config
-   );
-
    void addValueToColumn(
       const std::string& column_name,
       config::ColumnType column_type,

--- a/src/silo/common/table_reader.cpp
+++ b/src/silo/common/table_reader.cpp
@@ -11,6 +11,13 @@
 
 #include "silo/preprocessing/preprocessing_exception.h"
 
+silo::ColumnFunction::ColumnFunction(
+   std::string column_name,
+   std::function<void(size_t, const duckdb::Value&)> function
+)
+    : column_name(std::move(column_name)),
+      function(std::move(function)) {}
+
 silo::TableReader::TableReader(
    duckdb::Connection& connection,
    std::string_view table_name,
@@ -34,7 +41,7 @@ std::optional<std::string> silo::TableReader::nextKey() {
    return current_chunk->GetValue(0, current_row_in_chunk).GetValue<std::string>();
 }
 
-void silo::TableReader::read() {
+size_t silo::TableReader::read() {
    loadTable();
    assert(query_result->ColumnCount() == column_functions.size() + 1);
    while (nextKey()) {
@@ -44,6 +51,7 @@ void silo::TableReader::read() {
       }
       advanceRow();
    }
+   return current_row;
 }
 
 std::string silo::TableReader::getTableQuery() {


### PR DESCRIPTION


<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
instead of the columns pulling the next row from the file_reader, the file_reader
 instead pushes the value to the columns using callbacks.

This is in preparation for parallelizing the building of column functions

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
