### PR TITLE
Process chunks column-wise in the table reader

### DIFF
--- a/include/silo/common/table_reader.h
+++ b/include/silo/common/table_reader.h
@@ -35,8 +35,8 @@ class TableReader {
    std::string order_by_clause;
    std::unique_ptr<duckdb::MaterializedQueryResult> query_result;
    std::unique_ptr<duckdb::DataChunk> current_chunk;
-   size_t current_row;
-   size_t current_row_in_chunk;
+   size_t current_start_of_chunk = 0;
+   size_t current_chunk_size = 0;
 
   public:
    explicit TableReader(
@@ -51,11 +51,7 @@ class TableReader {
    size_t read();
 
   private:
-   std::optional<std::string> nextKey();
-
    std::string getTableQuery();
-
-   void advanceRow();
 
    void loadTable();
 };

--- a/src/silo/preprocessing/preprocessor.cpp
+++ b/src/silo/preprocessing/preprocessor.cpp
@@ -666,8 +666,18 @@ void Preprocessor::buildMetadataStore(
          fmt::format("partition_id = {}", partition_id),
          order_by_clause
       );
-      const size_t number_of_rows = table_reader.read();
-      database.partitions.at(partition_id).sequence_count += number_of_rows;
+
+      int64_t fill_time;
+      {
+         const silo::common::BlockTimer timer(fill_time);
+         const size_t number_of_rows = table_reader.read();
+         database.partitions.at(partition_id).sequence_count += number_of_rows;
+      }
+      SPDLOG_DEBUG(
+         "build - finished fill columns for partition {} in {} microseconds",
+         partition_id,
+         fill_time
+      );
       SPDLOG_INFO("build - finished columns for partition {}", partition_id);
    }
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #291

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

We now use tbb::parallel_for to build the different columns in parallel per input chunk.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
