### PR TITLE
make linter only run on changed files 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ concurrency:
 
 env:
   DOCKER_DEPENDENCY_IMAGE_NAME: ghcr.io/genspectrum/lapis-silo-dependencies
-  DOCKER_LINTER_DEPENDENCY_IMAGE_NAME: ghcr.io/genspectrum/lapis-silo-linter-dependencies
   DOCKER_IMAGE_NAME: ghcr.io/genspectrum/lapis-silo
 
 jobs:
@@ -30,94 +29,6 @@ jobs:
           clang-format-version: '17'
           check-path: ${{ matrix.path['check'] }}
           exclude-regex: ${{ matrix.path['exclude'] }}
-
-  linterDependencies:
-    name: Build linter dependencies
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Generate dependency files hash
-        id: files-hash
-        run: |
-          DIR_HASH=$(echo -n ${{ hashFiles('conanfile.py', 'conanprofile.docker', '.github/workflows/ci.yml', './Dockerfile_linter_dependencies') }})
-          echo "DIR_HASH=$DIR_HASH" >> $GITHUB_ENV
-
-      - name: Docker metadata
-        id: dockerMetadata
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.DOCKER_LINTER_DEPENDENCY_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=${{ env.DIR_HASH }}
-            type=sha,prefix=commit-
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check if image exists
-        id: check-image
-        run: |
-          EXISTS=$(docker manifest inspect ${{ env.DOCKER_LINTER_DEPENDENCY_IMAGE_NAME }}:${{ env.DIR_HASH }} > /dev/null 2>&1 && echo "true" || echo "false")
-          echo "CACHE_HIT=$EXISTS" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        if: env.CACHE_HIT == 'false'
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build linter dependencies image
-        if: env.CACHE_HIT == 'false'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.dockerMetadata.outputs.tags }}
-          file: ./Dockerfile_linter_dependencies
-          cache-from: type=gha,ref=linter-dependencies-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile_linter') }}
-          cache-to: type=gha,mode=min,ref=linter-dependencies-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile_linter') }}
-
-      - name: Retag and push existing image if cache hit
-        if: env.CACHE_HIT == 'true'
-        run: |
-          TAGS=(${{ steps.dockerMetadata.outputs.tags }})
-          for TAG in "${TAGS[@]}"; do
-            docker buildx imagetools create --tag $TAG ${{ env.DOCKER_LINTER_DEPENDENCY_IMAGE_NAME }}:${{ env.DIR_HASH }}
-          done
-
-  linter:
-    name: Build And Run linter
-    needs: linterDependencies
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Generate dependency files hash
-        id: files-hash
-        run: |
-          DIR_HASH=$(echo -n ${{ hashFiles('conanfile.py', 'conanprofile.docker', '.github/workflows/ci.yml', './Dockerfile_linter_dependencies') }})
-          echo "DIR_HASH=$DIR_HASH" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build linter image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile_linter
-          cache-from: type=gha,ref=${{ github.ref_name }}-linter-image-cache
-          cache-to: type=gha,mode=min,ref=${{ github.ref_name }}-linter-image-cache
-          push: false
-          build-args: |
-            DEPENDENCY_IMAGE=ghcr.io/genspectrum/lapis-silo-linter-dependencies:${{ env.DIR_HASH }}
 
   dependencyImage:
     name: Build Docker Image Dependencies
@@ -142,7 +53,7 @@ jobs:
             type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=${{ env.DIR_HASH }}
-            type=sha,prefix=commit-
+            type=sha,format=long,prefix=commit-
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -204,7 +115,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=sha,prefix=commit-
+            type=sha,format=long,prefix=commit-
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,105 @@
+name: Run Linter
+
+on:
+  pull_request:
+
+concurrency:
+  group: linter-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOCKER_LINTER_DEPENDENCY_IMAGE_NAME: ghcr.io/genspectrum/lapis-silo-linter-dependencies
+
+jobs:
+  linterDependencies:
+    name: Build linter dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate dependency files hash
+        id: files-hash
+        run: |
+          DIR_HASH=$(echo -n ${{ hashFiles('conanfile.py', 'conanprofile.docker', '.github/workflows/linter.yml', './Dockerfile_linter_dependencies') }})
+          echo "DIR_HASH=$DIR_HASH" >> $GITHUB_ENV
+
+      - name: Docker metadata
+        id: dockerMetadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_LINTER_DEPENDENCY_IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=${{ env.DIR_HASH }}
+            type=sha,format=long,prefix=commit-
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if image exists
+        id: check-image
+        run: |
+          EXISTS=$(docker manifest inspect ${{ env.DOCKER_LINTER_DEPENDENCY_IMAGE_NAME }}:${{ env.DIR_HASH }} > /dev/null 2>&1 && echo "true" || echo "false")
+          echo "CACHE_HIT=$EXISTS" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        if: env.CACHE_HIT == 'false'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build linter dependencies image
+        if: env.CACHE_HIT == 'false'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.dockerMetadata.outputs.tags }}
+          file: ./Dockerfile_linter_dependencies
+          cache-from: type=gha,ref=linter-dependencies-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile_linter') }}
+          cache-to: type=gha,mode=min,ref=linter-dependencies-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile_linter') }}
+
+      - name: Retag and push existing image if cache hit
+        if: env.CACHE_HIT == 'true'
+        run: |
+          TAGS=(${{ steps.dockerMetadata.outputs.tags }})
+          for TAG in "${TAGS[@]}"; do
+            docker buildx imagetools create --tag $TAG ${{ env.DOCKER_LINTER_DEPENDENCY_IMAGE_NAME }}:${{ env.DIR_HASH }}
+          done
+
+  linter:
+    name: Build And Run linter
+    needs: linterDependencies
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+    container:
+      image: ghcr.io/genspectrum/lapis-silo-linter-dependencies:commit-${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - shell: bash
+        name: Configure and run clang-tidy on changed files
+        run: |
+          mv /src/build .
+          cmake -DBUILD_WITH_CLANG_TIDY=on -D CMAKE_BUILD_TYPE=Debug -B build
+          echo "Successfully configured cmake"
+          files=$(curl -s \
+           "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+           | jq -r '.[].filename')
+          echo "Changed files of this PR:"
+          echo "$files"
+          IFS=$'\n'
+          for file in $files; do
+            echo "Check ending for file: $file"
+            if [[ $file == *.cpp ]]; then
+              echo "Now linting the file: $file"
+              echo "cmake --build build --target ${file%.cpp}.o"
+              cmake --build build --target ${file%.cpp}.o
+            fi
+          done

--- a/Dockerfile_linter_dependencies
+++ b/Dockerfile_linter_dependencies
@@ -12,7 +12,9 @@ RUN apt update \
     lsb-release=11.1.0ubuntu4 \
     && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
     && add-apt-repository 'deb http://apt.llvm.org/jammy/  llvm-toolchain-jammy main' \
-    && apt install -y clang-tidy-19
+    && apt install -y clang-tidy-19 \
+    && apt install -y jq \
+    && apt install -y curl
 
 RUN pip install conan==2.0.17
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #392 #491 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

Now for every pull request the linter is only run on the files, that are changed by the pull request.

We will also add a check for all files again that is run on main and on demand.


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
