### PR TITLE
build: share library for test and api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,9 @@ file(GLOB_RECURSE SRC_TEST "src/*.test.cpp")
 file(GLOB_RECURSE SRC_SILO "src/*.cpp")
 list(REMOVE_ITEM SRC_SILO ${SRC_TEST})
 
+set(SRC_SILO_WITHOUT_MAIN ${SRC_SILO})
+list(REMOVE_ITEM SRC_SILO_WITHOUT_MAIN "${CMAKE_SOURCE_DIR}/src/silo_api/api.cpp")
+
 # ---------------------------------------------------------------------------
 # Linter
 # ---------------------------------------------------------------------------
@@ -79,9 +82,9 @@ endif ()
 # Targets
 # ---------------------------------------------------------------------------
 
-add_executable(siloApi src/silo_api/api.cpp ${SRC_SILO})
+add_library(silolib OBJECT ${SRC_SILO_WITHOUT_MAIN})
 target_link_libraries(
-        siloApi
+        silolib
         PUBLIC
         ${Boost_LIBRARIES}
         ${duckdb_LIBRARIES}
@@ -96,6 +99,13 @@ target_link_libraries(
         Poco::JSON
 )
 
+add_executable(siloApi "${CMAKE_SOURCE_DIR}/src/silo_api/api.cpp" $<TARGET_OBJECTS:silolib>)
+target_link_libraries(
+        siloApi
+        PUBLIC
+        silolib
+)
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -104,26 +114,8 @@ enable_testing()
 find_package(GTest REQUIRED)
 include_directories(${GTest_INCLUDE_DIRS})
 
-set(SRC_SILO_WITHOUT_MAIN ${SRC_SILO})
-list(REMOVE_ITEM SRC_SILO_WITHOUT_MAIN "${CMAKE_SOURCE_DIR}/src/silo_api/api.cpp")
-
-add_executable(silo_test ${SRC_TEST} ${SRC_SILO_WITHOUT_MAIN})
+add_executable(silo_test ${SRC_TEST} $<TARGET_OBJECTS:silolib>)
 if (NOT GTest_LIBRARIES)
     set(GTest_LIBRARIES gtest gmock)
 endif ()
-target_link_libraries(
-        silo_test
-        ${GTest_LIBRARIES}
-        ${Boost_LIBRARIES}
-        ${duckdb_LIBRARIES}
-        nlohmann_json::nlohmann_json
-        ${roaring_LIBRARIES}
-        ${spdlog_LIBRARIES}
-        TBB::tbb
-        ${yaml-cpp_LIBRARIES}
-        zstd::libzstd_static
-        Poco::Net
-        Poco::Util
-        Poco::JSON
-        nlohmann_json::nlohmann_json
-)
+target_link_libraries(silo_test PUBLIC ${GTest_LIBRARIES} silolib)


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
Currently two object files are generated for every source file. See the linter doing his work twice:
https://github.com/GenSpectrum/LAPIS-SILO/actions/runs/9599350811/job/26473097915
But also the [normal build step](https://github.com/GenSpectrum/LAPIS-SILO/actions/runs/9599350009/job/26472879416) lists every source file twice, once for each target:
```
#9 367.9 [ 75%] Building CXX object CMakeFiles/siloApi.dir/src/silo/storage/column/date_column.cpp.o
#9 368.8 [ 76%] Building CXX object CMakeFiles/silo_test.dir/src/silo/storage/column/date_column.cpp.o
```
Here cmake is very conservative as different flags could be used to compile the same source file twice.
But we are the ones in control here and can adjust the `CMakeLists.txt` to compile the files once as a library, but without archiving that library using the [Object Library feature](https://cmake.org/cmake/help/latest/command/add_library.html#object-libraries). The object library feature does exactly what we want. As we do not want to distribute the library, expensively archiving all sources into a `.a`-archive is not being done. Still, all object files are only compiled once.

We also need to only list the relevant linked libraries once, as `target_link_libraries` correctly inherits them from the shared library.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
