### PR TITLE
chore: change base image to ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ COPY docker_default_preprocessing_config.yaml ./default_preprocessing_config.yam
 COPY docker_runtime_config.yaml ./runtime_config.yaml
 COPY --from=builder /src/siloApi ./
 
-RUN apt update \
-    &&  apt install -y libtbb-dev=2021.5.0-7ubuntu2 curl jq
+RUN apt update && apt dist-upgrade -y \
+    &&  apt install -y libtbb12 curl jq
 
 # call /info, extract "seqeunceCount" from the JSON and assert that the value is not 0. If any of those fails, "exit 1".
 HEALTHCHECK --start-period=20s CMD curl --fail --silent localhost:8081/info | jq .sequenceCount | xargs test 0 -ne || exit 1

--- a/Dockerfile_dependencies
+++ b/Dockerfile_dependencies
@@ -1,16 +1,14 @@
-FROM alpine:3.20
+FROM ubuntu:22.04
 
 ARG TARGETPLATFORM
 
-RUN apk update && apk add --no-cache py3-pip \
-    build-base=0.5-r3 \
-    cmake=3.29.3-r0 \
-    bash=5.2.26-r0 \
-    linux-headers=6.6-r0 \
-    boost-build=1.84.0-r0 \
-    onetbb=2021.12.0-r0
+RUN apt update \
+    && apt install -y \
+    cmake=3.22.1-1ubuntu1.22.04.2 \
+    python3-pip=22.0.2+dfsg-1ubuntu0.4 \
+    software-properties-common=0.99.22.9
 
-RUN pip install conan==2.4.1 --break-system-packages
+RUN pip install conan==2.5.0
 
 WORKDIR /src
 COPY conanfile.py conanprofile.docker conanprofile.docker_arm ./

--- a/Dockerfile_dependencies
+++ b/Dockerfile_dependencies
@@ -2,11 +2,9 @@ FROM ubuntu:22.04
 
 ARG TARGETPLATFORM
 
-RUN apt update \
+RUN apt update && apt dist-upgrade -y \
     && apt install -y \
-    cmake=3.22.1-1ubuntu1.22.04.2 \
-    python3-pip=22.0.2+dfsg-1ubuntu0.4 \
-    software-properties-common=0.99.22.9
+    cmake python3-pip
 
 RUN pip install conan==2.5.0
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->


### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

Tests revealed that there is a tremendous difference in speed between alpine and ubuntu images. The 182MB vs 62MB are negligible. 

debian images have a similar memory footprint to ubuntu at 220MB for debian:12 and 178MB for debian:12-slim images


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [ ] The implemented feature is covered by an appropriate test.
