### PR TITLE
Report sort error

### DIFF
--- a/include/silo/query_engine/query_parse_exception.h
+++ b/include/silo/query_engine/query_parse_exception.h
@@ -12,6 +12,6 @@ namespace silo {
 
 class [[maybe_unused]] QueryParseException : public std::runtime_error {
   public:
-   [[maybe_unused]] QueryParseException(const std::string& error_message);
+   [[maybe_unused]] explicit QueryParseException(const std::string& error_message);
 };
 }  // namespace silo

--- a/include/silo/query_engine/query_parse_exception.h
+++ b/include/silo/query_engine/query_parse_exception.h
@@ -10,8 +10,26 @@
 
 namespace silo {
 
-class [[maybe_unused]] QueryParseException : public std::runtime_error {
+class [[maybe_unused]] QueryException : public std::runtime_error {
+  protected:
+   explicit QueryException(const std::string& error_message);
+
+  public:
+   /// A short string describing the phase or similar of query
+   /// exception.
+   [[nodiscard]] virtual std::string_view duringString() const = 0;
+};
+
+class [[maybe_unused]] QueryParseException : public QueryException {
   public:
    [[maybe_unused]] explicit QueryParseException(const std::string& error_message);
+   [[nodiscard]] std::string_view duringString() const override;
 };
+
+class [[maybe_unused]] QueryEvaluationException : public QueryException {
+  public:
+   [[maybe_unused]] explicit QueryEvaluationException(const std::string& error_message);
+   [[nodiscard]] std::string_view duringString() const override;
+};
+
 }  // namespace silo

--- a/src/silo/query_engine/actions/action.cpp
+++ b/src/silo/query_engine/actions/action.cpp
@@ -149,8 +149,8 @@ QueryResult Action::executeAndOrder(
       // query syntax but with its execution. But this will disappear
       // from the code base again soon.
       auto error = [&](const std::string_view& what) {
-         throw silo::QueryParseException(fmt::format(
-            "{} not supported for streaming endpoints when receiving more than {} rows, but got "
+         throw silo::QueryEvaluationException(fmt::format(
+            "{} not supported for streaming endpoints when returning more than {} rows, but got "
             "{}+",
             what,
             MATERIALIZATION_CUTOFF,

--- a/src/silo/query_engine/query_parse_exception.cpp
+++ b/src/silo/query_engine/query_parse_exception.cpp
@@ -4,6 +4,23 @@
 #include <string>
 
 namespace silo {
-[[maybe_unused]] QueryParseException::QueryParseException(const std::string& error_message)
+
+QueryException::QueryException(const std::string& error_message)
     : std::runtime_error(error_message.c_str()) {}
+
+[[maybe_unused]] QueryParseException::QueryParseException(const std::string& error_message)
+    : QueryException(error_message) {}
+
+std::string_view QueryParseException::duringString() const {
+   return "parsing";
+}
+
+[[maybe_unused]] QueryEvaluationException::QueryEvaluationException(const std::string& error_message
+)
+    : QueryException(error_message) {}
+
+std::string_view QueryEvaluationException::duringString() const {
+   return "evaluation";
+}
+
 }  // namespace silo

--- a/src/silo_api/query_handler.cpp
+++ b/src/silo_api/query_handler.cpp
@@ -50,9 +50,11 @@ void QueryHandler::post(
             );
          }
       }
-   } catch (const silo::QueryParseException& ex) {
+   } catch (const silo::QueryException& ex) {
       response.setContentType("application/json");
-      SPDLOG_INFO("Query is invalid: " + query + " - exception: " + ex.what());
+      SPDLOG_INFO(
+         "Query is invalid: {} - exception during {}: {}", query, ex.duringString(), ex.what()
+      );
       response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
       std::ostream& out_stream = response.send();
       out_stream << nlohmann::json(ErrorResponse{.error = "Bad request", .message = ex.what()});


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves "also reject sorting" request on Slack.

### Summary

IIRC we never discussed the further plans for sorting when streaming. Probably refusing with an error ("unimplemented") is really the right thing to do so far. It's a bit weird and potentially problematic in that FASTA/FASTA aligned queries will succeed with sorting first, then when the data set grows until the result set becomes >10'000 rows, they will start to fail. But that may still be better than silently wrong sorting. It would be good to warn the user in advance (while there are still <10'000 rows) somehow; again something that NDJSON cannot deliver, while JSON could contain richer data than just the rows. Documentation will have to be enough, or perhaps the dashboard or other UI components could warn about such queries.
I worry a bit more now that Details should also be changed to stream, and will expose the same conundrum.

As per discussion (Fabian), for Details we might set the cut-off a lot higher though since/if the involved data is much smaller, and might make the problem go away for most organisms.

There is no test as it's still impossible to test without large data or future work, thus will test manually.

User documentation should be added, but where?

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
~~- [ ] The implemented feature is covered by an appropriate test.~~
