### PR TITLE
fix: increase duckdb memory limit to 80GB

### DIFF
--- a/src/silo/preprocessing/preprocessing_database.cpp
+++ b/src/silo/preprocessing/preprocessing_database.cpp
@@ -40,7 +40,7 @@ PreprocessingDatabase::PreprocessingDatabase(
       connection(duck_db) {
    query("PRAGMA default_null_order='NULLS FIRST';");
    query("SET preserve_insertion_order=FALSE;");
-   query("SET memory_limit='50 GB';");
+   query("SET memory_limit='80 GB';");
    const Identifiers compress_nucleotide_function_identifiers =
       Identifiers{reference_genomes.getSequenceNames<Nucleotide>()}.prefix("compress_nuc_");
    const Identifiers compress_amino_acid_function_identifiers =


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves the issue raised in slack of failing GISAID preprocessing on the staging server

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

duckdb memory_limit was set too conservative. This was done as previous duckdb versions did not conform to the memory limit for all features. This can now be raised to some higher limit.


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
