### PR TITLE
fix: validate that either a ndjson or tsv file was given as input

### DIFF
--- a/src/silo/config/preprocessing_config.cpp
+++ b/src/silo/config/preprocessing_config.cpp
@@ -14,11 +14,19 @@ void PreprocessingConfig::validate() const {
    if (!std::filesystem::exists(input_directory)) {
       throw preprocessing::PreprocessingException(input_directory.string() + " does not exist");
    }
-   if (ndjson_input_filename.has_value() && metadata_file) {
+   if (ndjson_input_filename.has_value() && metadata_file.has_value()) {
       throw preprocessing::PreprocessingException(fmt::format(
          "Cannot specify both a ndjsonInputFilename ('{}') and metadataFilename('{}').",
          ndjson_input_filename.value().string(),
          metadata_file.value().string()
+      ));
+   }
+   if (!ndjson_input_filename.has_value() && !metadata_file.has_value()) {
+      throw preprocessing::PreprocessingException(fmt::format(
+         "Neither a ndjsonInputFilename ('{}') nor a metadataFilename ('{}') was specified as "
+         "preprocessing option.",
+         NDJSON_INPUT_FILENAME_OPTION.toCamelCase(),
+         METADATA_FILENAME_OPTION.toCamelCase()
       ));
    }
 }
@@ -211,7 +219,7 @@ void PreprocessingConfig::overwrite(const silo::config::AbstractConfigSource& co
       ctx.out(),
       "{{ input directory: '{}', pango_lineage_definition_file: {}, output_directory: '{}', "
       "metadata_file: '{}', reference_genome_file: '{}',  gene_file_prefix: '{}',  "
-      "nucleotide_sequence_file_prefix: '{}', unalgined_nucleotide_sequence_file_prefix: '{}', "
+      "nucleotide_sequence_file_prefix: '{}', unaligned_nucleotide_sequence_file_prefix: '{}', "
       "ndjson_filename: {}, "
       "preprocessing_database_location: {} }}",
       preprocessing_config.input_directory.string(),


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #564 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

We did not check that either a ndjson or tsv file is actually specified as the input. 

The resulting duckdb error is not parsable for users. Instead we now return a proper error message, also hinting at the possible CLI arguments that can be given instead of amending the preprocessing_config


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [ ] The implemented feature is covered by an appropriate test.
