### PR TITLE
feat(docker): Add zstd to the dockerimage used in silo preprocessing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY docker_runtime_config.yaml ./runtime_config.yaml
 COPY --from=builder /src/siloApi ./
 
 RUN apt update && apt dist-upgrade -y \
-    &&  apt install -y libtbb12 curl jq
+    &&  apt install -y libtbb12 curl jq zstd
 
 # call /info, extract "seqeunceCount" from the JSON and assert that the value is not 0. If any of those fails, "exit 1".
 HEALTHCHECK --start-period=20s CMD curl --fail --silent localhost:8081/info | jq .sequenceCount | xargs test 0 -ne || exit 1


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
Adds zstd to the silo image, as we use zstd file compression this generally makes sense to have, I also need this to add changes proposed in https://github.com/loculus-project/loculus/pull/2773 (checking that we have received all streamed data).
