### PR TITLE
feat: make duckdb memory limit configurable via preprocessing config

### DIFF
--- a/include/silo/config/preprocessing_config.h
+++ b/include/silo/config/preprocessing_config.h
@@ -21,6 +21,7 @@ const AbstractConfigSource::Option INTERMEDIATE_RESULTS_DIRECTORY_OPTION = {
 const AbstractConfigSource::Option PREPROCESSING_DATABASE_LOCATION_OPTION = {
    {"preprocessingDatabaseLocation"}
 };
+const AbstractConfigSource::Option DUCKDB_MEMORY_LIMIT_OPTION = {{"duckdbMemoryLimitInG"}};
 const AbstractConfigSource::Option PANGO_LINEAGE_DEFINITION_FILENAME_OPTION = {
    {"pangoLineageDefinitionFilename"}
 };
@@ -47,6 +48,7 @@ class PreprocessingConfig {
    std::filesystem::path output_directory = DEFAULT_OUTPUT_DIRECTORY;
    std::filesystem::path intermediate_results_directory = "./temp/";
    std::optional<std::filesystem::path> preprocessing_database_location;
+   std::optional<uint32_t> duckdb_memory_limit_in_g;
    std::optional<std::filesystem::path> pango_lineage_definition_file;
    std::optional<std::filesystem::path> ndjson_input_filename;
    std::optional<std::filesystem::path> metadata_file;
@@ -68,6 +70,8 @@ class PreprocessingConfig {
    [[nodiscard]] std::filesystem::path getReferenceGenomeFilename() const;
 
    [[nodiscard]] std::optional<std::filesystem::path> getPreprocessingDatabaseLocation() const;
+
+   [[nodiscard]] std::optional<uint32_t> getDuckdbMemoryLimitInG() const;
 
    [[nodiscard]] std::optional<std::filesystem::path> getNdjsonInputFilename() const;
 

--- a/include/silo/preprocessing/preprocessing_database.h
+++ b/include/silo/preprocessing/preprocessing_database.h
@@ -29,7 +29,8 @@ class PreprocessingDatabase {
   public:
    PreprocessingDatabase(
       const std::optional<std::filesystem::path>& backing_file,
-      const ReferenceGenomes& reference_genomes
+      const ReferenceGenomes& reference_genomes,
+      std::optional<uint32_t> memory_limit
    );
 
    duckdb::Connection& getConnection();

--- a/src/silo/config/preprocessing_config.cpp
+++ b/src/silo/config/preprocessing_config.cpp
@@ -43,6 +43,10 @@ std::optional<std::filesystem::path> PreprocessingConfig::getPreprocessingDataba
    return preprocessing_database_location;
 }
 
+[[nodiscard]] std::optional<uint32_t> PreprocessingConfig::getDuckdbMemoryLimitInG() const {
+   return duckdb_memory_limit_in_g;
+}
+
 std::optional<std::filesystem::path> PreprocessingConfig::getPangoLineageDefinitionFilename(
 ) const {
    return pango_lineage_definition_file.has_value()
@@ -128,6 +132,15 @@ void PreprocessingConfig::overwrite(const silo::config::AbstractConfigSource& co
          *value
       );
       preprocessing_database_location = *value;
+   }
+   if (auto value = config.getUInt32(DUCKDB_MEMORY_LIMIT_OPTION)) {
+      SPDLOG_DEBUG(
+         "Using {} as passed via {}: {}",
+         DUCKDB_MEMORY_LIMIT_OPTION.toString(),
+         config.configType(),
+         *value
+      );
+      duckdb_memory_limit_in_g = value;
    }
    if (auto value = config.getString(PANGO_LINEAGE_DEFINITION_FILENAME_OPTION)) {
       SPDLOG_DEBUG(

--- a/src/silo/preprocessing/preprocessing_database.cpp
+++ b/src/silo/preprocessing/preprocessing_database.cpp
@@ -34,13 +34,16 @@ namespace silo::preprocessing {
 
 PreprocessingDatabase::PreprocessingDatabase(
    const std::optional<std::filesystem::path>& backing_file,
-   const ReferenceGenomes& reference_genomes
+   const ReferenceGenomes& reference_genomes,
+   std::optional<uint32_t> memory_limit
 )
     : duck_db(backing_file.value_or(":memory:")),
       connection(duck_db) {
    query("PRAGMA default_null_order='NULLS FIRST';");
    query("SET preserve_insertion_order=FALSE;");
-   query("SET memory_limit='80 GB';");
+   if (memory_limit.has_value()) {
+      query(fmt::format("SET memory_limit='{} GB';", memory_limit.value()));
+   }
    const Identifiers compress_nucleotide_function_identifiers =
       Identifiers{reference_genomes.getSequenceNames<Nucleotide>()}.prefix("compress_nuc_");
    const Identifiers compress_amino_acid_function_identifiers =

--- a/src/silo/preprocessing/preprocessor.cpp
+++ b/src/silo/preprocessing/preprocessor.cpp
@@ -56,7 +56,11 @@ Preprocessor::Preprocessor(
       database_config(std::move(database_config_)),
       reference_genomes(std::move(reference_genomes_)),
       alias_lookup(std::move(alias_lookup)),
-      preprocessing_db(preprocessing_config.getPreprocessingDatabaseLocation(), reference_genomes),
+      preprocessing_db(
+         preprocessing_config.getPreprocessingDatabaseLocation(),
+         reference_genomes,
+         preprocessing_config.getDuckdbMemoryLimitInG()
+      ),
       nuc_sequence_identifiers_without_prefix(
          Identifiers{reference_genomes.getSequenceNames<Nucleotide>()}
       ),

--- a/testBaseData/exampleDatasetAsNdjson/preprocessing_config.yaml
+++ b/testBaseData/exampleDatasetAsNdjson/preprocessing_config.yaml
@@ -1,3 +1,4 @@
 ndjsonInputFilename: "input_file.ndjson"
 pangoLineageDefinitionFilename: "pangolineage_alias.json"
 referenceGenomeFilename: "reference_genomes.json"
+duckdbMemoryLimitInG: 20


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #568 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

The memory limit was causing repeated issues as it is handled differently in recent duckdb versions than before. (In theory it is now consistent, but the it only worked smoothly due to inconsistencies in duckdb features that respect the memory limit).

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
