### PR TITLE
Enable duckdb option partitioned_write_flush_threshold=1024 to reduce memory

### DIFF
--- a/src/silo/preprocessing/preprocessing_database.cpp
+++ b/src/silo/preprocessing/preprocessing_database.cpp
@@ -41,6 +41,7 @@ PreprocessingDatabase::PreprocessingDatabase(
       connection(duck_db) {
    query("PRAGMA default_null_order='NULLS FIRST';");
    query("SET preserve_insertion_order=FALSE;");
+   query("SET partitioned_write_flush_threshold = 1024;");
    if (memory_limit.has_value()) {
       query(fmt::format("SET memory_limit='{} GB';", memory_limit.value()));
    }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves spurious OOM crashes when preprocessing large datasets

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

We now set the flag partitioned_write_flush_threshold to 1024, whereas its default value is 524288. Initial tests did not indicate a big slowdown of the preprocessing times.

We found this flag in a discussion of a similar issue [here](https://github.com/duckdb/duckdb/issues/9880#issuecomment-2266148994).

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
