### PR TITLE
fix: prevent setDatabase starvation which leads to no updates of currently loaded database

### DIFF
--- a/include/silo_api/database_mutex.h
+++ b/include/silo_api/database_mutex.h
@@ -1,19 +1,10 @@
 #pragma once
 
-#include <shared_mutex>
+#include <memory>
 
 #include "silo/database.h"
 
 namespace silo_api {
-
-class FixedDatabase {
-   std::shared_lock<std::shared_mutex> lock;
-
-  public:
-   FixedDatabase(const silo::Database& database, std::shared_lock<std::shared_mutex>&& mutex);
-
-   const silo::Database& database;
-};
 
 class UninitializedDatabaseException : public std::runtime_error {
   public:
@@ -22,15 +13,18 @@ class UninitializedDatabaseException : public std::runtime_error {
 };
 
 class DatabaseMutex {
-   std::shared_mutex mutex;
-   silo::Database database;
    bool is_initialized = false;
+   std::shared_ptr<silo::Database> database;
 
   public:
    DatabaseMutex() = default;
+   DatabaseMutex(const DatabaseMutex& other) = delete;
+   DatabaseMutex(DatabaseMutex&& other) = delete;
+   DatabaseMutex& operator=(const DatabaseMutex& other) = delete;
+   DatabaseMutex& operator=(DatabaseMutex&& other) = delete;
 
    void setDatabase(silo::Database&& new_database);
 
-   virtual FixedDatabase getDatabase();
+   virtual std::shared_ptr<silo::Database> getDatabase();
 };
 }  // namespace silo_api

--- a/src/silo_api/database_directory_watcher.cpp
+++ b/src/silo_api/database_directory_watcher.cpp
@@ -116,7 +116,7 @@ void silo_api::DatabaseDirectoryWatcher::checkDirectoryForData(Poco::Timer& /*ti
    {
       try {
          const auto current_data_version_timestamp =
-            database_mutex.getDatabase().database.getDataVersionTimestamp();
+            database_mutex.getDatabase()->getDataVersionTimestamp();
          const auto most_recent_data_version_timestamp_found =
             most_recent_database_state->second.getTimestamp();
          if (current_data_version_timestamp >= most_recent_data_version_timestamp_found) {
@@ -137,6 +137,11 @@ void silo_api::DatabaseDirectoryWatcher::checkDirectoryForData(Poco::Timer& /*ti
    try {
       database_mutex.setDatabase(silo::Database::loadDatabaseState(most_recent_database_state->first
       ));
+      SPDLOG_INFO(
+         "New database with version {} successfully loaded.",
+         most_recent_database_state->first.string()
+      );
+      return;
    } catch (const std::exception& ex) {
       SPDLOG_ERROR(ex.what());
    } catch (const std::string& ex) {
@@ -150,7 +155,7 @@ void silo_api::DatabaseDirectoryWatcher::checkDirectoryForData(Poco::Timer& /*ti
       }
    }
    SPDLOG_INFO(
-      "New database with version {} successfully loaded.",
+      "Did not load new database with version {} successfully.",
       most_recent_database_state->first.string()
    );
 }

--- a/src/silo_api/database_mutex.cpp
+++ b/src/silo_api/database_mutex.cpp
@@ -1,31 +1,24 @@
 #include "silo_api/database_mutex.h"
 
-#include <mutex>
+#include <atomic>
 #include <utility>
 
 #include "silo/database.h"
 
 namespace silo_api {
 
-silo_api::FixedDatabase::FixedDatabase(
-   const silo::Database& database,
-   std::shared_lock<std::shared_mutex>&& mutex
-)
-    : lock(std::move(mutex)),
-      database(database) {}
-
 void silo_api::DatabaseMutex::setDatabase(silo::Database&& new_database) {
-   const std::unique_lock lock(mutex);
-   database = std::move(new_database);
+   auto new_database_pointer = std::make_shared<silo::Database>(std::move(new_database));
+
+   std::atomic_store(&database, new_database_pointer);
    is_initialized = true;
 }
 
-silo_api::FixedDatabase silo_api::DatabaseMutex::getDatabase() {
+std::shared_ptr<silo::Database> silo_api::DatabaseMutex::getDatabase() {
    if (!is_initialized) {
       throw silo_api::UninitializedDatabaseException();
    }
-   std::shared_lock<std::shared_mutex> lock(mutex);
-   return {database, std::move(lock)};
+   return std::atomic_load(&database);
 }
 
 }  // namespace silo_api

--- a/src/silo_api/info_handler.cpp
+++ b/src/silo_api/info_handler.cpp
@@ -99,13 +99,13 @@ void InfoHandler::get(
 
    const auto fixed_database = database.getDatabase();
 
-   response.set("data-version", fixed_database.database.getDataVersionTimestamp().value);
+   response.set("data-version", fixed_database->getDataVersionTimestamp().value);
 
    const bool return_detailed_info = request_parameter.find("details") != request_parameter.end() &&
                                      request_parameter.at("details") == "true";
-   const nlohmann::json database_info =
-      return_detailed_info ? nlohmann::json(database.getDatabase().database.detailedDatabaseInfo())
-                           : nlohmann::json(database.getDatabase().database.getDatabaseInfo());
+   const nlohmann::json database_info = return_detailed_info
+                                           ? nlohmann::json(fixed_database->detailedDatabaseInfo())
+                                           : nlohmann::json(fixed_database->getDatabaseInfo());
    response.setContentType("application/json");
    std::ostream& out_stream = response.send();
    out_stream << database_info;

--- a/src/silo_api/query_handler.cpp
+++ b/src/silo_api/query_handler.cpp
@@ -35,9 +35,9 @@ void QueryHandler::post(
    try {
       const auto fixed_database = database_mutex.getDatabase();
 
-      auto query_result = fixed_database.database.executeQuery(query);
+      auto query_result = fixed_database->executeQuery(query);
 
-      response.set("data-version", fixed_database.database.getDataVersionTimestamp().value);
+      response.set("data-version", fixed_database->getDataVersionTimestamp().value);
 
       response.setContentType("application/x-ndjson");
       std::ostream& out_stream = response.send();


### PR DESCRIPTION
### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
resolves issue mentioned on slack, where the swap-over to the latest folder can sometimes fail.

Before, the setDatabase call requested a write-mutex. This was unnecessarily expensive. Instead, it is enough that we just atomically load and store the current database. Databases lifetimes for currently running transactions is now managed by a shared_ptr, which will correctly deallocate the old state once the last reference to the database is dropped (i.e. the last query using the old state has finished)

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
