### PR TITLE
chore: add CLion specific folder cmake-build-release to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ conanprofile
 # CLion
 /.idea
 /cmake-build-debug
+/cmake-build-release
 
 # Compiled Object files
 *.slo


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
add CLion specific folder cmake-build-release to .gitignore

This folder is generated when building sources in Release mode from CLion

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
