### PR TITLE
build: put conan-generated Find<lib>.cmake files in a separate directory from build/

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -87,7 +87,7 @@ jobs:
         name: Configure and run clang-tidy on changed files
         run: |
           mv /src/build .
-          cmake -DBUILD_WITH_CLANG_TIDY=on -D CMAKE_BUILD_TYPE=Debug -B build
+          cmake -DBUILD_WITH_CLANG_TIDY=on -D CMAKE_BUILD_TYPE=Debug -B build/Debug
           echo "Successfully configured cmake"
           files=""
           PAGE=1  
@@ -110,7 +110,7 @@ jobs:
             echo "Check ending for file: $file"
             if [[ $file == *.cpp ]]; then
               echo "Now linting the file: $file"
-              echo "cmake --build build --target ${file%.cpp}.o"
-              cmake --build build --target ${file%.cpp}.o
+              echo "cmake --build build/Debug --target ${file%.cpp}.o"
+              cmake --build build/Debug --target ${file%.cpp}.o
             fi
           done

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 # Conan
 conanprofile
 
-# Cmake Build folders
+# CMake Build folders
 /release
 /Release
 /RelWithDebInfo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,8 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif ()
 
 set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/build/")
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_BINARY_DIR}/generators/")
 
 # ---------------------------------------------------------------------------
 # Logging

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ COPY . ./
 
 RUN  \
     python3 ./build_with_conan.py --release --parallel 4\
-    && cp build/silo_test . \
-    && cp build/siloApi .
+    && cp build/Release/silo_test . \
+    && cp build/Release/siloApi .
 
 
 FROM ubuntu:22.04 AS server

--- a/Dockerfile_dependencies
+++ b/Dockerfile_dependencies
@@ -16,4 +16,4 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
         mv conanprofile.docker conanprofile; \
     fi
 
-RUN conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build
+RUN conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build/Release/generators

--- a/Dockerfile_dependencies
+++ b/Dockerfile_dependencies
@@ -6,7 +6,7 @@ RUN apt update && apt dist-upgrade -y \
     && apt install -y \
     cmake python3-pip
 
-RUN pip install conan==2.5.0
+RUN pip install conan==2.8.1
 
 WORKDIR /src
 COPY conanfile.py conanprofile.docker conanprofile.docker_arm ./

--- a/Dockerfile_linter_dependencies
+++ b/Dockerfile_linter_dependencies
@@ -16,7 +16,7 @@ RUN apt update \
     && apt install -y jq \
     && apt install -y curl
 
-RUN pip install conan==2.0.17
+RUN pip install conan==2.8.1
 
 COPY conanfile.py conanprofile.docker ./
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \

--- a/Dockerfile_linter_dependencies
+++ b/Dockerfile_linter_dependencies
@@ -4,12 +4,7 @@ WORKDIR /src
 
 RUN apt update \
     && apt install -y \
-    cmake=3.22.1-1ubuntu1.22.04.2 \
-    python3-pip=22.0.2+dfsg-1ubuntu0.4 \
-    software-properties-common=0.99.22.9 \
-    wget=1.21.2-2ubuntu1 \
-    gnupg=2.2.27-3ubuntu2.1 \
-    lsb-release=11.1.0ubuntu4 \
+    cmake python3-pip software-properties-common wget gnupg lsb-release \
     && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
     && add-apt-repository 'deb http://apt.llvm.org/jammy/  llvm-toolchain-jammy main' \
     && apt install -y clang-tidy-20 \

--- a/Dockerfile_linter_dependencies
+++ b/Dockerfile_linter_dependencies
@@ -20,4 +20,4 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
         mv conanprofile.docker conanprofile; \
     fi
 
-RUN conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build -s build_type=Debug
+RUN conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build/Debug/generators -s build_type=Debug

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ located in the corresponding source folder.
 To run all tests, run
 
 ```shell
-build/silo_test
+build/Release/silo_test
 ```
 
 For linting we use clang-tidy. The config is stored in `.clang-tidy`.


### PR DESCRIPTION
### Summary


This follows the convention of putting helper .cmake files in to a separate directory as in: https://cmake.org/cmake/help/latest/variable/CMAKE_MODULE_PATH.html.

This additionally helps with developer setupt. There is now a separate folder (build/) to deleting all generated of the build system (cmake), and a folder (cmake/) of configuration files generated by the package manager (conan)

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [ ] The implemented feature is covered by an appropriate test.
