### PR TITLE
build: fix broken build for clang by removing erroneous generator for fmt library, which we do not explicitly depend on ourselves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,11 @@ endif ()
 
 set(CMAKE_CXX_STANDARD 20)
 
+# For find_package calls in Module mode (looking for the Find<lib>.cmake files)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_BINARY_DIR}/generators/")
+# For find_package calls in config mode / find_dependency calls
+# (looking for the <lib>-config.cmake files of transitive dependencies of modules, e.g. spdlog->fmt)
+set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "${CMAKE_BINARY_DIR}/generators/")
 
 # ---------------------------------------------------------------------------
 # Logging

--- a/conanfile.py
+++ b/conanfile.py
@@ -102,7 +102,6 @@ class SiloRecipe(ConanFile):
         deps = CMakeDeps(self)
         deps.set_property("boost", "cmake_find_mode", "both")
         deps.set_property("duckdb", "cmake_find_mode", "both")
-        deps.set_property("fmt", "cmake_find_mode", "both")
         deps.set_property("gtest", "cmake_find_mode", "both")
         deps.set_property("hwloc", "cmake_find_mode", "both")
         deps.set_property("nlohmann_json", "cmake_find_mode", "both")


### PR DESCRIPTION
### Summary

We depend on fmt transitively through spdlog. Unfortunately, this makes us unable to explicitly depend on a different version of fmt. (There is the newer version 11.0.2 available on conan center, but spdlog still depends on version 10.2.1). With that fmt version there is a bug appearing when using a new version of clang-20. This bug does not appear when not calling the generator for fmt as well.



## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
