### PR TITLE
Linter revert version to clang-15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ list(REMOVE_ITEM SRC_SILO_WITHOUT_MAIN "${CMAKE_SOURCE_DIR}/src/silo_api/api.cpp
 
 option(BUILD_WITH_CLANG_TIDY "Build process clang-tidy")
 if (NOT CMAKE_BUILD_TYPE STREQUAL Release AND BUILD_WITH_CLANG_TIDY)
-    find_program(CLANG_TIDY_EXE NAMES clang-tidy-20)
+    find_program(CLANG_TIDY_EXE NAMES clang-tidy-15) # TODO(#632) revert to clang-tidy-20
     if (NOT CLANG_TIDY_EXE)
         message(SEND_ERROR "clang-tidy not found, aborting. You can run the build with '-D BUILD_WITH_CLANG_TIDY=OFF' to disable clang-tidy.")
     else ()

--- a/Dockerfile_linter_dependencies
+++ b/Dockerfile_linter_dependencies
@@ -7,7 +7,7 @@ RUN apt update \
     cmake python3-pip software-properties-common wget gnupg lsb-release \
     && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
     && add-apt-repository 'deb http://apt.llvm.org/jammy/  llvm-toolchain-jammy main' \
-    && apt install -y clang-tidy-20 \
+    && apt install -y clang-tidy-15 \
     && apt install -y jq \
     && apt install -y curl
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
Test PR for now, whether a revert to clang-tidy-15 (using clang-15) will make the CI green again


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [ ] The implemented feature is covered by an appropriate test.
