### PR TITLE
fix(preprocessing): correct error message when field is in config but not in metadata file

### DIFF
--- a/src/silo/preprocessing/metadata_info.cpp
+++ b/src/silo/preprocessing/metadata_info.cpp
@@ -75,7 +75,7 @@ void MetadataInfo::validateMetadataFile(
       if (!actual_fields.contains(field.name)) {
          const std::string error_message = fmt::format(
             "The field '{}' which is contained in the database config is not contained in the "
-            "input field '{}'.",
+            "metadata file '{}'.",
             field.name,
             metadata_file.string()
          );


### PR DESCRIPTION
### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
`The field 'versionComment' which is contained in the database config is not contained in the input field '/preprocessing/input/data.ndjson.zst'.` 
looks wrong.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [ ] The implemented feature is covered by an appropriate test.
