### PR TITLE
PR #639 linter error diagnostic - OperatorResult refactor

### DIFF
--- a/include/silo/query_engine/actions/action.h
+++ b/include/silo/query_engine/actions/action.h
@@ -9,7 +9,7 @@
 #include <nlohmann/json_fwd.hpp>
 
 #include "silo/database.h"
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/query_result.h"
 
 namespace silo::query_engine::actions {
@@ -35,7 +35,7 @@ class Action {
       /// Life time: until query result was delivered (and the lock
       /// inside `FixedDatabase` is released)
       const Database& database,
-      std::vector<OperatorResult> bitmap_filter
+      std::vector<CopyOnWriteBitmap> bitmap_filter
    ) const = 0;
 
   public:
@@ -51,7 +51,7 @@ class Action {
 
    [[nodiscard]] virtual QueryResult executeAndOrder(
       const Database& database,
-      std::vector<OperatorResult> bitmap_filter
+      std::vector<CopyOnWriteBitmap> bitmap_filter
    ) const;
 };
 

--- a/include/silo/query_engine/actions/aggregated.h
+++ b/include/silo/query_engine/actions/aggregated.h
@@ -8,7 +8,7 @@
 
 #include "silo/database.h"
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/query_result.h"
 
 namespace silo::query_engine::actions {
@@ -21,7 +21,7 @@ class Aggregated : public Action {
 
    [[nodiscard]] QueryResult execute(
       const Database& database,
-      std::vector<OperatorResult> bitmap_filter
+      std::vector<CopyOnWriteBitmap> bitmap_filter
    ) const override;
 
   public:

--- a/include/silo/query_engine/actions/details.h
+++ b/include/silo/query_engine/actions/details.h
@@ -8,7 +8,7 @@
 
 #include "silo/database.h"
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/query_result.h"
 
 namespace silo::query_engine::actions {
@@ -20,7 +20,7 @@ class Details : public Action {
 
    [[nodiscard]] QueryResult execute(
       const Database& database,
-      std::vector<OperatorResult> bitmap_filter
+      std::vector<CopyOnWriteBitmap> bitmap_filter
    ) const override;
 
   public:
@@ -32,7 +32,7 @@ class Details : public Action {
 
    [[nodiscard]] QueryResult executeAndOrder(
       const Database& database,
-      std::vector<OperatorResult> bitmap_filter
+      std::vector<CopyOnWriteBitmap> bitmap_filter
    ) const override;
 };
 

--- a/include/silo/query_engine/actions/fasta.h
+++ b/include/silo/query_engine/actions/fasta.h
@@ -8,7 +8,7 @@
 
 #include "silo/database.h"
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/query_result.h"
 
 namespace silo::query_engine::actions {
@@ -22,7 +22,7 @@ class Fasta : public Action {
 
    [[nodiscard]] QueryResult execute(
       const Database& database,
-      std::vector<OperatorResult> bitmap_filter
+      std::vector<CopyOnWriteBitmap> bitmap_filter
    ) const override;
 
   public:

--- a/include/silo/query_engine/actions/fasta_aligned.h
+++ b/include/silo/query_engine/actions/fasta_aligned.h
@@ -8,7 +8,7 @@
 
 #include "silo/database.h"
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/query_result.h"
 
 namespace silo::query_engine::actions {
@@ -20,7 +20,7 @@ class FastaAligned : public Action {
 
    [[nodiscard]] QueryResult execute(
       const Database& database,
-      std::vector<OperatorResult> bitmap_filter
+      std::vector<CopyOnWriteBitmap> bitmap_filter
    ) const override;
 
   public:

--- a/include/silo/query_engine/actions/insertions.h
+++ b/include/silo/query_engine/actions/insertions.h
@@ -15,7 +15,7 @@
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/database.h"
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/operator.h"
 #include "silo/query_engine/query_result.h"
 
@@ -33,11 +33,11 @@ class InsertionAggregation : public Action {
 
    struct PrefilteredBitmaps {
       std::vector<std::pair<
-         const OperatorResult&,
+         const CopyOnWriteBitmap&,
          const silo::storage::insertion::InsertionIndex<SymbolType>&>>
          bitmaps;
       std::vector<std::pair<
-         const OperatorResult&,
+         const CopyOnWriteBitmap&,
          const silo::storage::insertion::InsertionIndex<SymbolType>&>>
          full_bitmaps;
    };
@@ -52,7 +52,7 @@ class InsertionAggregation : public Action {
    std::unordered_map<std::string, InsertionAggregation<SymbolType>::PrefilteredBitmaps>
    validateFieldsAndPreFilterBitmaps(
       const Database& database,
-      std::vector<OperatorResult>& bitmap_filter
+      std::vector<CopyOnWriteBitmap>& bitmap_filter
    ) const;
 
   public:
@@ -62,7 +62,7 @@ class InsertionAggregation : public Action {
 
    [[nodiscard]] QueryResult execute(
       const Database& database,
-      std::vector<OperatorResult> bitmap_filter
+      std::vector<CopyOnWriteBitmap> bitmap_filter
    ) const override;
 };
 

--- a/include/silo/query_engine/actions/mutations.h
+++ b/include/silo/query_engine/actions/mutations.h
@@ -33,14 +33,16 @@ class Mutations : public Action {
    const std::string COUNT_FIELD_NAME = "count";
 
    struct PrefilteredBitmaps {
-      std::vector<std::pair<const OperatorResult&, const silo::SequenceStorePartition<SymbolType>&>>
+      std::vector<
+         std::pair<const CopyOnWriteBitmap&, const silo::SequenceStorePartition<SymbolType>&>>
          bitmaps;
-      std::vector<std::pair<const OperatorResult&, const silo::SequenceStorePartition<SymbolType>&>>
+      std::vector<
+         std::pair<const CopyOnWriteBitmap&, const silo::SequenceStorePartition<SymbolType>&>>
          full_bitmaps;
    };
 
    static std::unordered_map<std::string, Mutations<SymbolType>::PrefilteredBitmaps>
-   preFilterBitmaps(const silo::Database& database, std::vector<OperatorResult>& bitmap_filter);
+   preFilterBitmaps(const silo::Database& database, std::vector<CopyOnWriteBitmap>& bitmap_filter);
 
    static void addPositionToMutationCountsForMixedBitmaps(
       uint32_t position_idx,
@@ -70,7 +72,7 @@ class Mutations : public Action {
 
    [[nodiscard]] QueryResult execute(
       const Database& database,
-      std::vector<OperatorResult> bitmap_filter
+      std::vector<CopyOnWriteBitmap> bitmap_filter
    ) const override;
 
   public:

--- a/include/silo/query_engine/copy_on_write_bitmap.h
+++ b/include/silo/query_engine/copy_on_write_bitmap.h
@@ -8,15 +8,15 @@ namespace silo::query_engine {
 
 /// The return value of the Operator::evaluate method.
 /// May return either a mutable or immutable bitmap.
-class OperatorResult {
+class CopyOnWriteBitmap {
   private:
    std::shared_ptr<roaring::Roaring> mutable_bitmap;
    const roaring::Roaring* immutable_bitmap;
 
   public:
-   OperatorResult();
-   explicit OperatorResult(const roaring::Roaring& bitmap);
-   explicit OperatorResult(roaring::Roaring&& bitmap);
+   CopyOnWriteBitmap();
+   explicit CopyOnWriteBitmap(const roaring::Roaring& bitmap);
+   explicit CopyOnWriteBitmap(roaring::Roaring&& bitmap);
 
    roaring::Roaring& operator*();
    const roaring::Roaring& operator*() const;

--- a/include/silo/query_engine/operator_result.h
+++ b/include/silo/query_engine/operator_result.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include <roaring/roaring.hh>
 
 namespace silo::query_engine {
@@ -8,24 +10,17 @@ namespace silo::query_engine {
 /// May return either a mutable or immutable bitmap.
 class OperatorResult {
   private:
-   roaring::Roaring* mutable_bitmap;
+   std::shared_ptr<roaring::Roaring> mutable_bitmap;
    const roaring::Roaring* immutable_bitmap;
 
   public:
-   explicit OperatorResult();
+   OperatorResult();
    explicit OperatorResult(const roaring::Roaring& bitmap);
    explicit OperatorResult(roaring::Roaring&& bitmap);
 
-   // rule of five for manual memory management
-   ~OperatorResult();
-   OperatorResult(const OperatorResult& other) = delete;
-   OperatorResult(OperatorResult&& other) noexcept;
-   OperatorResult& operator=(const OperatorResult& other) = delete;
-   OperatorResult& operator=(OperatorResult&& other) noexcept;
-
    roaring::Roaring& operator*();
    const roaring::Roaring& operator*() const;
-   roaring::Roaring* operator->();
+   std::shared_ptr<roaring::Roaring> operator->();
    const roaring::Roaring* operator->() const;
 
    [[nodiscard]] bool isMutable() const;

--- a/include/silo/query_engine/operators/bitmap_producer.h
+++ b/include/silo/query_engine/operators/bitmap_producer.h
@@ -5,24 +5,24 @@
 #include <memory>
 #include <string>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::operators {
 
 class BitmapProducer : public Operator {
   private:
-   std::function<OperatorResult()> producer;
+   std::function<CopyOnWriteBitmap()> producer;
    uint32_t row_count;
 
   public:
-   explicit BitmapProducer(std::function<OperatorResult()> producer, uint32_t row_count);
+   explicit BitmapProducer(std::function<CopyOnWriteBitmap()> producer, uint32_t row_count);
 
    ~BitmapProducer() noexcept override;
 
    [[nodiscard]] virtual Type type() const override;
 
-   virtual OperatorResult evaluate() const override;
+   virtual CopyOnWriteBitmap evaluate() const override;
 
    virtual std::string toString() const override;
 

--- a/include/silo/query_engine/operators/bitmap_selection.h
+++ b/include/silo/query_engine/operators/bitmap_selection.h
@@ -6,7 +6,7 @@
 
 #include <roaring/roaring.hh>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::filter_expressions {
@@ -50,7 +50,7 @@ class BitmapSelection : public Operator {
 
    [[nodiscard]] virtual Type type() const override;
 
-   virtual OperatorResult evaluate() const override;
+   virtual CopyOnWriteBitmap evaluate() const override;
 
    virtual std::string toString() const override;
 

--- a/include/silo/query_engine/operators/complement.h
+++ b/include/silo/query_engine/operators/complement.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::operators {
@@ -28,7 +28,7 @@ class Complement : public Operator {
 
    [[nodiscard]] virtual Type type() const override;
 
-   virtual OperatorResult evaluate() const override;
+   virtual CopyOnWriteBitmap evaluate() const override;
 
    virtual std::string toString() const override;
 

--- a/include/silo/query_engine/operators/empty.h
+++ b/include/silo/query_engine/operators/empty.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include <string>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::operators {
@@ -20,7 +20,7 @@ class Empty : public Operator {
 
    [[nodiscard]] Type type() const override;
 
-   OperatorResult evaluate() const override;
+   CopyOnWriteBitmap evaluate() const override;
 
    virtual std::string toString() const override;
 

--- a/include/silo/query_engine/operators/full.h
+++ b/include/silo/query_engine/operators/full.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include <string>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::operators {
@@ -19,7 +19,7 @@ class Full : public Operator {
 
    [[nodiscard]] Type type() const override;
 
-   OperatorResult evaluate() const override;
+   CopyOnWriteBitmap evaluate() const override;
 
    virtual std::string toString() const override;
 

--- a/include/silo/query_engine/operators/index_scan.h
+++ b/include/silo/query_engine/operators/index_scan.h
@@ -6,7 +6,7 @@
 
 #include <roaring/roaring.hh>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::filter_expressions {
@@ -37,7 +37,7 @@ class IndexScan : public Operator {
 
    [[nodiscard]] virtual Type type() const override;
 
-   virtual OperatorResult evaluate() const override;
+   virtual CopyOnWriteBitmap evaluate() const override;
 
    virtual std::string toString() const override;
 

--- a/include/silo/query_engine/operators/intersection.h
+++ b/include/silo/query_engine/operators/intersection.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::filter_expressions {
@@ -37,7 +37,7 @@ class Intersection : public Operator {
 
    [[nodiscard]] Type type() const override;
 
-   virtual OperatorResult evaluate() const override;
+   virtual CopyOnWriteBitmap evaluate() const override;
 
    static std::unique_ptr<Operator> negate(std::unique_ptr<Intersection>&& intersection);
 };

--- a/include/silo/query_engine/operators/operator.h
+++ b/include/silo/query_engine/operators/operator.h
@@ -4,7 +4,7 @@
 #include <optional>
 #include <string>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 
 namespace silo::query_engine::operators {
 
@@ -30,7 +30,7 @@ class Operator {
 
    [[nodiscard]] virtual Type type() const = 0;
 
-   virtual OperatorResult evaluate() const = 0;
+   virtual CopyOnWriteBitmap evaluate() const = 0;
 
    virtual std::string toString() const = 0;
 

--- a/include/silo/query_engine/operators/range_selection.h
+++ b/include/silo/query_engine/operators/range_selection.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::operators {
@@ -30,7 +30,7 @@ class RangeSelection : public Operator {
 
    [[nodiscard]] Type type() const override;
 
-   [[nodiscard]] OperatorResult evaluate() const override;
+   [[nodiscard]] CopyOnWriteBitmap evaluate() const override;
 
    [[nodiscard]] std::string toString() const override;
 

--- a/include/silo/query_engine/operators/selection.h
+++ b/include/silo/query_engine/operators/selection.h
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "silo/common/string.h"
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::filter_expressions {
@@ -72,7 +72,7 @@ class Selection : public Operator {
 
    [[nodiscard]] Type type() const override;
 
-   [[nodiscard]] OperatorResult evaluate() const override;
+   [[nodiscard]] CopyOnWriteBitmap evaluate() const override;
 
    [[nodiscard]] std::string toString() const override;
 

--- a/include/silo/query_engine/operators/threshold.h
+++ b/include/silo/query_engine/operators/threshold.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::operators {
@@ -31,7 +31,7 @@ class Threshold : public Operator {
 
    [[nodiscard]] virtual Type type() const override;
 
-   virtual OperatorResult evaluate() const override;
+   virtual CopyOnWriteBitmap evaluate() const override;
 
    virtual std::string toString() const override;
 

--- a/include/silo/query_engine/operators/union.h
+++ b/include/silo/query_engine/operators/union.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::filter_expressions {
@@ -32,7 +32,7 @@ class Union : public Operator {
 
    [[nodiscard]] Type type() const override;
 
-   virtual OperatorResult evaluate() const override;
+   virtual CopyOnWriteBitmap evaluate() const override;
 
    static std::unique_ptr<Operator> negate(std::unique_ptr<Union>&& union_operator);
 };

--- a/include/silo/query_engine/query_result.h
+++ b/include/silo/query_engine/query_result.h
@@ -96,8 +96,7 @@ class QueryResult {
    [[nodiscard]] bool isMaterialized() const { return is_materialized_; }
 };
 
-// NOLINTBEGIN(readability-identifier-naming)
+// NOLINTNEXTLINE(readability-identifier-naming)
 void to_json(nlohmann::json& json, const QueryResultEntry& result_entry);
-// NOLINTEND(readability-identifier-naming)
 
 }  // namespace silo::query_engine

--- a/src/silo/common/lineage_tree.test.cpp
+++ b/src/silo/common/lineage_tree.test.cpp
@@ -34,28 +34,18 @@ CHILD:
 }
 
 TEST(LineageTreeAndIdMap, errorOnMissingParent) {
-   auto throwing_lambda = []() {
-      (void)LineageTreeAndIdMap::fromLineageDefinitionFile(LineageDefinitionFile::fromYAML(R"(
+   EXPECT_THAT(
+      []() {
+         (void)LineageTreeAndIdMap::fromLineageDefinitionFile(LineageDefinitionFile::fromYAML(R"(
 some_lineage:
   parents:
     - parent_that_does_not_exist
 )"));
-   };
-
-   EXPECT_THROW(
-      {
-         try {
-            throwing_lambda();
-         } catch (const silo::preprocessing::PreprocessingException& e) {
-            ASSERT_EQ(
-               std::string(e.what()),
-               "The lineage 'parent_that_does_not_exist' which is specified as the parent of "
-               "vertex 'some_lineage' does not have a definition itself."
-            );
-            throw;
-         }
       },
-      silo::preprocessing::PreprocessingException
+      ThrowsMessage<silo::preprocessing::PreprocessingException>(::testing::HasSubstr(
+         "The lineage 'parent_that_does_not_exist' which is specified as the parent of "
+         "vertex 'some_lineage' does not have a definition itself."
+      ))
    );
 }
 
@@ -241,12 +231,12 @@ TEST(containsCycle, doesNotFindCycleInPangoLineageTree) {
 
 TEST(containsCycle, doesNotFindCycleInMediumSizedChainGraph) {
    std::vector<std::pair<uint32_t, uint32_t>> chain_edges;
-   uint32_t N = UINT16_MAX;
-   chain_edges.reserve(N);
-   for (size_t i = 0; i + 1 < N; i++) {
+   const uint32_t number_of_edges = UINT16_MAX;
+   chain_edges.reserve(number_of_edges);
+   for (size_t i = 0; i + 1 < number_of_edges; i++) {
       chain_edges.emplace_back(i, i + 1);
    }
-   ASSERT_FALSE(silo::common::containsCycle(N, chain_edges));
+   ASSERT_FALSE(silo::common::containsCycle(number_of_edges, chain_edges));
 }
 
 TEST(containsCycle, findsCycles) {

--- a/src/silo/query_engine/actions/action.cpp
+++ b/src/silo/query_engine/actions/action.cpp
@@ -20,7 +20,7 @@
 #include "silo/query_engine/actions/fasta_aligned.h"
 #include "silo/query_engine/actions/insertions.h"
 #include "silo/query_engine/actions/mutations.h"
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/query_parse_exception.h"
 #include "silo/query_engine/query_result.h"
 
@@ -107,7 +107,7 @@ static const size_t MATERIALIZATION_CUTOFF = 10000;
 
 QueryResult Action::executeAndOrder(
    const Database& database,
-   std::vector<OperatorResult> bitmap_filter
+   std::vector<CopyOnWriteBitmap> bitmap_filter
 ) const {
    validateOrderByFields(database);
 

--- a/src/silo/query_engine/actions/details.cpp
+++ b/src/silo/query_engine/actions/details.cpp
@@ -13,7 +13,7 @@
 #include "silo/database.h"
 #include "silo/query_engine/actions/action.h"
 #include "silo/query_engine/actions/tuple.h"
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/query_parse_exception.h"
 #include "silo/query_engine/query_result.h"
 #include "silo/storage/column_group.h"
@@ -60,7 +60,7 @@ void Details::validateOrderByFields(const Database& database) const {
 
 QueryResult Details::execute(
    const silo::Database& /*database*/,
-   std::vector<OperatorResult> /*bitmap_filter*/
+   std::vector<CopyOnWriteBitmap> /*bitmap_filter*/
 ) const {
    return QueryResult{};
 }
@@ -103,7 +103,7 @@ std::vector<actions::Tuple> mergeSortedTuples(
 
 std::vector<actions::Tuple> produceSortedTuplesWithLimit(
    std::vector<TupleFactory>& tuple_factories,
-   std::vector<OperatorResult>& bitmap_filter,
+   std::vector<CopyOnWriteBitmap>& bitmap_filter,
    const Tuple::Comparator tuple_comparator,
    const uint32_t to_produce
 ) {
@@ -152,7 +152,7 @@ std::vector<actions::Tuple> produceSortedTuplesWithLimit(
 
 std::vector<Tuple> produceAllTuples(
    std::vector<TupleFactory>& tuple_factories,
-   std::vector<OperatorResult>& bitmap_filter
+   std::vector<CopyOnWriteBitmap>& bitmap_filter
 ) {
    if (tuple_factories.empty()) {
       return {};
@@ -185,7 +185,7 @@ std::vector<Tuple> produceAllTuples(
 
 QueryResult Details::executeAndOrder(
    const silo::Database& database,
-   std::vector<OperatorResult> bitmap_filter
+   std::vector<CopyOnWriteBitmap> bitmap_filter
 ) const {
    validateOrderByFields(database);
    const std::vector<storage::ColumnMetadata> field_metadata = parseFields(database, fields);

--- a/src/silo/query_engine/actions/fasta.cpp
+++ b/src/silo/query_engine/actions/fasta.cpp
@@ -11,7 +11,7 @@
 #include "silo/common/panic.h"
 #include "silo/common/range.h"
 #include "silo/database.h"
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/query_parse_exception.h"
 #include "silo/query_engine/query_result.h"
 #include "silo/zstd/zstd_table_reader.h"
@@ -147,7 +147,7 @@ uint32_t addSequencesToResultsForPartition(
    std::vector<std::string>& sequence_names,
    std::vector<QueryResultEntry>& results,
    const DatabasePartition& database_partition,
-   const OperatorResult& bitmap,
+   const CopyOnWriteBitmap& bitmap,
    const std::string& primary_key_column,
    size_t num_result_rows
 ) {
@@ -242,7 +242,7 @@ const size_t PARTITION_CHUNK_SIZE = 10000;
 
 }  // namespace
 
-QueryResult Fasta::execute(const Database& database, std::vector<OperatorResult> bitmap_filter)
+QueryResult Fasta::execute(const Database& database, std::vector<CopyOnWriteBitmap> bitmap_filter)
    const {
    for (const std::string& sequence_name : sequence_names) {
       CHECK_SILO_QUERY(

--- a/src/silo/query_engine/actions/fasta_aligned.cpp
+++ b/src/silo/query_engine/actions/fasta_aligned.cpp
@@ -20,7 +20,7 @@
 #include "silo/config/database_config.h"
 #include "silo/database.h"
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/query_parse_exception.h"
 #include "silo/query_engine/query_result.h"
 #include "silo/storage/sequence_store.h"
@@ -141,7 +141,7 @@ QueryResultEntry makeEntry(
 
 QueryResult FastaAligned::execute(
    const Database& database,
-   std::vector<OperatorResult> bitmap_filter
+   std::vector<CopyOnWriteBitmap> bitmap_filter
 ) const {
    std::vector<std::string> nuc_sequence_names;
    std::vector<std::string> aa_sequence_names;

--- a/src/silo/query_engine/actions/fasta_aligned.cpp
+++ b/src/silo/query_engine/actions/fasta_aligned.cpp
@@ -150,74 +150,73 @@ QueryResult FastaAligned::execute(
 
    uint32_t partition_index = 0;
    std::optional<Range<uint32_t>> remaining_result_row_indices{};
-   return QueryResult::fromGenerator(
-      [nuc_sequence_names = std::move(nuc_sequence_names),
-       aa_sequence_names = std::move(aa_sequence_names),
-       bitmap_filter = std::make_shared<std::vector<OperatorResult>>(std::move(bitmap_filter)),
-       remaining_result_row_indices,
-       &database,
-       partition_index](std::vector<QueryResultEntry>& results) mutable {
-         for (; partition_index < database.partitions.size();
-              ++partition_index, remaining_result_row_indices = {}) {
-            // We drain the bitmaps in bitmap_filter as we process the
-            // query, because roaring bitmaps don't come with
-            // external, only internal iterators, which can't be used
-            // for our external iterator. Instead of implementing an
-            // external iterator on bitmaps, we just remove the bitmap
-            // members as we process them. To know how far into the
-            // result generation we are, we maintain a `Range` of
-            // output rows at the same time.
-            auto& bitmap = (*bitmap_filter)[partition_index];
-            if (!remaining_result_row_indices.has_value()) {
-               // We set `remaining_result_row_indices` only once using the
-               // original, undrained bitmap.
-               remaining_result_row_indices = {
-                  {0, boost::numeric_cast<uint32_t, uint64_t>(bitmap->cardinality())}
-               };
-            }
+   return QueryResult::fromGenerator([nuc_sequence_names = std::move(nuc_sequence_names),
+                                      aa_sequence_names = std::move(aa_sequence_names),
+                                      bitmap_filter = std::move(bitmap_filter),
+                                      remaining_result_row_indices,
+                                      &database,
+                                      partition_index](std::vector<QueryResultEntry>& results
+                                     ) mutable {
+      for (; partition_index < database.partitions.size();
+           ++partition_index, remaining_result_row_indices = {}) {
+         // We drain the bitmaps in bitmap_filter as we process the
+         // query, because roaring bitmaps don't come with
+         // external, only internal iterators, which can't be used
+         // for our external iterator. Instead of implementing an
+         // external iterator on bitmaps, we just remove the bitmap
+         // members as we process them. To know how far into the
+         // result generation we are, we maintain a `Range` of
+         // output rows at the same time.
+         auto& bitmap = bitmap_filter[partition_index];
+         if (!remaining_result_row_indices.has_value()) {
+            // We set `remaining_result_row_indices` only once using the
+            // original, undrained bitmap.
+            remaining_result_row_indices = {
+               {0, boost::numeric_cast<uint32_t, uint64_t>(bitmap->cardinality())}
+            };
+         }
 
-            // The range of results to fully process in this batch
-            Range<uint32_t> result_row_indices =
-               remaining_result_row_indices->take(PARTITION_CHUNK_SIZE);
-            // Remove the same range from the result rows that need to be
-            // created for the current partition
-            remaining_result_row_indices = remaining_result_row_indices->skip(PARTITION_CHUNK_SIZE);
+         // The range of results to fully process in this batch
+         Range<uint32_t> result_row_indices =
+            remaining_result_row_indices->take(PARTITION_CHUNK_SIZE);
+         // Remove the same range from the result rows that need to be
+         // created for the current partition
+         remaining_result_row_indices = remaining_result_row_indices->skip(PARTITION_CHUNK_SIZE);
 
-            if (!result_row_indices.isEmpty()) {
-               SPDLOG_TRACE(
-                  "FastaAligned::execute: refill QueryResult for partition_index {}/{}, {}/{}",
-                  partition_index,
-                  database.partitions.size(),
-                  result_row_indices.toString(),
-                  remaining_result_row_indices->beyondLast()
-               );
+         if (!result_row_indices.isEmpty()) {
+            SPDLOG_TRACE(
+               "FastaAligned::execute: refill QueryResult for partition_index {}/{}, {}/{}",
+               partition_index,
+               database.partitions.size(),
+               result_row_indices.toString(),
+               remaining_result_row_indices->beyondLast()
+            );
 
-               const auto& database_partition = database.partitions[partition_index];
-               for (const uint32_t row_id : *bitmap) {
-                  results.emplace_back(makeEntry(
-                     database.database_config.schema.primary_key,
-                     database_partition,
-                     nuc_sequence_names,
-                     aa_sequence_names,
-                     row_id
-                  ));
+            const auto& database_partition = database.partitions[partition_index];
+            for (const uint32_t row_id : *bitmap) {
+               results.emplace_back(makeEntry(
+                  database.database_config.schema.primary_key,
+                  database_partition,
+                  nuc_sequence_names,
+                  aa_sequence_names,
+                  row_id
+               ));
 
-                  result_row_indices = result_row_indices.skip1();
-                  if (result_row_indices.isEmpty()) {
-                     // Finished the batch. Remove processed `row_id`s;
-                     // we already removed the corresponding result
-                     // indices from `remaining_result_row_indices`.
-                     bitmap->removeRange(0, add1(row_id));
-                     // "yield", although control comes back into the
-                     // `for` loop from outside:
-                     return;
-                  }
+               result_row_indices = result_row_indices.skip1();
+               if (result_row_indices.isEmpty()) {
+                  // Finished the batch. Remove processed `row_id`s;
+                  // we already removed the corresponding result
+                  // indices from `remaining_result_row_indices`.
+                  bitmap->removeRange(0, add1(row_id));
+                  // "yield", although control comes back into the
+                  // `for` loop from outside:
+                  return;
                }
-               PANIC("ran out of bitmap before finishing result_row_indices");
             }
+            PANIC("ran out of bitmap before finishing result_row_indices");
          }
       }
-   );
+   });
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/src/silo/query_engine/actions/insertions.cpp
+++ b/src/silo/query_engine/actions/insertions.cpp
@@ -16,13 +16,13 @@
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/database.h"
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/query_parse_exception.h"
 #include "silo/query_engine/query_result.h"
 #include "silo/storage/database_partition.h"
 #include "silo/storage/insertion_index.h"
 
-using silo::query_engine::OperatorResult;
+using silo::query_engine::CopyOnWriteBitmap;
 using silo::storage::insertion::InsertionIndex;
 
 namespace silo::query_engine::actions {
@@ -78,7 +78,7 @@ template <typename SymbolType>
 std::unordered_map<std::string, typename InsertionAggregation<SymbolType>::PrefilteredBitmaps>
 InsertionAggregation<SymbolType>::validateFieldsAndPreFilterBitmaps(
    const Database& database,
-   std::vector<OperatorResult>& bitmap_filter
+   std::vector<CopyOnWriteBitmap>& bitmap_filter
 ) const {
    validateSequenceNames<SymbolType>(database, sequence_names);
 
@@ -91,7 +91,7 @@ InsertionAggregation<SymbolType>::validateFieldsAndPreFilterBitmaps(
          if (sequence_names.empty() ||
              std::ranges::find(sequence_names, sequence_name) !=
                 sequence_names.end()) {
-            OperatorResult& filter = bitmap_filter[i];
+            CopyOnWriteBitmap& filter = bitmap_filter[i];
             const size_t cardinality = filter->cardinality();
             if (cardinality == 0) {
                continue;
@@ -190,7 +190,7 @@ void InsertionAggregation<SymbolType>::addAggregatedInsertionsToInsertionCounts(
 template <typename SymbolType>
 QueryResult InsertionAggregation<SymbolType>::execute(
    const Database& database,
-   std::vector<OperatorResult> bitmap_filter
+   std::vector<CopyOnWriteBitmap> bitmap_filter
 ) const {
    const auto bitmaps_to_evaluate = validateFieldsAndPreFilterBitmaps(database, bitmap_filter);
 

--- a/src/silo/query_engine/filter_expressions/insertion_contains.cpp
+++ b/src/silo/query_engine/filter_expressions/insertion_contains.cpp
@@ -12,8 +12,8 @@
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/database.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter_expressions/expression.h"
-#include "silo/query_engine/operator_result.h"
 #include "silo/query_engine/operators/bitmap_producer.h"
 #include "silo/query_engine/operators/empty.h"
 #include "silo/query_engine/operators/operator.h"
@@ -67,7 +67,7 @@ std::unique_ptr<silo::query_engine::operators::Operator> InsertionContains<Symbo
    return std::make_unique<operators::BitmapProducer>(
       [&]() {
          auto search_result = sequence_store.insertion_index.search(position_idx, value);
-         return OperatorResult(std::move(*search_result));
+         return CopyOnWriteBitmap(std::move(*search_result));
       },
       database_partition.sequence_count
    );

--- a/src/silo/query_engine/filter_expressions/string_search.cpp
+++ b/src/silo/query_engine/filter_expressions/string_search.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<silo::query_engine::operators::Operator> createMatchingBitmap(
                result_bitmap.add(row_idx);
             }
          }
-         return OperatorResult(std::move(result_bitmap));
+         return CopyOnWriteBitmap(std::move(result_bitmap));
       },
       row_count
    );

--- a/src/silo/query_engine/filter_expressions/symbol_equals.cpp
+++ b/src/silo/query_engine/filter_expressions/symbol_equals.cpp
@@ -101,7 +101,7 @@ std::unique_ptr<silo::query_engine::operators::Operator> SymbolEquals<SymbolType
       std::ranges::transform(
          symbols_to_match,
          std::back_inserter(symbol_filters),
-         [&](SymbolType::Symbol symbol) {
+         [&](typename SymbolType::Symbol symbol) {
             return std::make_unique<SymbolEquals<SymbolType>>(
                valid_sequence_name, position_idx, symbol
             );

--- a/src/silo/query_engine/operators/bitmap_producer.cpp
+++ b/src/silo/query_engine/operators/bitmap_producer.cpp
@@ -2,13 +2,13 @@
 
 #include <utility>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/complement.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::operators {
 
-BitmapProducer::BitmapProducer(std::function<OperatorResult()> producer, uint32_t row_count)
+BitmapProducer::BitmapProducer(std::function<CopyOnWriteBitmap()> producer, uint32_t row_count)
     : producer(std::move(producer)),
       row_count(row_count) {}
 
@@ -22,7 +22,7 @@ Type BitmapProducer::type() const {
    return BITMAP_PRODUCER;
 }
 
-OperatorResult BitmapProducer::evaluate() const {
+CopyOnWriteBitmap BitmapProducer::evaluate() const {
    return producer();
 }
 

--- a/src/silo/query_engine/operators/bitmap_producer.test.cpp
+++ b/src/silo/query_engine/operators/bitmap_producer.test.cpp
@@ -1,18 +1,18 @@
 #include "silo/query_engine/operators/bitmap_producer.h"
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 
 #include <gtest/gtest.h>
 #include <roaring/roaring.hh>
 
-using silo::query_engine::OperatorResult;
+using silo::query_engine::CopyOnWriteBitmap;
 using silo::query_engine::operators::BitmapProducer;
 
 TEST(OperatorBitmapProducer, evaluateShouldReturnCorrectValues) {
    const roaring::Roaring test_bitmap({1, 2, 3});
    const uint32_t row_count = 5;
 
-   const BitmapProducer under_test([&]() { return OperatorResult(test_bitmap); }, row_count);
+   const BitmapProducer under_test([&]() { return CopyOnWriteBitmap(test_bitmap); }, row_count);
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({1, 2, 3}));
 }
 
@@ -21,7 +21,7 @@ TEST(OperatorBitmapProducer, evaluateShouldReturnCorrectValuesWhenNegated) {
    const uint32_t row_count = 5;
 
    auto under_test =
-      std::make_unique<BitmapProducer>([&]() { return OperatorResult(test_bitmap); }, row_count);
+      std::make_unique<BitmapProducer>([&]() { return CopyOnWriteBitmap(test_bitmap); }, row_count);
    const auto negated = BitmapProducer::negate(std::move(under_test));
 
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring({0, 4}));
@@ -31,7 +31,7 @@ TEST(OperatorBitmapProducer, correctTypeInfo) {
    const roaring::Roaring test_bitmap({1, 2, 3});
    const uint32_t row_count = 5;
 
-   const BitmapProducer under_test([&]() { return OperatorResult(test_bitmap); }, row_count);
+   const BitmapProducer under_test([&]() { return CopyOnWriteBitmap(test_bitmap); }, row_count);
    ASSERT_EQ(under_test.type(), silo::query_engine::operators::BITMAP_PRODUCER);
 }
 
@@ -39,6 +39,6 @@ TEST(OperatorBitmapProducer, correctToString) {
    const roaring::Roaring test_bitmap({1, 2, 3});
    const uint32_t row_count = 5;
 
-   const BitmapProducer under_test([&]() { return OperatorResult(test_bitmap); }, row_count);
+   const BitmapProducer under_test([&]() { return CopyOnWriteBitmap(test_bitmap); }, row_count);
    ASSERT_EQ(under_test.toString(), "BitmapProducer");
 }

--- a/src/silo/query_engine/operators/bitmap_selection.cpp
+++ b/src/silo/query_engine/operators/bitmap_selection.cpp
@@ -5,8 +5,8 @@
 #include <fmt/format.h>
 #include <roaring/roaring.hh>
 
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter_expressions/expression.h"
-#include "silo/query_engine/operator_result.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::operators {
@@ -48,8 +48,8 @@ Type BitmapSelection::type() const {
    return BITMAP_SELECTION;
 }
 
-OperatorResult BitmapSelection::evaluate() const {
-   OperatorResult bitmap;
+CopyOnWriteBitmap BitmapSelection::evaluate() const {
+   CopyOnWriteBitmap bitmap;
    switch (this->comparator) {
       case CONTAINS:
          for (uint32_t i = 0; i < row_count; i++) {

--- a/src/silo/query_engine/operators/complement.cpp
+++ b/src/silo/query_engine/operators/complement.cpp
@@ -5,7 +5,7 @@
 
 #include <roaring/roaring.hh>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/intersection.h"
 #include "silo/query_engine/operators/operator.h"
 
@@ -49,7 +49,7 @@ Type Complement::type() const {
    return COMPLEMENT;
 }
 
-OperatorResult Complement::evaluate() const {
+CopyOnWriteBitmap Complement::evaluate() const {
    auto result = child->evaluate();
    result->flip(0, row_count);
    return result;

--- a/src/silo/query_engine/operators/empty.cpp
+++ b/src/silo/query_engine/operators/empty.cpp
@@ -22,7 +22,7 @@ Type Empty::type() const {
 }
 
 CopyOnWriteBitmap Empty::evaluate() const {
-   return CopyOnWriteBitmap();
+   return {};
 }
 
 std::unique_ptr<Operator> Empty::negate(std::unique_ptr<Empty>&& empty) {

--- a/src/silo/query_engine/operators/empty.cpp
+++ b/src/silo/query_engine/operators/empty.cpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/full.h"
 #include "silo/query_engine/operators/operator.h"
 
@@ -21,8 +21,8 @@ Type Empty::type() const {
    return EMPTY;
 }
 
-OperatorResult Empty::evaluate() const {
-   return OperatorResult();
+CopyOnWriteBitmap Empty::evaluate() const {
+   return CopyOnWriteBitmap();
 }
 
 std::unique_ptr<Operator> Empty::negate(std::unique_ptr<Empty>&& empty) {

--- a/src/silo/query_engine/operators/full.cpp
+++ b/src/silo/query_engine/operators/full.cpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/empty.h"
 #include "silo/query_engine/operators/operator.h"
 
@@ -21,8 +21,8 @@ Type Full::type() const {
    return FULL;
 }
 
-OperatorResult Full::evaluate() const {
-   OperatorResult result;
+CopyOnWriteBitmap Full::evaluate() const {
+   CopyOnWriteBitmap result;
    result->addRange(0, row_count);
    return result;
 }

--- a/src/silo/query_engine/operators/index_scan.cpp
+++ b/src/silo/query_engine/operators/index_scan.cpp
@@ -5,8 +5,8 @@
 #include <fmt/format.h>
 #include <roaring/roaring.hh>
 
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter_expressions/expression.h"
-#include "silo/query_engine/operator_result.h"
 #include "silo/query_engine/operators/complement.h"
 #include "silo/query_engine/operators/operator.h"
 
@@ -39,8 +39,8 @@ Type IndexScan::type() const {
    return INDEX_SCAN;
 }
 
-OperatorResult IndexScan::evaluate() const {
-   return OperatorResult(*bitmap);
+CopyOnWriteBitmap IndexScan::evaluate() const {
+   return CopyOnWriteBitmap(*bitmap);
 }
 std::unique_ptr<Operator> IndexScan::negate(std::unique_ptr<IndexScan>&& index_scan) {
    const uint32_t row_count = index_scan->row_count;

--- a/src/silo/query_engine/operators/range_selection.cpp
+++ b/src/silo/query_engine/operators/range_selection.cpp
@@ -6,7 +6,7 @@
 
 #include <boost/algorithm/string/join.hpp>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/operator.h"
 
 namespace silo::query_engine::operators {
@@ -38,8 +38,8 @@ Type RangeSelection::type() const {
    return RANGE_SELECTION;
 }
 
-OperatorResult RangeSelection::evaluate() const {
-   OperatorResult result;
+CopyOnWriteBitmap RangeSelection::evaluate() const {
+   CopyOnWriteBitmap result;
    for (const auto& range : ranges) {
       result->addRange(range.start, range.end);
    }

--- a/src/silo/query_engine/operators/selection.cpp
+++ b/src/silo/query_engine/operators/selection.cpp
@@ -18,7 +18,7 @@
 #include "silo/common/optional_bool.h"
 #include "silo/common/panic.h"
 #include "silo/common/string.h"
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/complement.h"
 #include "silo/query_engine/operators/operator.h"
 
@@ -96,10 +96,10 @@ bool Selection::matchesPredicates(uint32_t row) const {
    });
 }
 
-OperatorResult Selection::evaluate() const {
-   OperatorResult result;
+CopyOnWriteBitmap Selection::evaluate() const {
+   CopyOnWriteBitmap result;
    if (child_operator.has_value()) {
-      OperatorResult child_result = (*child_operator)->evaluate();
+      CopyOnWriteBitmap child_result = (*child_operator)->evaluate();
       for (const uint32_t row : *child_result) {
          if (matchesPredicates(row)) {
             result->add(row);

--- a/src/silo/query_engine/operators/threshold.cpp
+++ b/src/silo/query_engine/operators/threshold.cpp
@@ -6,7 +6,7 @@
 
 #include <roaring/roaring.hh>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/complement.h"
 #include "silo/query_engine/operators/operator.h"
 #include "silo/query_engine/query_compilation_exception.h"
@@ -61,7 +61,7 @@ Type Threshold::type() const {
    return THRESHOLD;
 }
 
-OperatorResult Threshold::evaluate() const {
+CopyOnWriteBitmap Threshold::evaluate() const {
    uint32_t dp_table_size;
    if (this->match_exactly) {
       // We need to keep track of the ones that matched too many
@@ -132,9 +132,9 @@ OperatorResult Threshold::evaluate() const {
       // Because exact, we remove all that have too many
       partition_bitmaps[number_of_matchers - 1] -= partition_bitmaps[number_of_matchers];
 
-      return OperatorResult(std::move(partition_bitmaps[number_of_matchers - 1]));
+      return CopyOnWriteBitmap(std::move(partition_bitmaps[number_of_matchers - 1]));
    }
-   return OperatorResult(std::move(partition_bitmaps.back()));
+   return CopyOnWriteBitmap(std::move(partition_bitmaps.back()));
 }
 
 std::unique_ptr<Operator> Threshold::negate(std::unique_ptr<Threshold>&& threshold) {

--- a/src/silo/query_engine/operators/union.cpp
+++ b/src/silo/query_engine/operators/union.cpp
@@ -6,7 +6,7 @@
 
 #include <roaring/roaring.hh>
 
-#include "silo/query_engine/operator_result.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/complement.h"
 #include "silo/query_engine/operators/operator.h"
 
@@ -32,16 +32,16 @@ Type Union::type() const {
    return UNION;
 }
 
-OperatorResult Union::evaluate() const {
+CopyOnWriteBitmap Union::evaluate() const {
    const uint32_t size_of_children = children.size();
    std::vector<const roaring::Roaring*> union_tmp(size_of_children);
-   std::vector<OperatorResult> child_res(size_of_children);
+   std::vector<CopyOnWriteBitmap> child_res(size_of_children);
    for (uint32_t i = 0; i < size_of_children; i++) {
       child_res[i] = children[i]->evaluate();
       const roaring::Roaring& const_bitmap = *child_res[i];
       union_tmp[i] = &const_bitmap;
    }
-   return OperatorResult(roaring::Roaring::fastunion(union_tmp.size(), union_tmp.data()));
+   return CopyOnWriteBitmap(roaring::Roaring::fastunion(union_tmp.size(), union_tmp.data()));
 }
 
 std::unique_ptr<Operator> Union::negate(std::unique_ptr<Union>&& union_operator) {

--- a/src/silo/query_engine/query_engine.cpp
+++ b/src/silo/query_engine/query_engine.cpp
@@ -11,8 +11,8 @@
 #include "silo/common/block_timer.h"
 #include "silo/common/log.h"
 #include "silo/database.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter_expressions/expression.h"
-#include "silo/query_engine/operator_result.h"
 #include "silo/query_engine/operators/operator.h"
 #include "silo/query_engine/query.h"
 #include "silo/query_engine/query_result.h"
@@ -28,7 +28,7 @@ QueryResult QueryEngine::executeQuery(const std::string& query_string) const {
    SPDLOG_DEBUG("Parsed query: {}", query.filter->toString());
 
    std::vector<std::string> compiled_queries(database.partitions.size());
-   std::vector<silo::query_engine::OperatorResult> partition_filters(database.partitions.size());
+   std::vector<silo::query_engine::CopyOnWriteBitmap> partition_filters(database.partitions.size());
    int64_t filter_time;
    {
       const silo::common::BlockTimer timer(filter_time);

--- a/src/silo/storage/column/indexed_string_column.cpp
+++ b/src/silo/storage/column/indexed_string_column.cpp
@@ -88,8 +88,7 @@ const std::optional<LineageIndex>& IndexedStringColumnPartition::getLineageIndex
 }
 
 IndexedStringColumn::IndexedStringColumn(std::string column_name)
-    : column_name(std::move(column_name)),
-      lookup() {}
+    : column_name(std::move(column_name)) {}
 
 IndexedStringColumn::IndexedStringColumn(
    std::string column_name,

--- a/src/silo/test/insertion_contains.test.cpp
+++ b/src/silo/test/insertion_contains.test.cpp
@@ -45,7 +45,7 @@ const auto REFERENCE_GENOMES = ReferenceGenomes{
    {{"gene1", "*"}},
 };
 
-QueryTestData TEST_DATA{
+const QueryTestData TEST_DATA{
    .ndjson_input_data = {DATA},
    .database_config = DATABASE_CONFIG,
    .reference_genomes = REFERENCE_GENOMES

--- a/src/silo_api/request_handler_factory.cpp
+++ b/src/silo_api/request_handler_factory.cpp
@@ -13,10 +13,6 @@
 #include "silo_api/query_handler.h"
 #include "silo_api/request_id_handler.h"
 
-using silo_api::ErrorRequestHandler;
-using silo_api::LoggingRequestHandler;
-using silo_api::RequestIdHandler;
-
 namespace silo_api {
 
 SiloRequestHandlerFactory::SiloRequestHandlerFactory(


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
While diagnosing the linter error  #639 it appears it was not a false positive but really something we should consider. The error raised was about a shared pointer that was created for capturing a moveonly variable in a lambda. Using a shared_ptr for this purpose is highly discouraged as discussed here:
https://floating.io/2017/07/lambda-shared_ptr-memory-leak/
and
https://stackoverflow.com/questions/6458612/proper-way-to-receive-a-lambda-as-parameter-by-reference

Now, I instead made `OperatorResult` copyable and cleaned up some code, requiring less manual memory management. Furthermore, I renamed it to `CopyOnWriteBitmap` to be more descriptive.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~- [ ] All necessary documentation has been adapted or there is an issue to do so.~
- [X] The implemented feature is covered by an appropriate test.
