### PR TITLE
README and docker compose improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,16 @@ The precendence is `CLI argument > Environment Variable > Configuration File > D
 The preprocessing acts as a program that takes an input directory that contains the to-be-processed data
 and an output directory where the processed data will be stored.
 Both need to be mounted to the container.
-SILO also expects a database config and a preprocessing config that need to be mounted to the default locations.
+
+SILO expects a preprocessing config that can to be mounted to the default location `/app/preprocessing_config.yaml`.
+
+Additionally, a database config and a ndjson file containing the data are required. They should typically be mounted in `/preprocessing/input`.
 
 ```shell
 docker run \
   -v your/input/directory:/preprocessing/input \
   -v your/preprocessing/output:/preprocessing/output \
-  -v your/preprocessing_config.yaml:/app/preprocessing_config.yaml \
-  -v your/database_config.yaml:/app/database_config.yaml \
+  -v your/preprocessing_config.yaml:/app/preprocessing_config.yaml
   silo preprocessing
 ```
 

--- a/docker-compose-for-tests-preprocessing-from-ndjson.yml
+++ b/docker-compose-for-tests-preprocessing-from-ndjson.yml
@@ -6,7 +6,6 @@ services:
       - ./testBaseData/exampleDataset:/preprocessing/input
       - ./testBaseData/output:/preprocessing/output
       - ./testBaseData/exampleDataset/preprocessing_config.yaml:/app/preprocessing_config.yaml
-      - ./testBaseData/exampleDataset/database_config.yaml:/app/database_config.yaml
       - ./logs:/app/logs
     command:
       - "preprocessing"


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

improve README.md and remove superfluous database_config mount in the docker compose for ci.

The help text already mentioned that the `database_config` is relative to the input directory.:

```
         ConfigAttributeSpecification::createWithDefault(
            databaseConfigFileOptionKey(),
            ConfigValue::fromPath("database_config.yaml"),
            "File name of the file holding the database table configuration. Relative from "
            "input_directory."
         ),
```

Maybe this should have also been in the change-log?


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
~~- [ ] The implemented feature is covered by an appropriate test.~~
