### PR TITLE
fix: return an error if reserved value INT32_MIN is used in filter

### DIFF
--- a/src/silo/query_engine/filter_expressions/int_between.cpp
+++ b/src/silo/query_engine/filter_expressions/int_between.cpp
@@ -74,14 +74,21 @@ void from_json(const nlohmann::json& json, std::unique_ptr<IntBetween>& filter) 
       json["column"].is_string(), "The field 'column' in a IntBetween expression must be a string"
    );
    CHECK_SILO_QUERY(json.contains("from"), "The field 'from' is required in IntBetween expression");
+   bool value_from_in_allowed_range =
+      json["from"].is_number_integer() &&
+      json["from"].get<int32_t>() != storage::column::IntColumn::null();
    CHECK_SILO_QUERY(
-      json["from"].is_null() || json["from"].is_number_integer(),
-      "The field 'from' in a IntBetween expression must be an int or null"
+      value_from_in_allowed_range || json["from"].is_null(),
+      "The field 'from' in an IntBetween expression must be an integer in [-2147483647; "
+      "2147483647] or null"
    );
    CHECK_SILO_QUERY(json.contains("to"), "The field 'to' is required in a IntBetween expression");
+   bool value_to_in_allowed_range = json["to"].is_number_integer() &&
+                                    json["to"].get<int32_t>() != storage::column::IntColumn::null();
    CHECK_SILO_QUERY(
-      json["to"].is_null() || json["to"].is_number_integer(),
-      "The field 'to' in a IntBetween expression must be an int or null"
+      value_to_in_allowed_range || json["to"].is_null(),
+      "The field 'to' in an IntBetween expression must be an integer in [-2147483647; 2147483647] "
+      "or null"
    );
    const std::string& column_name = json["column"];
    std::optional<int32_t> value_from;

--- a/src/silo/query_engine/filter_expressions/int_equals.cpp
+++ b/src/silo/query_engine/filter_expressions/int_equals.cpp
@@ -54,9 +54,12 @@ void from_json(const nlohmann::json& json, std::unique_ptr<IntEquals>& filter) {
    CHECK_SILO_QUERY(
       json.contains("value"), "The field 'value' is required in an IntEquals expression"
    );
+   bool value_in_allowed_range = json["value"].is_number_integer() &&
+                                 json["value"].get<int32_t>() != storage::column::IntColumn::null();
    CHECK_SILO_QUERY(
-      json["value"].is_number_integer() || json["value"].is_null(),
-      "The field 'value' in an IntEquals expression must be an integer or null"
+      value_in_allowed_range || json["value"].is_null(),
+      "The field 'value' in an IntEquals expression must be an integer in [-2147483647; "
+      "2147483647] or null"
    );
    const std::string& column = json["column"];
    const int32_t& value =

--- a/src/silo/test/int_equals_and_between.test.cpp
+++ b/src/silo/test/int_equals_and_between.test.cpp
@@ -141,6 +141,30 @@ const QueryTestScenario INT_BETWEEN_WITH_FROM_AND_TO_NULL_SCENARIO = {
        {{"primaryKey", "id_3"}, {"int_value", VALUE_ABOVE_FILTER}}}
    )
 };
+
+const QueryTestScenario INT_EQUALS_WITH_INVALID_VALUE = {
+   .name = "intEqualsWithInvalidValue",
+   .query = createIntEqualsQuery("int_value", INT32_MIN),
+   .expected_error_message =
+      "The field 'value' in an IntEquals expression must be an integer in [-2147483647; "
+      "2147483647] or null"
+};
+
+const QueryTestScenario INT_BETWEEN_WITH_INVALID_FROM_VALUE = {
+   .name = "intBetweenWithInvalidFromValue",
+   .query = createIntBetweenQuery("int_value", INT32_MIN, 1),
+   .expected_error_message =
+      "The field 'from' in an IntBetween expression must be an integer in [-2147483647; "
+      "2147483647] or null"
+};
+
+const QueryTestScenario INT_BETWEEN_WITH_INVALID_TO_VALUE = {
+   .name = "intBetweenWithInvalidToValue",
+   .query = createIntBetweenQuery("int_value", 0, INT32_MIN),
+   .expected_error_message =
+      "The field 'to' in an IntBetween expression must be an integer in [-2147483647; 2147483647] "
+      "or null"
+};
 }  // namespace
 
 QUERY_TEST(
@@ -152,6 +176,9 @@ QUERY_TEST(
       INT_BETWEEN_WITH_FROM_AND_TO_SCENARIO,
       INT_BETWEEN_WITH_FROM_SCENARIO,
       INT_BETWEEN_WITH_TO_SCENARIO,
-      INT_BETWEEN_WITH_FROM_AND_TO_NULL_SCENARIO
+      INT_BETWEEN_WITH_FROM_AND_TO_NULL_SCENARIO,
+      INT_EQUALS_WITH_INVALID_VALUE,
+      INT_BETWEEN_WITH_INVALID_FROM_VALUE,
+      INT_BETWEEN_WITH_INVALID_TO_VALUE
    )
 );


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #636 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

The value `INT32_MIN` is currently reserved in an Integer column. This fixes the bug, that a user could still filter for that value and receive unexpected results.


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
