### PR TITLE
Fix ci main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           tags: ${{ steps.dockerMetadataDependencies.outputs.tags }}
           cache-from: type=gha,ref=builder-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile') }}
           cache-to: type=gha,mode=min,ref=builder-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile') }}
-          platforms: ${{ matrix.os }}/${{ matrix.arch }}
+          platforms: "${{ matrix.os }}/${{ matrix.arch }}"
 
       - name: Retag and push existing image if cache hit
         if: env.CACHE_HIT == 'true' && env.PLATFORM_BUILD == 'true'
@@ -117,6 +117,7 @@ jobs:
           target: builder
           tags: builder
           load: true
+          platforms: "${{ matrix.os }}/${{ matrix.arch }}"
           cache-from: type=gha,ref=${{ github.ref_name }}-image-cache
           cache-to: type=gha,mode=min,ref=${{ github.ref_name }}-image-cache
           build-args: |
@@ -135,10 +136,12 @@ jobs:
         with:
           context: .
           push: true
-          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: "${{ matrix.os }}/${{ matrix.arch }}"
+          cache-from: type=gha,ref=${{ github.ref_name }}-image-cache
+          cache-to: type=gha,mode=min,ref=${{ github.ref_name }}-image-cache
           tags: ${{ steps.dockerMetadataImage.outputs.tags }}
           build-args: |
-            DEPENDENCY_IMAGE=ghcr.io/genspectrum/lapis-silo-dependencies:commit-${{ env.HEAD_SHA }}
+            DEPENDENCY_IMAGE=${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:commit-${{ env.HEAD_SHA }}
 
   endToEndTests:
     name: Run End To End Tests


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

build: only build image for the platform that is currently running in the matrix. Before, both images tried to build and push the production image for both target platforms (`linux/amd64` and `linux/arm64`) on main. The unit tests were always run with the `linux/amd64` image.. For now I changed this to run it for the respective architecture currently running in the matrix. This can be excessive but given that it only runs on main, it might be acceptable?

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [ ] The implemented feature is covered by an appropriate test.
