### PR TITLE
build: correctly specify our conan configuration for Debug builds

### DIFF
--- a/Dockerfile_dependencies
+++ b/Dockerfile_dependencies
@@ -22,4 +22,4 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     fi
 
 RUN conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build/Release/generators
-RUN conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --output-folder=build/Debug/generators
+RUN conan install . --build=missing --profile ./conanprofile --profile:build ./conanprofile --settings "&:build_type=Debug" --output-folder=build/Debug/generators

--- a/build_with_conan.py
+++ b/build_with_conan.py
@@ -9,6 +9,7 @@ def clean_build_folder(build_folder: str):
     if os.path.exists(build_folder):
         shutil.rmtree(build_folder)
 
+
 def run_cmd(context: str, cmd: str):
     print("----------------------------------")
     print(cmd)
@@ -16,6 +17,7 @@ def run_cmd(context: str, cmd: str):
 
     if subprocess.call(cmd, shell=True) != 0:
         raise Exception(f"{context} command failed.")
+
 
 def main(args):
     cmake_options = []
@@ -30,7 +32,8 @@ def main(args):
     else:
         build_folder = "build/Debug"
         cmake_options.append("-D CMAKE_BUILD_TYPE=Debug")
-        conan_options.append("-s build_type=Debug")
+        # We still want to have our dependencies in Release, but the & tells conan we will build the consumer as Debug
+        conan_options.append("--settings '&:build_type=Debug'")
         conan_options.append("--output-folder=build/Debug/generators")
 
     if args.clean:


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves current CI issue in #666 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
The comment in `build_with_conan.py` says all:
We still want to have our dependencies in Release, but the & tells conan we will build the consumer as Debug
Therefore, we set the flag `--settings '&:build_type=Debug'` (in both `build_with_conan.py` and `Dockerfile_dependencies`). 

It was not mentioned in the [docs](https://docs.conan.io/2/reference/commands/install.html), but I found this way of specifying packages only in: 
https://github.com/conan-io/conan/issues/14459


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
