### PR TITLE
Build arm images on demand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ env:
 jobs:
   dockerImage:
     name: Build docker images
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         arch:
           ['amd64', 'arm64']
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-latest' }}
     permissions:
       packages: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,27 @@ env:
   DOCKER_IMAGE_NAME: ghcr.io/genspectrum/lapis-silo
 
 jobs:
-  dockerImageUnitTests:
-    name: Build Docker Image and Run Unit Tests
+  dockerImage:
+    name: Build docker images
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os:
-          ['linux']
         arch:
           ['amd64', 'arm64']
     permissions:
       packages: write
     steps:
       - uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Determine HEAD_SHA
         run: |
@@ -42,41 +50,41 @@ jobs:
           DIR_HASH=$(echo -n ${{ hashFiles('conanfile.py', 'conanprofile.docker', './Dockerfile_dependencies') }})
           echo "DIR_HASH=$DIR_HASH" >> $GITHUB_ENV
 
-      - name: Docker metadata
-        id: dockerMetadataDependencies
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=filehash-${{ matrix.os }}-${{ matrix.arch }}-${{ env.DIR_HASH }}
-            type=raw,value=commit-${{ env.HEAD_SHA }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check if image exists
-        run: |
-          EXISTS=$(docker manifest inspect ${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:filehash-${{ matrix.os }}-${{ matrix.arch }}-${{ env.DIR_HASH }} > /dev/null 2>&1 && echo "true" || echo "false")
-          echo "CACHE_HIT=$EXISTS" >> $GITHUB_ENV
-
       - name: Determine platform build necessity
         run: |
-          if [[ "${{ matrix.arch }}" == "amd64" || "${{ github.ref }}" == "refs/heads/main" ]]; then
+          # Default PLATFORM_BUILD to false
+          echo "PLATFORM_BUILD=false" >> $GITHUB_ENV
+
+          # Check if architecture is amd64
+          if [[ "${{ matrix.arch }}" == "amd64" ]]; then
             echo "PLATFORM_BUILD=true" >> $GITHUB_ENV
-          else
-            echo "Skipping build for platform ${{ matrix.os }}/${{ matrix.arch }}"
-            echo "PLATFORM_BUILD=false" >> $GITHUB_ENV
+            exit 0
           fi
 
-      - name: Set up Docker Buildx
+          # Check if branch is main
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "PLATFORM_BUILD=true" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          # Write the current labels to a file
+          cat <<EOF > event.json
+          ${{ toJSON(github.event.pull_request.labels) }}
+          EOF
+
+          # Check if the PR has the label 'arm-image'
+          if jq -e '.[] | select(.name == "arm-image")' event.json > /dev/null; then
+            echo "PLATFORM_BUILD=true" >> $GITHUB_ENV
+            exit 0
+          fi
+
+      - name: Check if image exists
         if: env.PLATFORM_BUILD == 'true'
-        uses: docker/setup-buildx-action@v3
+        run: |
+          EXISTS=$(docker manifest inspect \
+            ${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:filehash-${{ env.DIR_HASH }}-${{ matrix.arch }} \ 
+            > /dev/null 2>&1 && echo "true" || echo "false")
+          echo "CACHE_HIT=$EXISTS" >> $GITHUB_ENV
 
       - name: Build and push image if input files changed
         if: env.CACHE_HIT == 'false' && env.PLATFORM_BUILD == 'true'
@@ -85,51 +93,17 @@ jobs:
           context: .
           file: Dockerfile_dependencies
           push: true
-          tags: ${{ steps.dockerMetadataDependencies.outputs.tags }}
+          tags: ${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:filehash-${{ env.DIR_HASH }}-${{ matrix.arch }}
           cache-from: type=gha,ref=builder-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile') }}
           cache-to: type=gha,mode=min,ref=builder-image-cache-${{ hashFiles('conanfile.py', 'Dockerfile') }}
-          platforms: "${{ matrix.os }}/${{ matrix.arch }}"
+          platforms: "linux/${{ matrix.arch }}"
 
-      - name: Retag and push existing image if cache hit
-        if: env.CACHE_HIT == 'true' && env.PLATFORM_BUILD == 'true'
-        run: |
-          TAGS=(${{ steps.dockerMetadataDependencies.outputs.tags }})
-          for TAG in "${TAGS[@]}"; do
-            docker buildx imagetools create --tag $TAG ${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:filehash-${{ matrix.os }}-${{ matrix.arch }}-${{ env.DIR_HASH }}
-          done
-
-      - name: Docker metadata
-        if: env.PLATFORM_BUILD == 'true'
-        id: dockerMetadataImage
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.DOCKER_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=commit-${{ env.HEAD_SHA }}
-
-      - name: Build unit test image
-        if: env.PLATFORM_BUILD == 'true'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          target: builder
-          tags: builder
-          load: true
-          platforms: "${{ matrix.os }}/${{ matrix.arch }}"
-          cache-from: type=gha,ref=${{ github.ref_name }}-image-cache
-          cache-to: type=gha,mode=min,ref=${{ github.ref_name }}-image-cache
-          build-args: |
-            DEPENDENCY_IMAGE=${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:commit-${{ env.HEAD_SHA }}
-
-      - name: Run unit tests
+      - name: Tag dependency image with commit hash
         if: env.PLATFORM_BUILD == 'true'
         run: |
-          docker run \
-            --platform "${{ matrix.os }}/${{ matrix.arch }}" \
-            --entrypoint "./silo_test" \
-            builder
+          docker buildx imagetools create \
+            --tag ${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:commit-${{ env.HEAD_SHA }}-${{ matrix.arch }} \
+            ${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:filehash-${{ env.DIR_HASH }}-${{ matrix.arch }}
 
       - name: Build and push production image
         if: env.PLATFORM_BUILD == 'true'
@@ -137,19 +111,22 @@ jobs:
         with:
           context: .
           push: true
-          platforms: "${{ matrix.os }}/${{ matrix.arch }}"
+          platforms: "linux/${{ matrix.arch }}"
           cache-from: type=gha,ref=${{ github.ref_name }}-image-cache
           cache-to: type=gha,mode=min,ref=${{ github.ref_name }}-image-cache
-          tags: ${{ steps.dockerMetadataImage.outputs.tags }}
+          tags: ${{ env.DOCKER_IMAGE_NAME }}:commit-${{ env.HEAD_SHA }}-${{ matrix.arch }}
           build-args: |
-            DEPENDENCY_IMAGE=${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:commit-${{ env.HEAD_SHA }}
+            DEPENDENCY_IMAGE=${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:commit-${{ env.HEAD_SHA }}-${{ matrix.arch }}
 
-  endToEndTests:
-    name: Run End To End Tests
-    needs: dockerImageUnitTests
+  unitTests:
+    name: Unit tests
+    needs: dockerImage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Determine HEAD_SHA
         run: |
@@ -159,10 +136,108 @@ jobs:
             echo "HEAD_SHA=${{ github.sha }}" >> $GITHUB_ENV
           fi
 
+      - name: Build unit test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: builder
+          tags: builder
+          load: true
+          cache-from: type=gha,ref=${{ github.ref_name }}-image-cache
+          cache-to: type=gha,mode=min,ref=${{ github.ref_name }}-image-cache
+          build-args: |
+            DEPENDENCY_IMAGE=${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:commit-${{ env.HEAD_SHA }}-amd64
+
+      - name: Run unit tests
+        run: |
+          docker run \
+            --entrypoint "./silo_test" \
+            builder
+
+  multiPlatformImages:
+    name: Create multi-platform images
+    needs: dockerImage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Determine HEAD_SHA
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+          else
+            echo "HEAD_SHA=${{ github.sha }}" >> $GITHUB_ENV
+          fi
+
+      - name: Detect all platforms with built images
+        run: |
+          PLATFORMS=""
+          
+          PLATFORMS_TO_CHECK=(
+          "${{ env.DOCKER_IMAGE_NAME }}:commit-${{ env.HEAD_SHA }}-arm64"
+          "${{ env.DOCKER_IMAGE_NAME }}:commit-${{ env.HEAD_SHA }}-amd64"
+          )
+          
+          for PLATFORM in "${PLATFORMS_TO_CHECK[@]}"; do
+            echo "Checking existence of: $PLATFORM"
+            if docker manifest inspect "$PLATFORM" > /dev/null 2>&1; then
+              echo "Image for $PLATFORM exists"
+              PLATFORMS+="$PLATFORM "
+            else
+              echo "Image for $PLATFORM does not exist"
+            fi
+          done
+          
+          # Trim trailing space from PLATFORMS
+          PLATFORMS=$(echo "$PLATFORMS" | sed 's/[[:space:]]*$//')
+          
+          echo "PLATFORM_SPECIFIC_IMAGES=$PLATFORMS" >> $GITHUB_ENV
+
+      - name: Docker metadata
+        id: dockerMetadataImage
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=commit-${{ env.HEAD_SHA }}
+
+      - name: Tag images
+        run: |
+          TAGS=(${{ steps.dockerMetadataImage.outputs.tags }})
+          for TAG in "${TAGS[@]}"; do
+            docker buildx imagetools create --tag $TAG \
+              ${{ env.PLATFORM_SPECIFIC_IMAGES }}
+          done
+
+  endToEndTests:
+    name: Run End To End Tests
+    needs: dockerImage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: 18.x
+
+      - name: Determine HEAD_SHA
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+          else
+            echo "HEAD_SHA=${{ github.sha }}" >> $GITHUB_ENV
+          fi
 
       - uses: actions/cache@v4
         with:
@@ -178,25 +253,25 @@ jobs:
       - name: Start Docker Container and preprocess data
         run: docker compose -f docker-compose-for-tests-preprocessing-from-ndjson.yml up
         env:
-          SILO_IMAGE: ${{ env.DOCKER_IMAGE_NAME }}:commit-${{ env.HEAD_SHA }}
+          SILO_IMAGE: ${{ env.DOCKER_IMAGE_NAME }}:commit-${{ env.HEAD_SHA }}-amd64
 
       - name: Start Docker Container and run api
         run: docker compose -f docker-compose-for-tests-api.yml up -d --wait
         env:
-          SILO_IMAGE: ${{ env.DOCKER_IMAGE_NAME }}:commit-${{ env.HEAD_SHA }}
+          SILO_IMAGE: ${{ env.DOCKER_IMAGE_NAME }}:commit-${{ env.HEAD_SHA }}-amd64
 
       - name: Run Tests
         run: cd endToEndTests && SILO_URL=localhost:8080 npm run test
 
   linterChanges:
-    name: Build And Run linter
-    needs: dockerImageUnitTests
+    name: Build/Run linter on changed files
+    needs: dockerImage
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.number }}
     container:
-      image: ghcr.io/genspectrum/lapis-silo-dependencies:commit-${{ github.event.pull_request.head.sha }}
+      image: ghcr.io/genspectrum/lapis-silo-dependencies:commit-${{ github.event.pull_request.head.sha }}-amd64
     steps:
       - uses: actions/checkout@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG DEPENDENCY_IMAGE=ghcr.io/genspectrum/lapis-silo-dependencies:latest
+ARG DEPENDENCY_IMAGE
 
 FROM $DEPENDENCY_IMAGE AS builder
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

When testing builds, it can be beneficial, to also have the arm images ready to test in PRs. This is not possible currently, because we only build these images on merges main, as github's arm emulation is quite time-consuming. This PR adds the possibility to request an ARM image by adding the label `arm-image` to the PR

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
