### PR TITLE
build: make sure that dependabot is allowed to tag Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
     name: Create multi-platform images
     needs: dockerImage
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

Currently, dependabot PRs are failing on the "Tag images" step:
```
Run TAGS=(ghcr.io/genspectrum/lapis-silo:commit-2a21f6462fead47369031b1678f81564d7fdb3a5)
#1 [internal] pushing ghcr.io/genspectrum/lapis-silo:commit-2a21f6462fead47369031b1678f81564d7fdb3a5
#1 0.000 pushing sha256:adffed351a41aa07c46b0c47c0e1dede17cbfaa80fe5f4097143c57e3f3c7234 to ghcr.io/genspectrum/lapis-silo:commit-2a21f6462fead47369031b1678f81564d7fdb3a5
#1 ERROR: failed commit on ref "index-sha256:adffed351a41aa07c46b0c47c0e1dede17cbfaa80fe5f4097143c57e3f3c7234": unexpected status from PUT request to https://ghcr.io/v2/genspectrum/lapis-silo/manifests/commit-2a21f6462fead47369031b1678f81564d7fdb3a5: 403 Forbidden
------
 > [internal] pushing ghcr.io/genspectrum/lapis-silo:commit-2a21f6462fead47369031b1678f81564d7fdb3a5:
0.000 pushing sha256:adffed351a41aa07c46b0c47c0e1dede17cbfaa80fe5f4097143c57e3f3c7234 to ghcr.io/genspectrum/lapis-silo:commit-2a21f6462fead47369031b1678f81564d7fdb3a5
------
ERROR: failed commit on ref "index-sha256:adffed351a41aa07c46b0c47c0e1dede17cbfaa80fe5f4097143c57e3f3c7234": unexpected status from PUT request to https://ghcr.io/v2/genspectrum/lapis-silo/manifests/commit-2a21f6462fead47369031b1678f81564d7fdb3a5: 403 Forbidden
Error: Process completed with exit code 1.
``` 

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
