### PR TITLE
build(deps): update poco dependency version to 1.13.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Check if dependency image exists
         run: |
           EXISTS=$(docker manifest inspect \
-            ${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:filehash-${{ env.DIR_HASH }}-${{ matrix.arch }} \ 
-            > /dev/null 2>&1 && echo "true" || echo "false")
+            ${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:filehash-${{ env.DIR_HASH }}-${{ matrix.arch }} > /dev/null 2>&1 && 
+            echo "true" || echo "false")
           echo "CACHE_HIT=$EXISTS" >> $GITHUB_ENV
 
       - name: Build and push dependency image if input files changed

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ class SiloRecipe(ConanFile):
     requires = [
         "boost/1.82.0",
         "duckdb/1.0.0",
-        "poco/1.12.4",
+        "poco/1.13.3",
         "hwloc/2.9.3",
         "onetbb/2021.10.0",
         "nlohmann_json/3.11.2",

--- a/src/silo/api/api.cpp
+++ b/src/silo/api/api.cpp
@@ -30,8 +30,16 @@ int Api::runApi(const silo::config::RuntimeConfig& runtime_config) {
    );
    poco_parameter->setMaxThreads(runtime_config.api_options.parallel_threads);
 
+   // For better profiling, we do not want requests to allocate new threads in the thread pool.
+   // Instead, just allocate all of them directly on start-up (by setting minCapacity)
+   Poco::ThreadPool thread_pool(
+      /* minCapacity = */ runtime_config.api_options.parallel_threads,
+      /* maxCapacity = */ runtime_config.api_options.parallel_threads
+   );
+
    Poco::Net::HTTPServer server(
       new silo::api::SiloRequestHandlerFactory(database_mutex, runtime_config),
+      thread_pool,
       server_socket,
       poco_parameter
    );


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

There is a [fix](https://github.com/pocoproject/poco/pull/3992) in POCO for a leak in [v1.12.5](https://github.com/pocoproject/poco/blob/poco-1.12.5-release/CHANGELOG). It lead to overallocation of threads during heavy load which are then never deallocated subsequently. This upgrade fixes this leak. It is uncertain, whether it fully resolves the behavior in #697. Therefore, I also introduced an additional change that allocates all threads Poco will ever use already at startup. This makes it easier to profile SILO in the future.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
