### PR TITLE
Hotfix sequence download

### DIFF
--- a/src/silo/query_engine/actions/fasta.cpp
+++ b/src/silo/query_engine/actions/fasta.cpp
@@ -1,5 +1,9 @@
 #include "silo/query_engine/actions/fasta.h"
 
+#if defined(__linux__)
+#include <malloc.h>
+#endif
+
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
 #include <boost/numeric/conversion/cast.hpp>
@@ -296,6 +300,13 @@ QueryResult Fasta::execute(const Database& database, std::vector<CopyOnWriteBitm
                primary_key_column,
                result_row_indices.size()
             );
+#if defined(__linux__)
+            SPDLOG_INFO(
+               "Fasta sequences generated for partition. Manually invoking malloc_trim() to give "
+               "back memory to OS."
+            );
+            malloc_trim(0);
+#endif
 
             SILO_ASSERT(results.size() == result_row_indices.size());
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #697 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

While #705 already fixes a memory contention directly, there is another more pressing concern with the download of Fasta sequences. 

Due to the same `malloc` behavior, this leads to an increase of ~1.5 GB every time all mpox sequences are downloaded on Pathoplexus. This is bounded at _some_ point, when malloc decides to finally give back some of its free memory (>90% of the total memory consumption!). This fix tells malloc to trim its memory on every Fasta request.


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [ ] The implemented feature is covered by an appropriate test.
