### PR TITLE
fix: correctly expect an escaped stop codon in requests

### DIFF
--- a/endToEndTests/test/invalidQueries/insertionContains_invalidPattern.json
+++ b/endToEndTests/test/invalidQueries/insertionContains_invalidPattern.json
@@ -12,6 +12,6 @@
   },
   "expectedError": {
     "error": "Bad request",
-    "message": "The field 'value' in the InsertionContains expression does not contain a valid regex pattern: \"CC+++\". It must only consist of nucleotide symbols and the regex symbol '.*'."
+    "message": "The field 'value' in the InsertionContains expression does not contain a valid regex pattern: \"CC+++\". It must only consist of nucleotide symbols and the regex symbol '.*'. Also note that the stop codon * must be escaped correctly with a \\ in amino acid queries."
   }
 }

--- a/endToEndTests/test/invalidQueries/insertionContains_invalidPattern2.json
+++ b/endToEndTests/test/invalidQueries/insertionContains_invalidPattern2.json
@@ -12,6 +12,6 @@
   },
   "expectedError": {
     "error": "Bad request",
-    "message": "The field 'value' in the InsertionContains expression does not contain a valid regex pattern: \"CC..*\". It must only consist of nucleotide symbols and the regex symbol '.*'."
+    "message": "The field 'value' in the InsertionContains expression does not contain a valid regex pattern: \"CC..*\". It must only consist of nucleotide symbols and the regex symbol '.*'. Also note that the stop codon * must be escaped correctly with a \\ in amino acid queries."
   }
 }

--- a/endToEndTests/test/queries/aaInsertionsAction.json
+++ b/endToEndTests/test/queries/aaInsertionsAction.json
@@ -32,7 +32,14 @@
       "sequenceName": "S"
     },
     {
-      "count": 5,
+      "count": 1,
+      "insertedSymbols": "*EPE",
+      "insertion": "ins_S:214:*EPE",
+      "position": 214,
+      "sequenceName": "S"
+    },
+    {
+      "count": 4,
       "insertedSymbols": "EPE",
       "insertion": "ins_S:214:EPE",
       "position": 214,

--- a/endToEndTests/test/queries/aaInsertionsActionAndFilter.json
+++ b/endToEndTests/test/queries/aaInsertionsActionAndFilter.json
@@ -14,7 +14,14 @@
   },
   "expectedQueryResult": [
     {
-      "count": 5,
+      "count": 1,
+      "insertedSymbols": "*EPE",
+      "insertion": "ins_S:214:*EPE",
+      "position": 214,
+      "sequenceName": "S"
+    },
+    {
+      "count": 4,
       "insertedSymbols": "EPE",
       "insertion": "ins_S:214:EPE",
       "position": 214,

--- a/endToEndTests/test/queries/aaInsertionsActionOneSequence.json
+++ b/endToEndTests/test/queries/aaInsertionsActionOneSequence.json
@@ -12,7 +12,14 @@
   },
   "expectedQueryResult": [
     {
-      "count": 5,
+      "count": 1,
+      "insertedSymbols": "*EPE",
+      "insertion": "ins_S:214:*EPE",
+      "position": 214,
+      "sequenceName": "S"
+    },
+    {
+      "count": 4,
       "insertedSymbols": "EPE",
       "insertion": "ins_S:214:EPE",
       "position": 214,

--- a/endToEndTests/test/queries/insertionContainsStopCodon.json
+++ b/endToEndTests/test/queries/insertionContainsStopCodon.json
@@ -1,0 +1,23 @@
+{
+  "testCaseName": "insertionContains with a StopCodon",
+  "query": {
+    "action": {
+      "groupByFields": ["date"],
+      "orderByFields": [
+        {
+          "field": "date",
+          "order": "ascending"
+        }
+      ],
+      "randomize": false,
+      "type": "Aggregated"
+    },
+    "filterExpression": {
+      "position": 214,
+      "value": "\\*E",
+      "sequenceName": "S",
+      "type": "AminoAcidInsertionContains"
+    }
+  },
+  "expectedQueryResult": [{ "count": 1, "date": "2021-01-25" }]
+}

--- a/include/silo/common/aa_symbols.h
+++ b/include/silo/common/aa_symbols.h
@@ -94,10 +94,6 @@ class AminoAcid {
    static char symbolToChar(Symbol symbol);
 
    static std::optional<Symbol> charToSymbol(char character);
-
-   static std::optional<std::vector<Symbol>> stringToSymbolVector(const std::string& sequence);
-
-   static std::optional<char> findIllegalChar(const std::string& sequence);
 };
 
 }  // namespace silo

--- a/include/silo/common/nucleotide_symbols.h
+++ b/include/silo/common/nucleotide_symbols.h
@@ -89,10 +89,6 @@ class Nucleotide {
    static char symbolToChar(Symbol symbol);
 
    static std::optional<Symbol> charToSymbol(char character);
-
-   static std::optional<std::vector<Symbol>> stringToSymbolVector(const std::string& sequence);
-
-   static std::optional<char> findIllegalChar(const std::string& sequence);
 };
 
 }  // namespace silo

--- a/include/silo/storage/insertion_index.h
+++ b/include/silo/storage/insertion_index.h
@@ -17,6 +17,12 @@
 
 namespace silo::storage::insertion {
 
+class InsertionException : public std::runtime_error {
+  public:
+   explicit InsertionException(const std::string& error_message)
+       : runtime_error(error_message) {}
+};
+
 template <typename SymbolType>
 class ThreeMerHash {
   public:

--- a/src/silo/common/aa_symbols.cpp
+++ b/src/silo/common/aa_symbols.cpp
@@ -121,31 +121,6 @@ std::optional<AminoAcid::Symbol> AminoAcid::charToSymbol(char character) {
    }
 }
 
-std::optional<std::vector<AminoAcid::Symbol>> AminoAcid::stringToSymbolVector(
-   const std::string& sequence
-) {
-   const size_t size = sequence.size();
-   std::vector<AminoAcid::Symbol> result(size);
-   for (size_t i = 0; i < size; ++i) {
-      auto symbol = AminoAcid::charToSymbol(sequence[i]);
-      if (symbol == std::nullopt) {
-         return std::nullopt;
-      }
-      result[i] = *symbol;
-   }
-   return result;
-}
-
-std::optional<char> AminoAcid::findIllegalChar(const std::string& sequence) {
-   for (const auto aa_char : sequence) {
-      auto symbol = AminoAcid::charToSymbol(aa_char);
-      if (symbol == std::nullopt) {
-         return aa_char;
-      }
-   }
-   return std::nullopt;
-}
-
 const silo::SymbolMap<AminoAcid, std::vector<AminoAcid::Symbol>> AminoAcid::AMBIGUITY_SYMBOLS{{{
    {AminoAcid::Symbol::GAP, AminoAcid::Symbol::X},
    {AminoAcid::Symbol::A, AminoAcid::Symbol::X},

--- a/src/silo/common/aa_symbols.test.cpp
+++ b/src/silo/common/aa_symbols.test.cpp
@@ -17,8 +17,3 @@ TEST(AminoAcidSymbol, conversionFromCharacter) {
    EXPECT_EQ(silo::AminoAcid::charToSymbol('J'), std::nullopt);
    EXPECT_EQ(silo::AminoAcid::charToSymbol(')'), std::nullopt);
 }
-
-TEST(AminoAcidSymbol, findIllegalAminoAcidChar) {
-   EXPECT_EQ(silo::AminoAcid::findIllegalChar("ACGT"), std::nullopt);
-   EXPECT_EQ(silo::AminoAcid::findIllegalChar("ACGTJ"), 'J');
-}

--- a/src/silo/common/nucleotide_symbols.cpp
+++ b/src/silo/common/nucleotide_symbols.cpp
@@ -81,31 +81,6 @@ std::optional<Nucleotide::Symbol> Nucleotide::charToSymbol(char character) {
    }
 }
 
-std::optional<std::vector<Nucleotide::Symbol>> Nucleotide::stringToSymbolVector(
-   const std::string& sequence
-) {
-   const size_t size = sequence.size();
-   std::vector<Symbol> result(size);
-   for (size_t i = 0; i < size; ++i) {
-      auto symbol = Nucleotide::charToSymbol(sequence[i]);
-      if (symbol == std::nullopt) {
-         return std::nullopt;
-      }
-      result[i] = *symbol;
-   }
-   return result;
-}
-
-std::optional<char> Nucleotide::findIllegalChar(const std::string& sequence) {
-   for (const auto nuc_char : sequence) {
-      auto symbol = Nucleotide::charToSymbol(nuc_char);
-      if (symbol == std::nullopt) {
-         return nuc_char;
-      }
-   }
-   return std::nullopt;
-}
-
 const silo::SymbolMap<Nucleotide, std::vector<Nucleotide::Symbol>> Nucleotide::AMBIGUITY_SYMBOLS{{{
    {Nucleotide::Symbol::GAP},
    {Nucleotide::Symbol::A,

--- a/src/silo/common/nucleotide_symbols.test.cpp
+++ b/src/silo/common/nucleotide_symbols.test.cpp
@@ -13,8 +13,3 @@ TEST(NucleotideSymbol, conversionFromCharacter) {
    EXPECT_EQ(silo::Nucleotide::charToSymbol('N'), silo::Nucleotide::Symbol::N);
    EXPECT_EQ(silo::Nucleotide::charToSymbol('X'), std::nullopt);
 }
-
-TEST(NucleotideSymbol, findIllegalNucleotideChar) {
-   EXPECT_EQ(silo::Nucleotide::findIllegalChar("ACGT"), std::nullopt);
-   EXPECT_EQ(silo::Nucleotide::findIllegalChar("ACGTZ"), 'Z');
-}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #725

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

We now correctly expect a `\*` when searching for a stop codon. We validate the insertion search regex to only contain valid symbols, `.*` or `\*`.

Also, clean up of some code paths in the `insertion_index`

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
