### PR TITLE
fix: return 503 response when no database has been loaded yet

### DIFF
--- a/include/silo/api/info_handler.h
+++ b/include/silo/api/info_handler.h
@@ -10,10 +10,10 @@ namespace silo::api {
 
 class InfoHandler : public RestResource {
   private:
-   std::shared_ptr<Database> database;
+   std::shared_ptr<ActiveDatabase> database_handle;
 
   public:
-   explicit InfoHandler(std::shared_ptr<Database> database);
+   explicit InfoHandler(std::shared_ptr<ActiveDatabase> database_handle);
 
    void get(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response)
       override;

--- a/include/silo/api/lineage_definition_handler.h
+++ b/include/silo/api/lineage_definition_handler.h
@@ -10,11 +10,14 @@ namespace silo::api {
 
 class LineageDefinitionHandler : public RestResource {
   private:
-   std::shared_ptr<Database> database;
+   std::shared_ptr<ActiveDatabase> database_handle;
    std::string column_name;
 
   public:
-   explicit LineageDefinitionHandler(std::shared_ptr<Database> database, std::string column_name);
+   explicit LineageDefinitionHandler(
+      std::shared_ptr<ActiveDatabase> database_handle,
+      std::string column_name
+   );
 
    void get(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response)
       override;

--- a/include/silo/api/query_handler.h
+++ b/include/silo/api/query_handler.h
@@ -9,10 +9,10 @@
 namespace silo::api {
 class QueryHandler : public RestResource {
   private:
-   std::shared_ptr<Database> database;
+   std::shared_ptr<ActiveDatabase> database_handle;
 
   public:
-   explicit QueryHandler(std::shared_ptr<Database> database);
+   explicit QueryHandler(std::shared_ptr<ActiveDatabase> database_handle);
 
    void post(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response)
       override;

--- a/src/silo/api/info_handler.cpp
+++ b/src/silo/api/info_handler.cpp
@@ -89,14 +89,16 @@ std::map<std::string, std::string> getQueryParameter(const Poco::Net::HTTPServer
 
 namespace silo::api {
 
-InfoHandler::InfoHandler(std::shared_ptr<Database> database)
-    : database(database) {}
+InfoHandler::InfoHandler(std::shared_ptr<ActiveDatabase> database_handle)
+    : database_handle(database_handle) {}
 
 void InfoHandler::get(
    Poco::Net::HTTPServerRequest& request,
    Poco::Net::HTTPServerResponse& response
 ) {
    const auto request_parameter = getQueryParameter(request);
+
+   const auto database = database_handle->getActiveDatabase();
 
    response.set("data-version", database->getDataVersionTimestamp().value);
 

--- a/src/silo/api/lineage_definition_handler.cpp
+++ b/src/silo/api/lineage_definition_handler.cpp
@@ -5,7 +5,6 @@
 
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/Net/HTTPServerResponse.h>
-#include <Poco/URI.h>
 #include <nlohmann/json.hpp>
 
 #include "silo/api/active_database.h"
@@ -14,16 +13,18 @@
 namespace silo::api {
 
 LineageDefinitionHandler::LineageDefinitionHandler(
-   std::shared_ptr<Database> database,
+   std::shared_ptr<ActiveDatabase> database_handle,
    std::string column_name
 )
-    : database(database),
+    : database_handle(database_handle),
       column_name(std::move(column_name)) {}
 
 void LineageDefinitionHandler::get(
    Poco::Net::HTTPServerRequest& request,
    Poco::Net::HTTPServerResponse& response
 ) {
+   const auto database = database_handle->getActiveDatabase();
+
    response.set("data-version", database->getDataVersionTimestamp().value);
 
    auto column_metadata = std::ranges::find_if(

--- a/src/silo/api/query_handler.cpp
+++ b/src/silo/api/query_handler.cpp
@@ -17,13 +17,15 @@
 namespace silo::api {
 using silo::query_engine::QueryResultEntry;
 
-QueryHandler::QueryHandler(std::shared_ptr<Database> database)
-    : database(database) {}
+QueryHandler::QueryHandler(std::shared_ptr<ActiveDatabase> database_handle)
+    : database_handle(database_handle) {}
 
 void QueryHandler::post(
    Poco::Net::HTTPServerRequest& request,
    Poco::Net::HTTPServerResponse& response
 ) {
+   const auto database = database_handle->getActiveDatabase();
+
    const auto request_id = response.get("X-Request-Id");
 
    std::string query;

--- a/src/silo/api/request_handler_factory.cpp
+++ b/src/silo/api/request_handler_factory.cpp
@@ -41,15 +41,13 @@ std::unique_ptr<Poco::Net::HTTPRequestHandler> SiloRequestHandlerFactory::routeR
    uri.getPathSegments(segments);
 
    if (path == "/info") {
-      return std::make_unique<silo::api::InfoHandler>(database_handle->getActiveDatabase());
+      return std::make_unique<silo::api::InfoHandler>(database_handle);
    }
    if (segments.size() == 2 && segments.at(0) == "lineageDefinition") {
-      return std::make_unique<silo::api::LineageDefinitionHandler>(
-         database_handle->getActiveDatabase(), segments.at(1)
-      );
+      return std::make_unique<silo::api::LineageDefinitionHandler>(database_handle, segments.at(1));
    }
    if (path == "/query") {
-      return std::make_unique<silo::api::QueryHandler>(database_handle->getActiveDatabase());
+      return std::make_unique<silo::api::QueryHandler>(database_handle);
    }
    return std::make_unique<silo::api::NotFoundHandler>();
 }

--- a/src/silo/api/request_handler_factory.test.cpp
+++ b/src/silo/api/request_handler_factory.test.cpp
@@ -4,6 +4,7 @@
 
 #include "silo/api/info_handler.h"
 #include "silo/api/lineage_definition_handler.h"
+#include "silo/api/manual_poco_mocks.test.h"
 #include "silo/api/not_found_handler.h"
 #include "silo/api/query_handler.h"
 #include "silo/api/request_handler_factory.h"
@@ -34,18 +35,56 @@ void assertHoldsHandlerType(std::unique_ptr<Poco::Net::HTTPRequestHandler>& hand
 }
 }  // namespace
 
-TEST(SiloRequestHandlerFactory, returnsErrorWhenDatabaseIsNotInitialized) {
-   Poco::URI uri("/info");
+TEST(SiloRequestHandlerFactory, returns503ResponseWhenDatabaseIsNotInitializedOnInfoEndpoint) {
+   silo::api::test::MockResponse response;
+   silo::api::test::MockRequest request(response);
+   request.setURI("/info");
 
    auto handle = std::make_shared<silo::api::ActiveDatabase>();
    SiloRequestHandlerFactory under_test{silo::config::RuntimeConfig::withDefaults(), handle};
 
-   EXPECT_THAT(
-      [&]() { auto handler = under_test.routeRequest(uri); },
-      ThrowsMessage<silo::api::UninitializedDatabaseException>(
-         ::testing::HasSubstr("Database not initialized yet")
-      )
-   );
+   const auto handler = under_test.createRequestHandler(request);
+
+   handler->handleRequest(request, response);
+
+   EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_SERVICE_UNAVAILABLE);
+   EXPECT_THAT(response.out_stream.str(), testing::HasSubstr("Database not initialized yet"));
+}
+
+TEST(SiloRequestHandlerFactory, returns503ResponseWhenDatabaseIsNotInitializedOnQueryEndpoint) {
+   silo::api::test::MockResponse response;
+   silo::api::test::MockRequest request(response);
+   request.setMethod("POST");
+   request.setURI("/query");
+
+   auto handle = std::make_shared<silo::api::ActiveDatabase>();
+   SiloRequestHandlerFactory under_test{silo::config::RuntimeConfig::withDefaults(), handle};
+
+   const auto handler = under_test.createRequestHandler(request);
+
+   handler->handleRequest(request, response);
+
+   EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_SERVICE_UNAVAILABLE);
+   EXPECT_THAT(response.out_stream.str(), testing::HasSubstr("Database not initialized yet"));
+}
+
+TEST(
+   SiloRequestHandlerFactory,
+   returns503ResponseWhenDatabaseIsNotInitializedOnLineageDefinitionEndpoint
+) {
+   silo::api::test::MockResponse response;
+   silo::api::test::MockRequest request(response);
+   request.setURI("/lineageDefinition/someColumn");
+
+   auto handle = std::make_shared<silo::api::ActiveDatabase>();
+   SiloRequestHandlerFactory under_test{silo::config::RuntimeConfig::withDefaults(), handle};
+
+   const auto handler = under_test.createRequestHandler(request);
+
+   handler->handleRequest(request, response);
+
+   EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_SERVICE_UNAVAILABLE);
+   EXPECT_THAT(response.out_stream.str(), testing::HasSubstr("Database not initialized yet"));
 }
 
 TEST(SiloRequestHandlerFactory, routesGetInfoRequest) {


### PR DESCRIPTION
resolves #723


### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

We need to delay getting the database into the handlers, otherwise the exception is not caught by the `ErrorRequestHandler`. The `SiloRequestHandlerFactory` must not throw exceptions, because then POCO simply returns an empty response.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [x] The implemented feature is covered by an appropriate test.
