### PR TITLE
Benchmarking: add copy of evobench-probes library, and add actual probes

### DIFF
--- a/benchmarking/.gitignore
+++ b/benchmarking/.gitignore
@@ -1,0 +1,13 @@
+api-query/
+WisePulse/
+
+merger_tmp/
+sorted_chunks/
+
+output/
+sorted_output/
+logs/
+
+.silo.pid
+.silo.stopped
+

--- a/benchmarking/Makefile
+++ b/benchmarking/Makefile
@@ -1,0 +1,136 @@
+
+# Required env vars:
+
+# Should sorted input be used?
+ifeq ($(SORTED),0)
+INPUT_FILE = $(BENCHMARK_DATASET_DIR)/input_file.ndjson.zst
+OUTPUT_DIR = output
+else ifeq ($(SORTED),1)
+# OK to write back into the $(BENCHMARK_DATASET_DIR)?
+INPUT_FILE = $(BENCHMARK_DATASET_DIR)/sorted_input_file.ndjson.zst
+OUTPUT_DIR = sorted_output
+else
+$(error "SORTED must be either 0 or 1, got '$(SORTED)'")
+endif
+export OUTPUT_DIR
+
+# Should API query order be randomized?
+ifeq ($(RANDOMIZED),0)
+API_QUERY_OPTS=
+else ifeq ($(RANDOMIZED),1)
+API_QUERY_OPTS=--randomize
+else
+$(error "RANDOMIZED must be either 0 or 1, got '$(RANDOMIZED)'")
+endif
+
+# The name of a subfolder of `~/silo-benchmark-datasets/` where the
+# dataset is stored
+ifeq ($(BENCHMARK_DATASET_NAME),)
+$(error "BENCHMARK_DATASET_NAME must be a subfolder name, got '$(BENCHMARK_DATASET_NAME)'")
+endif
+
+# ---- General -----------------------------------------------------------------
+
+BENCHMARK_DATASET_DIR=$(HOME)/silo-benchmark-datasets/$(BENCHMARK_DATASET_NAME)
+
+# Instead of preprocessing_config.yaml:
+SILO_LINEAGE_DEFINITIONS_FILENAME=$(BENCHMARK_DATASET_DIR)/lineage_definitions.yaml
+export SILO_LINEAGE_DEFINITIONS_FILENAME
+SILO_REFERENCE_GENOME_FILENAME=$(BENCHMARK_DATASET_DIR)/reference_genomes.json
+export SILO_REFERENCE_GENOME_FILENAME
+SILO_DATABASE_CONFIG=$(BENCHMARK_DATASET_DIR)/database_config.yaml
+export SILO_DATABASE_CONFIG
+
+all: bench
+
+# ---- Get dependencies --------------------------------------------------------
+
+API_QUERY_VERSION=f1d7ff35b03ac740a58186578bf38e8cc39acc67
+
+API_QUERY_DIR=api-query
+API_QUERY_CLONE=$(API_QUERY_DIR)/Cargo.toml
+API_QUERY_CHECKOUT_STAMP_DIR=$(API_QUERY_DIR)/.git/.checkout
+API_QUERY_CHECKOUT=$(API_QUERY_CHECKOUT_STAMP_DIR)/$(API_QUERY_VERSION)
+API_QUERY=$(API_QUERY_DIR)/target/release/api-query
+
+$(API_QUERY_CLONE):
+	git clone https://github.com/GenSpectrum/api-query $(API_QUERY_DIR)
+
+$(API_QUERY_CHECKOUT): $(API_QUERY_CLONE)
+	rm -rf $(API_QUERY_CHECKOUT_STAMP_DIR) # remove previous version stamp
+	( cd $(API_QUERY_DIR) && git remote update && git checkout -b local_hidden_$(API_QUERY_VERSION) $(API_QUERY_VERSION) )
+	mkdir -p $(API_QUERY_CHECKOUT_STAMP_DIR)
+	touch $(API_QUERY_CHECKOUT)
+
+$(API_QUERY): $(API_QUERY_CHECKOUT)
+	cd $(API_QUERY_DIR) && cargo build --release
+
+
+WISEPULSE_DIR=WisePulse
+WISEPULSE_CHECKOUT=$(WISEPULSE_DIR)/Cargo.toml
+WISEPULSE_BIN=$(WISEPULSE_DIR)/target/release
+# Build the other binaries at the same time, too
+WISEPULSE=$(WISEPULSE_BIN)/split_into_sorted_chunks
+
+$(WISEPULSE_CHECKOUT):
+	git clone https://github.com/cbg-ethz/WisePulse $(WISEPULSE_DIR)
+	cd $(WISEPULSE_DIR) && git checkout -b sort-by-metadata-hack origin/sort-by-metadata-hack
+
+$(WISEPULSE): $(WISEPULSE_CHECKOUT)
+	cd $(WISEPULSE_DIR) && cargo build --release
+
+
+# just for manual call comfort
+dependencies: $(API_QUERY) $(WISEPULSE)
+
+
+# ---- Sorting input -----------------------------------------------------------
+
+sorted_input_file.ndjson.zst: input_file.ndjson.zst $(WISEPULSE)
+	rm -rf sorted_chunks merger_tmp 
+	zstdcat input_file.ndjson.zst \
+	    | $(WISEPULSE_BIN)/split_into_sorted_chunks --output-path sorted_chunks --chunk-size 100000 --sort-field date \
+	    | $(WISEPULSE_BIN)/merge_sorted_chunks --tmp-directory merger_tmp --sort-field date \
+	    | zstd > sorted_input_file.ndjson.zst.tmp
+	mv sorted_input_file.ndjson.zst.tmp sorted_input_file.ndjson.zst
+
+# ---- Running silo -----------------------------------------------------------
+
+SILO=../build/Release/silo_$(COMMIT_ID)
+export SILO
+API_OPTIONS=--api-threads-for-http-connections 16
+export API_OPTIONS
+PREPROCESSING_STAMP = $(OUTPUT_DIR)/.done
+
+$(SILO):
+	bin/build-silo
+
+$(PREPROCESSING_STAMP): $(SILO) $(INPUT_FILE)
+	$(SILO) preprocessing --ndjson-input-filename $(INPUT_FILE) \
+	             --output-directory $(OUTPUT_DIR)
+	touch $(PREPROCESSING_STAMP)
+
+.silo.pid: $(PREPROCESSING_STAMP)
+	rm -f .silo.stopped
+	bin/start-silo
+
+.silo.stopped:
+	bin/stop-silo
+	touch .silo.stopped
+
+bench: $(BENCHMARK_DATASET_DIR)/silo_queries.ndjson $(API_QUERY) .silo.stopped
+	@echo "running benchmark"
+	make .silo.pid
+	$(API_QUERY) iter $(API_QUERY_OPTS) $(BENCHMARK_DATASET_DIR)/silo_queries.ndjson --drop --concurrency 50
+	make .silo.stopped
+
+clean:
+	rm -rf output sorted_output logs sorted_chunks merger_tmp sorted_input_file.ndjson.zst
+
+clean-fully: clean
+	rm -rf ../build
+
+# ----------------------------------------------------------------------------
+
+.PHONY:
+	bench clean clean-fully $(SILO)

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -1,0 +1,80 @@
+# Makefile / scripts to do SILO benchmarking runs
+
+This is meant to be run via the `evobench-run` tool from
+[evobench](https://github.com/GenSpectrum/evobench/).
+
+ 1. Make sure you have the Rust compiler, version 1.86.0 or later,
+    installed: get it via [rustup.rs](https://rustup.rs/) (if you
+    already installed the compiler earlier, but you get a message
+    about async closures not being stable, then the compiler is too
+    old, you can then update it via `rustup update` (or, if you want
+    the oldest supported version, `rustup toolchain install 1.86.0`
+    then `rustup toolchain list` then `rustup default <the name in the
+    list>`)
+
+ 1. Install `evobench-run` by running:
+ 
+        cargo install --locked https://github.com/GenSpectrum/evobench/
+
+ 1. Set up configuration for `evobench-run`, currently at
+    `~/.evobench-run.ron` (if you need configuration in a local
+    directory, please submit a feature request); copy the included
+    file [evobench-run.ron](evobench-run.ron) and adapt it to your
+    local paths and wishes. For local (interactive) use, you will want
+    to make sure `benchmarking_job_settings.error_budget` is set to 1,
+    since chances are high that you have a failure preventing the
+    benchmark from running, and you don't want the benchmarking
+    process to re-try. You may also want to change
+    `custom_parameters_set` to only use one `CustomParameters`.
+    
+    (While RON works best to represent the types referred to in the
+    configuration, other config file formats are supported, too--run
+    `evobench-run config-formats` to see which, and `evobench-run
+    config-save` to recode an already-placed file.)
+
+ 1. Make sure that you have a folder
+    `~/silo-benchmark-datasets/$BENCHMARK_DATASET_NAME` (where
+    `$BENCHMARK_DATASET_NAME` is the value of the
+    `BENCHMARK_DATASET_NAME` setting in [the config
+    file](evobench-run.ron) that you use), with these files (or symlinks to them):
+    
+        database_config.yaml
+        input_file.ndjson.zst
+        lineage_definitions.yaml
+        reference_genomes.json
+        silo_queries.ndjson
+
+    Currently, get these files from gs-staging-1, or when running
+    there, use the folder `~christian/silo-benchmark-datasets` (it is
+    planned to fetch these via S3 in the future).
+
+ 1. Run an instance of a daemon, `evobench-run --verbose run daemon`
+    (the `--verbose` allows you to see what's going on, feel free to
+    omit it). Important: since the daemon is going to build SILO, and
+    neither the SILO build process nor the setup here install conan
+    for you, you need to make sure that conan is in the context of the
+    daemon. In other words, run your `source ~/venv/bin/activate` or
+    similar *before* starting the daemon.
+
+ 1. Insert some jobs. If you're working locally, to benchmark the
+    current commit, run `evobench-run insert-local HEAD` from within
+    the directory that is configured as the `remote_repository.url` in
+    `~/.evobench-run.ron`.
+
+ 1. Observe the status of your jobs via `evobench-run list`. (Use
+    `evobench-run list-all` to see which jobs were inserted when.) If
+    you need to inspect errors, `cd
+    ~/.evobench-run/working_directory_pool/` then inspect the
+    `*.error_at*processing_error file` and if necessary the contents
+    of the associated working directory. Once done with inspection,
+    you can make the working directory available for re-use by
+    renaming it to just the id at the beginning of the directory name
+    (unless perhaps it's somehow messed up in a way that "git reset
+    --hard" won't recover from, i.e. .git's metadata is broken, or
+    there are issues in the SILO build system that would require a
+    make clean or similar--in those cases delete the directory).
+
+ 1. Once the jobs have finished, find the results in
+    `~/silo-benchmark-outputs/` (or whatever directory you have
+    changed `output_base_dir` to).
+

--- a/benchmarking/bin/build-silo
+++ b/benchmarking/bin/build-silo
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -meuo pipefail
+IFS=
+
+cd ..
+
+set -x
+
+if ! [ -e conanprofile ]; then
+    cp conanprofile.example conanprofile
+fi
+
+python3 build_with_conan.py --release
+
+# `ln` works, too, currently (the SILO build does not overwrite the
+# original file in place), but it's dicey, so better use 'cp'
+cp build/Release/silo{,_"$COMMIT_ID"}
+# cp build/Release/silo_test{,_"$COMMIT_ID"}

--- a/benchmarking/bin/date-rfc-3339
+++ b/benchmarking/bin/date-rfc-3339
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -meuo pipefail
+IFS=
+
+d=$(date +"%Y-%m-%dT%H:%M:%S%z")
+
+printf '%q\n' "$d" | sed -E 's/([+-][0-9]{2})([0-9]{2})$/\1:\2/'

--- a/benchmarking/bin/describe-commit
+++ b/benchmarking/bin/describe-commit
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -meuo pipefail
+IFS=
+
+( cd .. ; git describe --tags )

--- a/benchmarking/bin/run-silo
+++ b/benchmarking/bin/run-silo
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -meuo pipefail
+IFS=' '
+
+echo "$$" > .silo.pid
+exec "$SILO" api --data-directory "$OUTPUT_DIR" $API_OPTIONS
+
+

--- a/benchmarking/bin/start-silo
+++ b/benchmarking/bin/start-silo
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -meuo pipefail
+IFS=
+
+# Start and wait until up
+
+bin/run-silo > "$BENCH_OUTPUT_LOG" &
+disown %
+
+echo -n "Waiting for pid file..."
+until [ -e .silo.pid ]; do
+    sleep 0.1
+done
+echo done.
+
+pid=$(cat .silo.pid)
+
+n=0
+until kill -0 "$pid"; do
+    n=$(( n + 1 ))
+    if (( n > 20 )); then
+        echo "SILO is not there. Output:"
+        cat "$BENCH_OUTPUT_LOG"
+        exit 1
+    fi
+    pid=$(cat .silo.pid)
+    sleep 0.5
+done
+
+echo -n "Waiting for silo (PID $pid) to be ready..."
+until curl -s -o /dev/null -w "%{http_code}" http://localhost:8081/info | grep -q "200"; do 
+    sleep 0.5
+done
+echo done.

--- a/benchmarking/bin/stop-silo
+++ b/benchmarking/bin/stop-silo
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -meuo pipefail
+IFS=
+
+if [ -e .silo.pid ]; then
+    pid=$(cat .silo.pid)
+    if kill -INT "$pid"; then
+
+        echo -n "Waiting for silo (PID $pid) to shut down..."
+        while kill -0 "$pid"; do 
+            sleep 0.5
+        done
+    fi
+
+    rm -f .silo.pid
+    
+    echo done.
+    
+else
+    echo "Not running (there is no .silo.pid file)"
+fi
+

--- a/benchmarking/evobench-run.ron
+++ b/benchmarking/evobench-run.ron
@@ -1,0 +1,132 @@
+// More docs may be available in the evobench source code, start with
+// `RunConfig` in `evobench-evaluator/src/run/config.rs`
+
+RunConfig(
+    queues: (
+        // run_queues_basedir: Some("other/path/than/home/.evobench-run/queues/"),
+
+        // List of queues each job goes through in order--subdirectory
+        // name and queue configuration
+        pipeline: [
+            ("immediately1", Immediately),
+            ("immediately2", Immediately),
+            // "local naive time" is a time without date that matches
+            // every day, in the local time zone. Jobs in such a queue
+            // are run in the given time window, only. When the time
+            // window is entered, the `stop_start` command is run with
+            // an additional `stop` argument, when the window ends or
+            // all jobs are finished, it is run with `start`.
+            ("day", LocalNaiveTimeWindow(
+                stop_start: Some([
+                    "echo",
+                    "running during the day:",
+                ]),
+                // When `repeatedly` is false, the job is run only
+                // once then moved to the next queue. When `true`, the
+                // job is run until its `count` reaches 0 or the time
+                // window runs out.
+                repeatedly: false,
+                // If true, unfinished jobs in this queue are moved to
+                // the next queue when the time window ends.
+                move_when_time_window_ends: true,
+                from: "17:00:00",
+                to: "18:00:00",
+            )),
+            ("night", LocalNaiveTimeWindow(
+                stop_start: Some([
+                    "echo",
+                    "running in the night:",
+                ]),
+                repeatedly: true,
+                move_when_time_window_ends: true,
+                from: "2:00",
+                to: "7:00",
+            )),
+            // `GraveYard` queues do not run their jobs, meaning jobs
+            // that are moved here stay forever; this is meant as a
+            // debugging/verification tool (omitting this last queue
+            // would get them deleted instead)
+            ("grave_yard", GraveYard),
+        ],
+
+        // Where jobs go when they run out of error_budget (`None`
+        // would get them deleted instead)
+        erroneous_jobs_queue: Some(
+            ("erroneous_jobs", GraveYard)
+        ),
+    ),
+
+    working_directory_pool: (
+        // base_dir: Some("other/path/than/home/.evobench-run/working_directory_pool/"),
+
+        // Smaller: less disk space use for build dirs, but less
+        // chance to re-use a build with the same commit id without
+        // having to rebuild
+        capacity: 6,
+    ),
+
+    remote_repository: (
+        // For server use:
+        // url: "https://github.com/GenSpectrum/LAPIS-SILO/",
+
+        // For benchmarking local developments, give the path to your local working directory:
+        url: "~/LAPIS-SILO",
+
+        // For the `poll` subcommand:
+        remote_branch_names: [
+            "main"
+        ]
+    ),
+
+    // A list of *all* environment variables your benchmarking process
+    // can take, with a boolean that says whether they are also
+    // *required* (do *not* list the environment variables which the
+    // evobench daemon passes anyway (i.e. are not custom):
+    // "COMMIT_ID", "EVOBENCH_LOG", "BENCH_OUTPUT_LOG")
+    custom_parameters_required: {
+        "SORTED": true,
+        "RANDOMIZED": true,
+        "BENCHMARK_DATASET_NAME": true,
+    },
+
+    // Each `CustomParameters` group is used for a separate benchmark
+    // run for each commit it.
+    custom_parameters_set: CustomParametersSet([
+        CustomParameters({
+            "SORTED": "1",
+            "RANDOMIZED": "1",
+            "BENCHMARK_DATASET_NAME": "full",
+        }),
+        CustomParameters({
+            "SORTED": "0",
+            "RANDOMIZED": "1",
+            "BENCHMARK_DATASET_NAME": "full",
+        }),
+    ]),
+
+    // Each job receives a copy of these settings
+    benchmarking_job_settings: BenchmarkingJobSettings(
+        // How many times to run the same benchmarking job (higher:
+        // better statistics, at higher cost); default: 5
+        count: Some(5),
+        // How many times the job can fail before it is moved to the
+        // `erroneous_jobs_queue` (or dropped if that is `None`);
+        // default: 3
+        error_budget: Some(1)
+    ),
+
+    // What command to run on the target project to execute a
+    // benchmarking run; the env variables configured in
+    // CustomParameters are set when running this command.
+    benchmarking_command: BenchmarkingCommand(
+        // Relative path to the subdirectory (provide "." for the top
+        // level of the working directory) where to run the command
+        subdir: "benchmarking",
+        command: "make",
+        arguments: ["bench"],
+    ),
+
+    /// The base of the directory hierarchy where the output files
+    /// should be placed
+    output_base_dir: "~/silo-benchmark-outputs",
+)

--- a/src/evobench/_evobench_point_kind.hpp
+++ b/src/evobench/_evobench_point_kind.hpp
@@ -1,0 +1,24 @@
+// Do not include directly, syntax is not complete! This file is both
+// Rust and C++ compatible!
+
+// Keep in sync with `point_kind_name` in evobench.cpp! XX better solution?
+
+pub enum PointKind {
+   /// Point at process init -- XX necessary?
+   TStart,
+   /// Individual (unpaired) point
+   T,
+   /// Point at the start of a scope
+   TS,
+   /// Point at the end of a scope
+   TE,
+   /// Point at thread start
+   TThreadStart,
+   /// Point at thread exit
+   TThreadEnd,
+   /// Point at process exit (benchmark always end with this
+   /// message, except if there was an IO error).  XXX
+   TEnd,
+   /// Point directly after flushing the buffer for the current thread.
+   TIO,
+}

--- a/src/evobench/evobench.cpp
+++ b/src/evobench/evobench.cpp
@@ -1,0 +1,442 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "evobench/evobench.hpp"
+
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/file.h>
+#include <sys/resource.h>
+#include <sys/utsname.h>
+#include <time.h>
+#include <unistd.h>
+
+// Getting thread statistics on macOS
+#ifdef __MACH__
+#include <mach/mach.h>
+
+int mac_get_thread_info(struct timeval& utime, struct timeval& stime) {
+   thread_basic_info tinfo;
+   mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+   kern_return_t kr =
+      thread_info(mach_thread_self(), THREAD_BASIC_INFO, (thread_info_t)&tinfo, &count);
+   if (kr == KERN_SUCCESS) {
+      utime.tv_sec = tinfo.user_time.seconds;
+      utime.tv_usec = tinfo.user_time.microseconds;
+      stime.tv_sec = tinfo.system_time.seconds;
+      stime.tv_usec = tinfo.system_time.microseconds;
+      return 0;
+   }
+   // Does thread_info set errno?
+   return -1;
+}
+
+uint64_t our_get_thread_id() {
+   uint64_t thread_id;
+   pthread_threadid_np(NULL, &thread_id);
+   return thread_id;
+}
+
+#else
+
+// Linux
+__pid_t our_get_thread_id() {
+   return gettid();
+}
+
+#endif
+
+// Necessary on macOS
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX 512
+#endif
+#ifndef LOGIN_NAME_MAX
+#define LOGIN_NAME_MAX 512
+#endif
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+#define WARN(expr)                                                            \
+   do {                                                                       \
+      std::cerr << expr;                                                      \
+      std::cerr << " at " __FILE__ ":" TOSTRING(__LINE__) "\n" << std::flush; \
+   } while (0)
+
+// Macros for outputting JSON as "expressions", but expanding to
+// side-effecting code, taking an implicit `out` std::string&
+// parameter. (Hoping the compiler optimizes multiple constant string
+// outputs into one.)
+
+/// A single atomic value that has an implementation of the `js_print`
+/// function.
+#define ATOM(expr) js_print(expr, out);
+
+/// Slow fallback for now, XX optimize later.
+#define SLOW(expr) js_print_slow(expr, out);
+
+/// A JSON object
+#define OBJ(expr)      \
+   out.push_back('{'); \
+   expr;               \
+   out.push_back('}');
+/// A single key-value pair; key is implicitly `ATOM`-wrapped, val
+/// must be wrapped explicitly.
+#define KV(key, val)   \
+   ATOM(key);          \
+   out.push_back(':'); \
+   val;
+/// Separator between `KV` in `OBJ`.
+#define COMMA out.push_back(',');
+
+#define ARRAY2(val1, val2) \
+   out.push_back('[');     \
+   val1;                   \
+   out.push_back(',');     \
+   val2;                   \
+   out.push_back(']');
+
+/// Separator between records
+#define NEWLINE out.push_back('\n');
+
+namespace {
+// Slow fallback to be used via `SLOW`; e.g. for `pthread_t`.
+// XX future: provide js_print overloads for various integer types
+// if needed for optimization
+template <typename T>
+void js_print_slow(T val, std::string& out) {
+   std::ostringstream tmpout;
+   tmpout << val;
+   out.append(tmpout.str());
+}
+
+void js_print(const std::string_view input, std::string& out) {
+   out.push_back('"');
+   for (char ch : input) {
+      switch (ch) {
+         case '\"':
+            out.append("\\\"");
+            break;
+         case '\\':
+            out.append("\\\\");
+            break;
+         case '\b':
+            out.append("\\b");
+            break;
+         case '\f':
+            out.append("\\f");
+            break;
+         case '\n':
+            out.append("\\n");
+            break;
+         case '\r':
+            out.append("\\r");
+            break;
+         case '\t':
+            out.append("\\t");
+            break;
+         default:
+            if (ch < 32) {
+               // XX slow; but rare, so ok?
+               std::ostringstream tmpout;
+               tmpout << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+                      << static_cast<int>(static_cast<unsigned char>(ch));
+               out.append(tmpout.str());
+            } else {
+               // Including characters 0x80+, which are
+               // multi-byte UTF-8 code points in the input
+               out.push_back(ch);
+            }
+      }
+   }
+   out.push_back('"');
+}
+
+void js_print(const timespec& t, std::string& out) {
+   OBJ(KV("sec", SLOW(t.tv_sec)) COMMA KV("nsec", SLOW(t.tv_nsec)))
+}
+
+void js_print(const timeval& t, std::string& out) {
+   OBJ(KV("sec", SLOW(t.tv_sec)) COMMA KV("usec", SLOW(t.tv_usec)))
+}
+
+// Keep in sync with `PointKind` ! XX better solution?
+const char* point_kind_name[8] =
+   {"TStart", "T", "TS", "TE", "TThreadStart", "TThreadEnd", "TEnd", "TIO"};
+
+#define ERRCHECK(expr)                                              \
+   do {                                                             \
+      auto result = (expr);                                         \
+      if (result < 0) {                                             \
+         perror(#expr " at file " __FILE__ ":" TOSTRING(__LINE__)); \
+         return;                                                    \
+      }                                                             \
+   } while (0)
+
+void log_start(std::string& out) {
+   OBJ(
+      KV("Start",
+         OBJ(KV("evobench_log_version", SLOW(evobench::EVOBENCH_LOG_VERSION))
+                COMMA KV("evobench_version", ATOM(EVOBENCH_VERSION))))
+   );
+   NEWLINE;
+
+   char hostname[HOST_NAME_MAX];
+   char username[LOGIN_NAME_MAX];
+   ERRCHECK(gethostname(hostname, HOST_NAME_MAX));
+   ERRCHECK(getlogin_r(username, LOGIN_NAME_MAX));
+
+   struct utsname os_release;
+   ERRCHECK(uname(&os_release));
+
+   std::ostringstream compiler;
+#if defined(__clang__)
+   compiler << "Clang " << __clang_major__ << "." << __clang_minor__ << "." << __clang_patchlevel__;
+#elif defined(__GNUC__)
+   compiler << "GCC " << __GNUC__ << "." << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__;
+#elif defined(_MSC_VER)
+   compiler << "MSVC " << _MSC_VER;
+#else
+   compiler << "Unknown";
+#endif
+
+   // clang-format off
+   OBJ(KV("Metadata",
+	  OBJ(KV("username", ATOM(username))
+	      COMMA
+	      KV("hostname", ATOM(hostname))
+	      COMMA
+	      KV("uname",
+		 OBJ(KV("sysname", ATOM(os_release.sysname))
+		     COMMA
+		     KV("nodename", ATOM(os_release.nodename))
+		     COMMA
+		     KV("release", ATOM(os_release.release))
+		     COMMA
+		     KV("version", ATOM(os_release.version))
+		     COMMA
+		     KV("machine", ATOM(os_release.machine))))
+	      COMMA
+	      KV("compiler", ATOM(compiler.str())))));
+   NEWLINE;
+   // clang-format on
+}
+
+void log_resource_usage(const char* module_and_action, evobench::PointKind kind, std::string& out) {
+   struct timespec t;
+   ERRCHECK(clock_gettime(CLOCK_REALTIME, &t));
+
+   struct timeval utime;
+   struct timeval stime;
+#ifdef __MACH__
+   ERRCHECK(mac_get_thread_info(utime, stime));
+#else
+   struct rusage r;
+   ERRCHECK(getrusage(RUSAGE_THREAD, &r));
+   utime = r.ru_utime;
+   stime = r.ru_stime;
+#endif
+
+   // clang-format off
+   OBJ(KV(point_kind_name[kind],
+	  OBJ(KV("pn", ATOM(module_and_action))
+	      COMMA
+	      KV("pid", SLOW(getpid()))
+	      COMMA
+	      KV("tid", SLOW(our_get_thread_id()))
+	      COMMA
+	      KV("r", ATOM(t))
+	      COMMA
+	      KV("u", ATOM(utime))
+	      COMMA
+	      KV("s", ATOM(stime))
+#ifndef __MACH__
+	      COMMA
+	      // Some of these are per process, but when do we
+	      // want to know, still per thread action?
+	      KV("maxrss", SLOW(r.ru_maxrss))
+	      COMMA
+	      // KV("ixrss", ATOM(r.ru_ixrss)) -- This field is currently unused on Linux.
+	      // COMMA
+	      // KV("idrss", ATOM(r.ru_idrss)) -- This field is currently unused on Linux.
+	      // COMMA
+	      // KV("isrss", ATOM(r.ru_isrss)) -- This field is currently unused on Linux.
+	      // COMMA
+	      KV("minflt", SLOW(r.ru_minflt))
+	      COMMA
+	      KV("majflt", SLOW(r.ru_majflt))
+	      COMMA
+	      // KV("nswap", ATOM(r.ru_nswap)) -- This field is currently unused on Linux.
+	      // COMMA
+	      KV("inblock", SLOW(r.ru_inblock))
+	      COMMA
+	      KV("oublock", SLOW(r.ru_oublock))
+	      COMMA
+	      // KV("msgsnd", ATOM(r.ru_msgsnd)) -- This field is currently unused on Linux.
+	      // COMMA
+	      // KV("msgrcv", ATOM(r.ru_msgrcv)) -- This field is currently unused on Linux.
+	      // COMMA
+	      // KV("nsignals", ATOM(r.ru_nsignals)) -- This field is currently unused on Linux.
+	      // COMMA
+	      KV("nvcsw", SLOW(r.ru_nvcsw))
+	      COMMA
+	      KV("nivcsw", SLOW(r.ru_nivcsw))
+#endif
+	      )));
+   NEWLINE;
+   // clang-format on
+}
+
+/// Slow, but we're not using it in a fast path
+template <typename T>
+void js_print_stream(T val, std::ostream& out) {
+   std::string tmpout{};
+   js_print(val, tmpout);
+   out << tmpout;
+}
+
+}  // namespace
+
+namespace evobench {
+
+Output::Output(const char* maybe_output_path) {
+   path = maybe_output_path;
+   if (!maybe_output_path) {
+      is_enabled = false;
+      return;
+   }
+
+   lock_fd = open(path, O_CREAT, 0666);
+   if (lock_fd < 0) {
+      auto err = errno;
+      std::cerr << "evobench::Output: can't create or open file for locking: ";
+      js_print_stream(std::string_view{path}, std::cerr);
+      std::cerr << ": " << std::strerror(err) << "\n";
+      exit(1);
+   }
+   if (flock(lock_fd, LOCK_EX | LOCK_NB) < 0) {
+      auto err = errno;
+      std::cerr << "evobench::Output: can't lock file: ";
+      js_print_stream(std::string_view{path}, std::cerr);
+      std::cerr << ": " << std::strerror(err) << "\n";
+      exit(1);
+   }
+
+   fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0666);
+   if (fd < 0) {
+      auto err = errno;
+      std::cerr << "evobench::Output: can't open file for writing: ";
+      js_print_stream(std::string_view{path}, std::cerr);
+      std::cerr << ": " << std::strerror(err) << "\n";
+      exit(1);
+   }
+   is_enabled = true;
+   {
+      // Allocate a temporary buffer that doesn't announce the
+      // thread, and write the benchmark file header.
+      Buffer buffer{true};
+      log_start(buffer.string);
+      log_resource_usage("-", PointKind::TStart, buffer.string);
+   }
+}
+
+Output::~Output() {
+   // Should only be called once all threads have exited? Or
+   // how does this work? XXX otherwise will have to flush
+   // all thread-local buffers, or? Simply do not close?
+   if (is_enabled) {
+      {
+         Buffer out{true};
+         log_resource_usage("-", PointKind::TEnd, out.string);
+      }
+      is_enabled = false;
+   }
+}
+
+void Output::write_all(const std::string_view buffer) {
+   // Take lock before checking is_enabled, as a way to avoid
+   // being knowledgeable enough about how atomics and
+   // mutexes interact.
+   std::lock_guard<std::mutex> guard(write_mutex);
+   if (is_enabled) {
+      ssize_t to_be_written = buffer.length();
+      ssize_t written = 0;
+      while (to_be_written > 0) {
+         auto res = write(fd, buffer.data() + written, to_be_written);
+         if (res < 0) {
+            auto err = errno;
+            std::cerr << "evobench::Output::write_all: ";
+            js_print_stream(std::string_view{path}, std::cerr);
+            std::cerr << ": " << std::strerror(err) << "\n";
+            is_enabled = false;
+            return;
+         }
+         to_be_written -= res;
+         written += res;
+      }
+   }
+}
+
+Output output{getenv("EVOBENCH_LOG")};
+
+void Buffer::flush() {
+   output.write_all(string);
+   string.clear();
+}
+
+bool Buffer::possibly_flush() {
+   if (string.length() > BUF_MAX_SIZE) {
+      flush();
+      return true;
+   }
+   return false;
+}
+
+Buffer::Buffer(bool is_manual_)
+    : is_manual(is_manual_) {
+   if (!is_manual) {
+      _log_any("-", PointKind::TThreadStart);
+   }
+}
+
+Buffer::~Buffer() {
+   if (output.is_enabled) {
+      if (!is_manual) {
+         _log_any("-", PointKind::TThreadEnd);
+      }
+      flush();
+   }
+}
+
+thread_local Buffer local_buffer{false};
+
+void _log_key_value(std::string_view key, std::string_view value) {
+   std::string& out = local_buffer.string;
+
+   OBJ(KV(
+      "KeyValue",
+      OBJ(KV("tid", SLOW(our_get_thread_id())) COMMA KV("k", ATOM(key)) COMMA KV("v", ATOM(value)))
+   ));
+   NEWLINE;
+}
+
+void _log_any(const char* module_and_action, PointKind kind) {
+   log_resource_usage(module_and_action, kind, local_buffer.string);
+   if (local_buffer.possibly_flush()) {
+      log_resource_usage(module_and_action, PointKind::TIO, local_buffer.string);
+   }
+}
+
+}  // namespace evobench

--- a/src/evobench/evobench.hpp
+++ b/src/evobench/evobench.hpp
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <mutex>
+#include <string>
+#include <string_view>
+
+#include "evobench_version.hpp"
+
+namespace evobench {
+// If you change this, you'll want to update `log_message.rs` to
+// have a new protocol variant that mirrors the C++ side, for that
+// same `EVOBENCH_LOG_VERSION` value.
+const uint32_t EVOBENCH_LOG_VERSION = 1;
+
+#define pub
+#include "_evobench_point_kind.hpp"
+;
+#undef pub
+
+class Output {
+   // Only if maybe_output_path was true. Stays with that value
+   // even if `is_enabled` is turned off later.
+   const char* path;
+   // Opened for reading for holding a lock
+   int lock_fd;
+   // Opened for writing
+   int fd;
+   std::mutex write_mutex;
+
+   friend class Buffer;
+   void write_all(const std::string_view buffer);
+
+  public:
+   // This is turned to false on errors, too. It is public for
+   // performance (inlined access from `log_point` function).  XX
+   // use an atomic
+   bool is_enabled;
+
+   /// Opens the file at `maybe_output_path`. Exits the process
+   /// with status 1 on errors (this is run during init, better
+   /// don't throw?). Logs a `TStart` message.
+   Output(const char* maybe_output_path);
+
+   /// Logs a `TEnd` message.
+   ~Output();
+};
+
+extern Output output;
+
+/// A thread-local output buffer. Uses the global
+/// `evobench::output` `Output` instance for writing.
+class Buffer {
+   const size_t BUF_MAX_SIZE = 8192;
+
+   /// Whether constructor and destructor should remain silent;
+   /// used by `Output` for temporary buffers to do start and end
+   /// of process logging.
+   bool is_manual;
+
+  public:
+   /// The buffer contents
+   std::string string;
+
+   void flush();
+
+   /// Flushes if the buffer is overly full. Returns true if it
+   /// did flush.
+   bool possibly_flush();
+
+   /// Writes a `TThreadStart` message, unless `is_manual` or
+   /// output is not enabled.
+   Buffer(bool is_manual_);
+
+   /// Writes a `TThreadEnd` message, unless `is_manual` or
+   /// output is not enabled.
+   ~Buffer();
+};
+
+// These are private; only call if is_enabled is true!
+void _log_any(const char* module_and_action, PointKind kind);
+void _log_key_value(std::string_view key, std::string_view value);
+
+/// Log a key value pair, without timings, for information
+/// tracking.
+inline static void log_key_value(std::string_view key, std::string_view value) {
+   if (output.is_enabled) {
+      _log_key_value(key, value);
+   }
+}
+
+/// Log at the point of call as a single "T" event.
+inline static void log_point(const char* module_and_action) {
+   if (output.is_enabled) {
+      _log_any(module_and_action, PointKind::T);
+   }
+}
+
+/// Log at the object creation as "TS" and its destruction as
+/// "TE" event.
+class Scope {
+   // Keep this object small, to keep overhead low when
+   // !output.is_enabled.
+   const char* module_and_action;
+
+  public:
+   inline Scope(const char* module_and_action_)
+       : module_and_action(module_and_action_) {
+      if (output.is_enabled) {
+         _log_any(module_and_action_, PointKind::TS);
+      }
+   }
+   inline ~Scope() {
+      if (output.is_enabled) {
+         _log_any(module_and_action, PointKind::TE);
+      }
+   }
+};
+
+}  // namespace evobench
+
+/// `NO_EVOBENCH` disables the probe points; the logfile will still be
+/// written but with just the TStart and TEnd points.
+#ifdef NO_EVOBENCH
+#define EVOBENCH_SCOPE(module, action)
+#define EVOBENCH_POINT(module, action)
+#define EVOBENCH_KEY_VALUE(key, value)
+#else
+#define EVOBENCH_SCOPE(module, action) evobench::Scope __evobench_scope{module "|" action};
+#define EVOBENCH_POINT(module, action) evobench::log_point(module "|" action);
+#define EVOBENCH_KEY_VALUE(key, value) evobench::log_key_value(key, value)
+#endif

--- a/src/evobench/evobench_version.hpp
+++ b/src/evobench/evobench_version.hpp
@@ -1,0 +1,1 @@
+#define EVOBENCH_VERSION "v0.1.1"

--- a/src/silo/api/api.cpp
+++ b/src/silo/api/api.cpp
@@ -24,7 +24,9 @@ int Api::runApi(const silo::config::RuntimeConfig& runtime_config) {
       server_socket.bind(address, true);
       server_socket.listen();
    } catch (const Poco::Net::NetException& e) {
-      SPDLOG_ERROR("Failed to bind to port {}", runtime_config.api_options.port);
+      SPDLOG_ERROR(
+         "Failed to bind to port {}: {}", runtime_config.api_options.port, e.displayText()
+      );
       return EXIT_FAILURE;
    }
 

--- a/src/silo/api/api.cpp
+++ b/src/silo/api/api.cpp
@@ -21,7 +21,7 @@ int Api::runApi(const silo::config::RuntimeConfig& runtime_config) {
 
    Poco::Net::ServerSocket server_socket;
    try {
-      server_socket.bind(address);
+      server_socket.bind(address, true);
       server_socket.listen();
    } catch (const Poco::Net::NetException& e) {
       SPDLOG_ERROR("Failed to bind to port {}", runtime_config.api_options.port);

--- a/src/silo/query_engine/filter/expressions/date_between.cpp
+++ b/src/silo/query_engine/filter/expressions/date_between.cpp
@@ -7,7 +7,6 @@
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
-#include "evobench/evobench.hpp"
 #include "silo/common/date.h"
 #include "silo/database.h"
 #include "silo/query_engine/bad_request.h"
@@ -60,7 +59,6 @@ std::unique_ptr<operators::Operator> DateBetween::compile(
    const auto& date_column = table_partition.columns.date_columns.at(column_name);
 
    if (!date_column.isSorted()) {
-      EVOBENCH_KEY_VALUE("Date sort optimization", "false");
       operators::PredicateVector predicates;
       predicates.emplace_back(
          std::make_unique<operators::CompareToValueSelection<silo::common::Date>>(
@@ -80,7 +78,6 @@ std::unique_ptr<operators::Operator> DateBetween::compile(
          std::move(predicates), table_partition.sequence_count
       );
    }
-   EVOBENCH_KEY_VALUE("Date sort optimization", "true");
    return std::make_unique<operators::RangeSelection>(
       computeRangesOfSortedColumn(date_column, {table_partition.sequence_count}),
       table_partition.sequence_count

--- a/src/silo/query_engine/filter/expressions/date_between.cpp
+++ b/src/silo/query_engine/filter/expressions/date_between.cpp
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
+#include "evobench/evobench.hpp"
 #include "silo/common/date.h"
 #include "silo/database.h"
 #include "silo/query_engine/bad_request.h"
@@ -59,6 +60,7 @@ std::unique_ptr<operators::Operator> DateBetween::compile(
    const auto& date_column = table_partition.columns.date_columns.at(column_name);
 
    if (!date_column.isSorted()) {
+      EVOBENCH_KEY_VALUE("Date sort optimization", "false");
       operators::PredicateVector predicates;
       predicates.emplace_back(
          std::make_unique<operators::CompareToValueSelection<silo::common::Date>>(
@@ -78,6 +80,7 @@ std::unique_ptr<operators::Operator> DateBetween::compile(
          std::move(predicates), table_partition.sequence_count
       );
    }
+   EVOBENCH_KEY_VALUE("Date sort optimization", "true");
    return std::make_unique<operators::RangeSelection>(
       computeRangesOfSortedColumn(date_column, {table_partition.sequence_count}),
       table_partition.sequence_count

--- a/src/silo/query_engine/filter/operators/bitmap_producer.cpp
+++ b/src/silo/query_engine/filter/operators/bitmap_producer.cpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 
+#include "evobench/evobench.hpp"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter/operators/complement.h"
 #include "silo/query_engine/filter/operators/operator.h"
@@ -23,6 +24,7 @@ Type BitmapProducer::type() const {
 }
 
 CopyOnWriteBitmap BitmapProducer::evaluate() const {
+   EVOBENCH_SCOPE("BitmapProducer", "evaluate");
    return producer();
 }
 

--- a/src/silo/query_engine/filter/operators/bitmap_selection.cpp
+++ b/src/silo/query_engine/filter/operators/bitmap_selection.cpp
@@ -5,6 +5,7 @@
 #include <fmt/format.h>
 #include <roaring/roaring.hh>
 
+#include "evobench/evobench.hpp"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/operator.h"
@@ -49,6 +50,7 @@ Type BitmapSelection::type() const {
 }
 
 CopyOnWriteBitmap BitmapSelection::evaluate() const {
+   EVOBENCH_SCOPE("BitmapSelection", "evaluate");
    CopyOnWriteBitmap bitmap;
    switch (this->comparator) {
       case CONTAINS:

--- a/src/silo/query_engine/filter/operators/complement.cpp
+++ b/src/silo/query_engine/filter/operators/complement.cpp
@@ -5,6 +5,7 @@
 
 #include <roaring/roaring.hh>
 
+#include "evobench/evobench.hpp"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter/operators/intersection.h"
 #include "silo/query_engine/filter/operators/operator.h"
@@ -50,6 +51,7 @@ Type Complement::type() const {
 }
 
 CopyOnWriteBitmap Complement::evaluate() const {
+   EVOBENCH_SCOPE("Complement", "evaluate");
    auto result = child->evaluate();
    result->flip(0, row_count);
    return result;

--- a/src/silo/query_engine/filter/operators/full.cpp
+++ b/src/silo/query_engine/filter/operators/full.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "evobench/evobench.hpp"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter/operators/empty.h"
 #include "silo/query_engine/filter/operators/operator.h"
@@ -22,6 +23,7 @@ Type Full::type() const {
 }
 
 CopyOnWriteBitmap Full::evaluate() const {
+   EVOBENCH_SCOPE("Full", "evaluate");
    CopyOnWriteBitmap result;
    result->addRange(0, row_count);
    return result;

--- a/src/silo/query_engine/filter/operators/index_scan.cpp
+++ b/src/silo/query_engine/filter/operators/index_scan.cpp
@@ -5,6 +5,7 @@
 #include <fmt/format.h>
 #include <roaring/roaring.hh>
 
+#include "evobench/evobench.hpp"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/complement.h"
@@ -40,6 +41,7 @@ Type IndexScan::type() const {
 }
 
 CopyOnWriteBitmap IndexScan::evaluate() const {
+   EVOBENCH_SCOPE("IndexScan", "evaluate");
    return CopyOnWriteBitmap(*bitmap);
 }
 std::unique_ptr<Operator> IndexScan::negate(std::unique_ptr<IndexScan>&& index_scan) {

--- a/src/silo/query_engine/filter/operators/intersection.cpp
+++ b/src/silo/query_engine/filter/operators/intersection.cpp
@@ -6,6 +6,7 @@
 
 #include <spdlog/spdlog.h>
 
+#include "evobench/evobench.hpp"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter/operators/complement.h"
 #include "silo/query_engine/filter/operators/operator.h"
@@ -78,6 +79,7 @@ CopyOnWriteBitmap intersectTwo(CopyOnWriteBitmap first, CopyOnWriteBitmap second
 }  // namespace
 
 CopyOnWriteBitmap Intersection::evaluate() const {
+   EVOBENCH_SCOPE("Intersection", "evaluate");
    std::vector<CopyOnWriteBitmap> children_bm;
    children_bm.reserve(children.size());
    std::ranges::transform(children, std::back_inserter(children_bm), [&](const auto& child) {

--- a/src/silo/query_engine/filter/operators/range_selection.cpp
+++ b/src/silo/query_engine/filter/operators/range_selection.cpp
@@ -6,6 +6,7 @@
 
 #include <boost/algorithm/string/join.hpp>
 
+#include "evobench/evobench.hpp"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter/operators/operator.h"
 
@@ -39,6 +40,7 @@ Type RangeSelection::type() const {
 }
 
 CopyOnWriteBitmap RangeSelection::evaluate() const {
+   EVOBENCH_SCOPE("RangeSelection", "evaluate");
    CopyOnWriteBitmap result;
    for (const auto& range : ranges) {
       result->addRange(range.start, range.end);

--- a/src/silo/query_engine/filter/operators/selection.cpp
+++ b/src/silo/query_engine/filter/operators/selection.cpp
@@ -14,6 +14,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <roaring/roaring.hh>
 
+#include "evobench/evobench.hpp"
 #include "silo/common/date.h"
 #include "silo/common/optional_bool.h"
 #include "silo/common/panic.h"
@@ -97,6 +98,7 @@ bool Selection::matchesPredicates(uint32_t row) const {
 }
 
 CopyOnWriteBitmap Selection::evaluate() const {
+   EVOBENCH_SCOPE("Selection", "evaluate");
    CopyOnWriteBitmap result;
    if (child_operator.has_value()) {
       CopyOnWriteBitmap child_result = (*child_operator)->evaluate();

--- a/src/silo/query_engine/filter/operators/threshold.cpp
+++ b/src/silo/query_engine/filter/operators/threshold.cpp
@@ -6,6 +6,7 @@
 
 #include <roaring/roaring.hh>
 
+#include "evobench/evobench.hpp"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter/operators/complement.h"
 #include "silo/query_engine/filter/operators/operator.h"
@@ -62,6 +63,7 @@ Type Threshold::type() const {
 }
 
 CopyOnWriteBitmap Threshold::evaluate() const {
+   EVOBENCH_SCOPE("Threshold", "evaluate");
    uint32_t dp_table_size;
    if (this->match_exactly) {
       // We need to keep track of the ones that matched too many

--- a/src/silo/query_engine/filter/operators/union.cpp
+++ b/src/silo/query_engine/filter/operators/union.cpp
@@ -6,6 +6,7 @@
 
 #include <roaring/roaring.hh>
 
+#include "evobench/evobench.hpp"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter/operators/complement.h"
 #include "silo/query_engine/filter/operators/operator.h"
@@ -33,6 +34,7 @@ Type Union::type() const {
 }
 
 CopyOnWriteBitmap Union::evaluate() const {
+   EVOBENCH_SCOPE("Union", "evaluate");
    const uint32_t size_of_children = children.size();
    std::vector<const roaring::Roaring*> union_tmp(size_of_children);
    std::vector<CopyOnWriteBitmap> child_res(size_of_children);

--- a/src/silo/query_engine/query_plan.cpp
+++ b/src/silo/query_engine/query_plan.cpp
@@ -6,6 +6,7 @@
 #include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
 
+#include "evobench/evobench.hpp"
 #include "silo/query_engine/exec_node/ndjson_sink.h"
 
 namespace silo::query_engine {
@@ -23,6 +24,7 @@ arrow::Result<QueryPlan> QueryPlan::makeQueryPlan(
 }
 
 arrow::Status QueryPlan::executeAndWriteImpl(std::ostream* output_stream) {
+   EVOBENCH_SCOPE("QueryPlan", "execute");
    SPDLOG_TRACE("{}", arrow_plan->ToString());
    arrow_plan->StartProducing();
    SPDLOG_TRACE("Plan started producing, will now read the resulting batches.");


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #757

### Summary

This adds a copy of the evobench-probes library from [evobench](https://github.com/GenSpectrum/evobench/) as per its documentation (running of `../evobench/evobench-probes/bin/add-include-and-src`), as well as a set of probes (test points).

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
~~- [ ] The implemented feature is covered by an appropriate test.~~
