### PR TITLE
refactor: keep sequences compressed in the query engine to allow sorting of large sequence sets

### DIFF
--- a/include/silo/query_engine/exec_node/zstd_decompress_expression.h
+++ b/include/silo/query_engine/exec_node/zstd_decompress_expression.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <arrow/compute/expression.h>
+
+namespace silo::query_engine::exec_node {
+
+class ZstdDecompressExpression {
+  public:
+   static arrow::compute::Expression Make(
+      arrow::compute::Expression input_expression,
+      std::string dictionary_string
+   );
+};
+
+}  // namespace silo::query_engine::exec_node

--- a/include/silo/storage/column/sequence_column.h
+++ b/include/silo/storage/column/sequence_column.h
@@ -102,6 +102,23 @@ class SequenceColumnPartition {
    storage::insertion::InsertionIndex<SymbolType> insertion_index;
    uint32_t sequence_count = 0;
 
+   explicit SequenceColumnPartition(Metadata* metadata);
+
+   [[nodiscard]] size_t computeSize() const;
+
+   [[nodiscard]] const roaring::Roaring* getBitmap(
+      size_t position_idx,
+      typename SymbolType::Symbol symbol
+   ) const;
+
+   [[nodiscard]] SequenceColumnInfo getInfo() const;
+
+   ReadSequence& appendNewSequenceRead();
+
+   void appendInsertion(const std::string& insertion_and_position);
+
+   void finalize();
+
   private:
    static constexpr size_t BUFFER_SIZE = 1024;
    std::vector<ReadSequence> lazy_buffer;
@@ -119,24 +136,6 @@ class SequenceColumnPartition {
    void optimizeBitmaps();
 
    void flushBuffer();
-
-  public:
-   explicit SequenceColumnPartition(Metadata* metadata);
-
-   [[nodiscard]] size_t computeSize() const;
-
-   [[nodiscard]] const roaring::Roaring* getBitmap(
-      size_t position_idx,
-      typename SymbolType::Symbol symbol
-   ) const;
-
-   [[nodiscard]] SequenceColumnInfo getInfo() const;
-
-   ReadSequence& appendNewSequenceRead();
-
-   void appendInsertion(const std::string& insertion_and_position);
-
-   void finalize();
 };
 }  // namespace silo::storage::column
 

--- a/src/silo/query_engine/exec_node/zstd_decompress_expression.cpp
+++ b/src/silo/query_engine/exec_node/zstd_decompress_expression.cpp
@@ -1,0 +1,136 @@
+#include "silo/query_engine/exec_node/zstd_decompress_expression.h"
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/acero/options.h>
+#include <arrow/acero/query_context.h>
+#include <arrow/api.h>
+#include <arrow/compute/api.h>
+#include <arrow/compute/expression.h>
+#include <arrow/compute/kernel.h>
+#include <arrow/compute/registry.h>
+#include <arrow/memory_pool.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+#include <arrow/type.h>
+#include <arrow/type_traits.h>
+#include <spdlog/spdlog.h>
+
+#include "silo/common/panic.h"
+#include "silo/zstd/zstd_context.h"
+#include "silo/zstd/zstd_decompressor.h"
+#include "silo/zstd/zstd_dictionary.h"
+
+namespace silo::query_engine::exec_node {
+
+namespace {
+struct BinaryDecompressKernel {
+   static arrow::Status Exec(
+      arrow::compute::KernelContext* context,
+      const arrow::compute::ExecSpan& input,
+      arrow::compute::ExecResult* out
+   ) {
+      if (input.num_values() != 2) {
+         return arrow::Status::Invalid("Expected 2 input arrays, got ", input.num_values());
+      }
+
+      if (!input.values[0].is_array()) {
+         return arrow::Status::Invalid("Expected array input, got scalar/chunked array");
+      }
+      const auto& input_span = input.values[0].array;
+
+      if (!input.values[1].is_scalar()) {
+         return arrow::Status::Invalid("Expected scalar input of type binary as second argument");
+      }
+      auto input_dict = static_cast<const arrow::BinaryScalar*>(input.values[1].scalar);
+      SILO_ASSERT(input_dict);
+      auto dictionary = std::make_shared<silo::ZstdDDictionary>(input_dict->view());
+      silo::ZstdDecompressor decompressor{dictionary};
+
+      arrow::StringBuilder builder(context->memory_pool());
+      ARROW_RETURN_NOT_OK(builder.Reserve(input_span.length));
+
+      const int32_t* offsets = input_span.GetValues<const int32_t>(1);
+      const char* data = input_span.GetValues<const char>(2);
+      for (int64_t i = 0; i < input_span.length; ++i) {
+         if (input_span.IsNull(i)) {
+            ARROW_RETURN_NOT_OK(builder.AppendNull());
+         } else {
+            int64_t start_offset = offsets[i];
+            int64_t end_offset = offsets[i + 1];
+            size_t length = end_offset - start_offset;
+            const std::string_view value{data + start_offset, length};
+            std::string decompressed_buffer;
+            decompressor.decompress(value.data(), value.length(), decompressed_buffer);
+            ARROW_RETURN_NOT_OK(builder.Append(decompressed_buffer));
+         }
+      }
+
+      // Finish building the output array
+      std::shared_ptr<arrow::Array> output_array;
+      ARROW_RETURN_NOT_OK(builder.Finish(&output_array));
+
+      // Set the output Datum
+      *out = arrow::compute::ExecResult{.value = output_array->data()};
+      return arrow::Status::OK();
+   }
+};
+
+arrow::Result<std::string> RegisterCustomFunctionImpl() {
+   std::string function_name = "silo_zstd_decompressor";
+   auto registry = arrow::compute::GetFunctionRegistry();
+
+   std::string summary =
+      "A function to decompress binary values with a statically known zstd dictionary";
+   std::string description =
+      "This function takes a zstd-dictionary as argument and decompresses each value using this "
+      "dictionary. The output is written into the output batch.";
+   std::vector<std::string> arg_names = {"zstd_compressed_binary", "dictionary"};
+
+   // Create a new ScalarFunction
+   auto custom_function = std::make_shared<arrow::compute::ScalarFunction>(
+      function_name,
+      arrow::compute::Arity::Binary(),
+      arrow::compute::FunctionDoc(summary, description, arg_names)
+   );
+
+   {
+      arrow::compute::ScalarKernel kernel;
+      kernel.exec = BinaryDecompressKernel::Exec;
+      kernel.signature =
+         arrow::compute::KernelSignature::Make({arrow::utf8(), arrow::utf8()}, arrow::utf8());
+      kernel.null_handling = arrow::compute::NullHandling::INTERSECTION;
+      kernel.mem_allocation = arrow::compute::MemAllocation::NO_PREALLOCATE;
+      ARROW_RETURN_NOT_OK(custom_function->AddKernel(std::move(kernel)));
+   }
+
+   ARROW_RETURN_NOT_OK(registry->AddFunction(custom_function));
+
+   return function_name;
+}
+
+std::string RegisterCustomFunction() {
+   std::string function_name;
+   auto status = RegisterCustomFunctionImpl().Value(&function_name);
+   if (!status.ok()) {
+      throw std::runtime_error(fmt::format("Err: {}", status.ToString()));
+   }
+   return function_name;
+}
+}  // namespace
+
+arrow::Expression ZstdDecompressExpression::Make(
+   arrow::Expression input_expression,
+   std::string dictionary_string
+) {
+   {
+      static std::string function_name = RegisterCustomFunction();
+
+      auto dict_scalar = std::make_shared<arrow::StringScalar>(std::move(dictionary_string));
+
+      return arrow::compute::call(
+         function_name, {input_expression, arrow::compute::literal(arrow::Datum(dict_scalar))}
+      );
+   }
+}
+
+}  // namespace silo::query_engine::exec_node

--- a/src/silo/query_engine/exec_node/zstd_decompress_expression.test.cpp
+++ b/src/silo/query_engine/exec_node/zstd_decompress_expression.test.cpp
@@ -1,0 +1,139 @@
+#include "silo/query_engine/exec_node/zstd_decompress_expression.h"
+
+#include <gtest/gtest.h>
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/acero/options.h>
+#include <arrow/acero/query_context.h>
+#include <arrow/api.h>
+#include <arrow/compute/api.h>
+#include <arrow/compute/expression.h>
+#include <arrow/compute/kernel.h>
+#include <arrow/compute/registry.h>
+#include <arrow/memory_pool.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+#include <arrow/type.h>
+#include <arrow/type_traits.h>
+#include <spdlog/spdlog.h>
+
+#include "silo/zstd/zstd_compressor.h"
+#include "silo/zstd/zstd_dictionary.h"
+
+arrow::Result<std::shared_ptr<arrow::Table>> setupTestTable(
+   std::vector<std::optional<std::string>> values,
+   std::string dictionary_string
+) {
+   std::shared_ptr<arrow::Schema> schema = arrow::schema(
+      {arrow::field("id", arrow::int32()),
+       arrow::field("some_zstd_compressed_column", arrow::utf8())}
+   );
+
+   auto dictionary = std::make_shared<silo::ZstdCDictionary>(dictionary_string, 3);
+   silo::ZstdCompressor compressor{dictionary};
+
+   arrow::Int32Builder id_builder;
+   arrow::StringBuilder value_builder;
+   int32_t id = 1;
+   for (auto& value : values) {
+      ARROW_RETURN_NOT_OK(id_builder.Append(id++));
+      if (value.has_value()) {
+         ARROW_RETURN_NOT_OK(value_builder.Append(compressor.compress(value.value())));
+      } else {
+         ARROW_RETURN_NOT_OK(value_builder.AppendNull());
+      }
+   }
+   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Array> id_array, id_builder.Finish());
+   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Array> value_array, value_builder.Finish());
+   return arrow::Table::Make(schema, {id_array, value_array});
+}
+
+using silo::query_engine::exec_node::ZstdDecompressExpression;
+
+std::shared_ptr<arrow::Table> runValuesThroughProjection(
+   std::vector<std::optional<std::string>> values,
+   std::string dictionary_string
+) {
+   auto input_table = setupTestTable(values, dictionary_string).ValueOrDie();
+
+   auto arrow_plan = arrow::acero::ExecPlan::Make().ValueOrDie();
+
+   arrow::acero::TableSourceNodeOptions source_options{input_table};
+   auto node =
+      arrow::acero::MakeExecNode("table_source", arrow_plan.get(), {}, source_options).ValueOrDie();
+
+   arrow::acero::ProjectNodeOptions project_options(
+      {arrow::compute::field_ref("id"),
+       ZstdDecompressExpression::Make(
+          arrow::compute::field_ref("some_zstd_compressed_column"), dictionary_string
+       )}
+   );
+   node =
+      arrow::acero::MakeExecNode("project", arrow_plan.get(), {node}, project_options).ValueOrDie();
+
+   std::shared_ptr<arrow::Table> result_table;
+
+   arrow::acero::TableSinkNodeOptions options{&result_table};
+   arrow::acero::MakeExecNode("table_sink", arrow_plan.get(), {node}, options).ValueOrDie();
+
+   arrow_plan->StartProducing();
+   arrow_plan->finished().result().ValueOrDie();
+
+   return result_table;
+}
+
+void assertDecompressedStringArray(
+   const std::vector<std::optional<std::string>>& expected_values,
+   const std::shared_ptr<arrow::Table>& result_table
+) {
+   for (size_t chunk_id = 0; chunk_id < result_table->column(1)->num_chunks(); ++chunk_id) {
+      std::shared_ptr<arrow::StringArray> string_array =
+         std::static_pointer_cast<arrow::StringArray>(result_table->column(1)->chunk(0));
+
+      ASSERT_EQ(string_array->length(), expected_values.size())
+         << "Decompressed array length does not match expected values size.";
+
+      for (size_t i = 0; i < expected_values.size(); i++) {
+         if (string_array->IsNull(i)) {
+            ASSERT_FALSE(expected_values[i].has_value())
+               << "Value at index " << i << " is null, but expected a value.";
+         } else {
+            ASSERT_TRUE(expected_values[i].has_value())
+               << "Value at index " << i << " is not null, but expected null.";
+            ASSERT_EQ(string_array->Value(i), expected_values[i].value())
+               << "Decompressed value at index " << i << " does not match expected.";
+         }
+      }
+   }
+}
+
+TEST(ZstdDecompressExpression, decompressesValues) {
+   std::vector<std::optional<std::string>> values = {"ACGT", "ACCT", "ACGG"};
+   auto result_table = runValuesThroughProjection(values, "ACGTC");
+   assertDecompressedStringArray(values, result_table);
+}
+
+TEST(ZstdDecompressExpression, worksWithNullValues) {
+   std::vector<std::optional<std::string>> values = {std::nullopt, "ACCT", std::nullopt};
+   auto result_table = runValuesThroughProjection(values, "ACGTC");
+   assertDecompressedStringArray(values, result_table);
+}
+
+TEST(ZstdDecompressExpression, empty) {
+   std::vector<std::optional<std::string>> values = {};
+   auto result_table = runValuesThroughProjection(values, "ACGTC");
+   assertDecompressedStringArray(values, result_table);
+}
+
+TEST(ZstdDecompressExpression, largeSet) {
+   std::vector<std::optional<std::string>> values = {};
+   for (size_t i = 0; i < 15000; ++i) {
+      values.push_back("ACGT");
+   }
+   values.push_back(std::nullopt);
+   for (size_t i = 0; i < 10000; ++i) {
+      values.push_back("AAAA");
+   }
+   auto result_table = runValuesThroughProjection(values, "ACGTC");
+   assertDecompressedStringArray(values, result_table);
+}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #763

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This PR is a follow-up to issue #654 to allow downloads of large sequence sets

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
