### PR TITLE
SILO crashes on FastaAligned with InsertionContains filter

### DIFF
--- a/include/silo/query_engine/exec_node/legacy_result_producer.h
+++ b/include/silo/query_engine/exec_node/legacy_result_producer.h
@@ -61,7 +61,7 @@ class LegacyResultProducer : public arrow::acero::ExecNode {
    arrow::Status StartProducing() override {
       try {
          return produce();
-      } catch (const std::runtime_error& error) {
+      } catch (const std::exception& error) {
          SPDLOG_ERROR("TableScan::produce exited with error: {}", error.what());
          return arrow::Status::ExecutionError(error.what());
       }

--- a/include/silo/query_engine/exec_node/legacy_result_producer.h
+++ b/include/silo/query_engine/exec_node/legacy_result_producer.h
@@ -58,7 +58,14 @@ class LegacyResultProducer : public arrow::acero::ExecNode {
       SILO_PANIC("LegacyResultProducer does not support having inputs.");
    }
 
-   arrow::Status StartProducing() override { return produce(); }
+   arrow::Status StartProducing() override {
+      try {
+         return produce();
+      } catch (const std::runtime_error& error) {
+         SPDLOG_ERROR("TableScan::produce exited with error: {}", error.what());
+         return arrow::Status::ExecutionError(error.what());
+      }
+   }
 
    arrow::Status StopProducingImpl() override { return arrow::Status::OK(); }
 

--- a/include/silo/query_engine/exec_node/table_scan.h
+++ b/include/silo/query_engine/exec_node/table_scan.h
@@ -72,8 +72,12 @@ class TableScan : public arrow::acero::ExecNode {
 
    arrow::Status StartProducing() override {
       SPDLOG_TRACE("TableScan::StartProducing");
-      ARROW_RETURN_NOT_OK(produce());
-      return arrow::Status::OK();
+      try {
+         ARROW_RETURN_NOT_OK(produce());
+         return arrow::Status::OK();
+      } catch (const std::exception& exception) {
+         return arrow::Status::ExecutionError(exception.what());
+      }
    }
 
    arrow::Status StopProducingImpl() override {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,7 +162,7 @@ int mainWhichMayThrowExceptions(int argc, char** argv) {
 int main(int argc, char** argv) {
    try {
       return mainWhichMayThrowExceptions(argc, argv);
-   } catch (const std::runtime_error& error) {
+   } catch (const std::exception& error) {
       SPDLOG_ERROR("Internal Error: {}", error.what());
       return 2;
    }

--- a/src/silo/query_engine/actions/fasta_aligned.test.cpp
+++ b/src/silo/query_engine/actions/fasta_aligned.test.cpp
@@ -205,6 +205,46 @@ const QueryTestScenario FASTA_ALIGNED_DESCENDING = {
    )
 };
 
+const QueryTestScenario FASTA_ALIGNED_SUBSET = {
+   .name = "FASTA_ALIGNED_SUBSET",
+   .query = nlohmann::json::parse(
+      R"(
+{
+   "action": {
+     "type": "FastaAligned",
+     "sequenceName": ["segment1"]
+   },
+  "filterExpression": {
+    "type": "Or",
+    "children": [
+      {
+        "type": "StringEquals",
+        "column": "primaryKey",
+        "value": "id_0"
+      },
+      {
+        "type": "StringEquals",
+        "column": "primaryKey",
+        "value": "id_2"
+      },
+      {
+        "type": "StringEquals",
+        "column": "primaryKey",
+        "value": "id_3"
+      }
+    ]
+  }
+}
+)"
+   ),
+   .expected_query_result = nlohmann::json::parse(
+      R"(
+[{"primaryKey":"id_0","segment1":"ATGCN"},
+{"primaryKey":"id_2","segment1":"NNNNN"},
+{"primaryKey":"id_3","segment1":"CATTT"}])"
+   )
+};
+
 }  // namespace
 
 QUERY_TEST(
@@ -215,6 +255,7 @@ QUERY_TEST(
       FASTA_ALIGNED_ADDITIONAL_HEADER,
       FASTA_ALIGNED_DUPLICATE_HEADER,
       FASTA_ALIGNED_EXPLICIT_PRIMARY_KEY,
-      FASTA_ALIGNED_DESCENDING
+      FASTA_ALIGNED_DESCENDING,
+      FASTA_ALIGNED_SUBSET
    )
 );

--- a/src/silo/query_engine/exec_node/ndjson_sink.cpp
+++ b/src/silo/query_engine/exec_node/ndjson_sink.cpp
@@ -87,7 +87,7 @@ arrow::Status NdjsonSink::InputReceived(
          output_stream = nullptr;
       }
       return arrow::Status::OK();
-   } catch (const std::runtime_error& error) {
+   } catch (const std::exception& error) {
       const auto error_message = fmt::format(
          "NdjsonSink::InputReceived, exception thrown when not expected: {}", error.what()
       );

--- a/src/silo/query_engine/exec_node/table_scan.cpp
+++ b/src/silo/query_engine/exec_node/table_scan.cpp
@@ -61,7 +61,7 @@ arrow::Status appendSequences(
    size_t id_in_reconstructed_sequences = 0;
    for (size_t row_id : row_ids) {
       for (const size_t position_idx : sequence_store.missing_symbol_bitmaps.at(row_id)) {
-         reconstructed_sequences[id_in_reconstructed_sequences][position_idx] =
+         reconstructed_sequences.at(id_in_reconstructed_sequences).at(position_idx) =
             SymbolType::symbolToChar(SymbolType::SYMBOL_MISSING);
       }
       id_in_reconstructed_sequences++;


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #777 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

There was a bug in `table_scan.cpp` where the method for bulk sequence reconstruction confused the `row_id` in the database with the id in the current batch.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
