### PR TITLE
fix: remove erroneous warning printed on every preprocessing run

### DIFF
--- a/src/silo/config/preprocessing_config.cpp
+++ b/src/silo/config/preprocessing_config.cpp
@@ -105,8 +105,8 @@ ConfigSpecification PreprocessingConfig::getConfigSpecification() {
             "Path to the input data. Relative from inputDirectory."
          ),
          // DEPRECATED: TODO(#737) fully remove after next major release
-         ConfigAttributeSpecification::createWithDefault(
-            intermediateResultsDirectoryOptionKey(), ConfigValue::fromPath("./temp/"), "DEPRECATED."
+         ConfigAttributeSpecification::createWithoutDefault(
+            intermediateResultsDirectoryOptionKey(), ConfigValueType::PATH, "DEPRECATED."
          ),
          ConfigAttributeSpecification::createWithoutDefault(
             preprocessingDatabaseLocationOptionKey(), ConfigValueType::PATH, "DEPRECATED."


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
resolves a minor issue where a deprecation warning is printed on every execution of `silo preprocessing`

The problem was that the deprecated option `intermediateResultsDirectory` had a default value. When this default value was used on initialization of the config, it printed the deprecation warning

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
