### PR TITLE
refactor: be more permissible of the working directory when running tests

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "ms-vscode.cpptools-extension-pack",      // Microsoft C++ extension
+    "llvm-vs-code-extensions.lldb-dap",     // CodeLLDB debugger
+  ]
+}

--- a/src/main.test.cpp
+++ b/src/main.test.cpp
@@ -1,19 +1,35 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <filesystem>
+
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/spdlog.h>
-#include <filesystem>
 
 #include "silo/common/log.h"
 
-int main(int argc, char* argv[]) {
-   try {
-      if (!std::filesystem::exists("testBaseData/exampleDataset")) {
-         throw std::runtime_error("must be run in root of repository");
+int changeCwdToTestFolder() {
+   // Look for the test data directory (`testBaseData`) in the current directory and up to
+   // <search_depth> directories above the current directory. If found, change the current working
+   // directory to the directory containing the test data directory
+   size_t search_depth = 3;
+   std::filesystem::path candidate_directory = std::filesystem::current_path().string();
+   for (size_t i = 0; i < search_depth; i++, candidate_directory = candidate_directory / "..") {
+      if (std::filesystem::exists(candidate_directory / "testBaseData/exampleDataset")) {
+         std::filesystem::current_path(candidate_directory);
+         return 0;
       }
-   } catch (std::exception& e) {
-      SPDLOG_ERROR(e.what());
-      return 1;
+   }
+   SPDLOG_ERROR(
+      "Should be run in root of repository, got {} and could not find root by heuristics",
+      std::filesystem::current_path().string()
+   );
+   return 1;
+}
+
+int main(int argc, char* argv[]) {
+   if (auto exit = changeCwdToTestFolder()) {
+      return exit;
    }
    if (spdlog::get_level() > spdlog::level::debug) {
       spdlog::set_level(spdlog::level::trace);


### PR DESCRIPTION


<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
resolves an issue where it is cumbersome to change the working directory where the tests should be run in vscode (see #787). Anyways it should not always require manual setup as also other IDEs use the build directory as the default cwd when running the tests. This is an easy heuristic that should work for most setups

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
