### PR TITLE
747 insertions validation

### DIFF
--- a/src/silo/storage/column/sequence_column.test.cpp
+++ b/src/silo/storage/column/sequence_column.test.cpp
@@ -19,7 +19,7 @@ TEST(SequenceColumn, validErrorOnBadInsertionFormat_noTwoParts) {
       [&]() { under_test.appendInsertion("A"); },
       ThrowsMessage<InsertionFormatException>(
          ::testing::HasSubstr("Failed to parse insertion due to invalid format. Expected two parts "
-                              "(position and insertion value), instead got: 'A'")
+                              "(position and non-empty insertion value), instead got: 'A'")
       )
    );
 }
@@ -47,7 +47,32 @@ TEST(SequenceColumn, validErrorOnBadInsertionFormat_secondPartIllegalSymbol) {
          under_test.finalize();
       },
       ThrowsMessage<InsertionFormatException>(
-         ::testing::HasSubstr("Illegal nucleotide character 'E' in insertion: EEEEE")
+         ::testing::HasSubstr("Illegal nucleotide character 'E' in insertion: 0:EEEEE")
+      )
+   );
+}
+
+TEST(SequenceColumn, validErrorOnBadInsertionFormat_secondPartIsANumber) {
+   SequenceColumnMetadata<Nucleotide> column_metadata{"test_column", {}};
+   SequenceColumnPartition<Nucleotide> under_test(&column_metadata);
+   EXPECT_THAT(
+      // NOLINTNEXTLINE(clang-diagnostic-error)
+      [&]() { under_test.appendInsertion("0:0"); },
+      ThrowsMessage<InsertionFormatException>(
+         ::testing::HasSubstr("Illegal nucleotide character '0' in insertion: 0:0")
+      )
+   );
+}
+
+TEST(SequenceColumn, validErrorOnBadInsertionFormat_secondPartEmpty) {
+   SequenceColumnMetadata<Nucleotide> column_metadata{"test_column", {}};
+   SequenceColumnPartition<Nucleotide> under_test(&column_metadata);
+   EXPECT_THAT(
+      // NOLINTNEXTLINE(clang-diagnostic-error)
+      [&]() { under_test.appendInsertion("0:"); },
+      ThrowsMessage<InsertionFormatException>(
+         ::testing::HasSubstr("Failed to parse insertion due to invalid format. Expected two parts "
+                              "(position and non-empty insertion value), instead got: '0:'")
       )
    );
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #747

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

Add validation when adding insertions to the lazy buffer. Not only when building the threemer indexes later


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
