### PR TITLE
769 migrate mutations action to new framework

### DIFF
--- a/src/silo/query_engine/actions/action.cpp
+++ b/src/silo/query_engine/actions/action.cpp
@@ -308,8 +308,7 @@ std::vector<schema::ColumnIdentifier> columnNamesToFields(
 
 arrow::Result<QueryPlan> Action::toQueryPlanImpl(
    std::shared_ptr<const storage::Table> table,
-   std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
-      partition_filter_operators,
+   std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators,
    const config::QueryOptions& query_options
 ) {
    ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
@@ -326,8 +325,7 @@ arrow::Result<QueryPlan> Action::toQueryPlanImpl(
 
 QueryPlan Action::toQueryPlan(
    std::shared_ptr<const storage::Table> table,
-   std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
-      partition_filter_operators,
+   std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators,
    const config::QueryOptions& query_options
 ) {
    auto query_plan = toQueryPlanImpl(table, partition_filter_operators, query_options);

--- a/src/silo/query_engine/actions/action.cpp
+++ b/src/silo/query_engine/actions/action.cpp
@@ -308,7 +308,8 @@ std::vector<schema::ColumnIdentifier> columnNamesToFields(
 
 arrow::Result<QueryPlan> Action::toQueryPlanImpl(
    std::shared_ptr<const storage::Table> table,
-   const std::vector<std::unique_ptr<filter::operators::Operator>>& partition_filter_operators,
+   std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
+      partition_filter_operators,
    const config::QueryOptions& query_options
 ) {
    ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
@@ -325,7 +326,8 @@ arrow::Result<QueryPlan> Action::toQueryPlanImpl(
 
 QueryPlan Action::toQueryPlan(
    std::shared_ptr<const storage::Table> table,
-   const std::vector<std::unique_ptr<filter::operators::Operator>>& partition_filter_operators,
+   std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
+      partition_filter_operators,
    const config::QueryOptions& query_options
 ) {
    auto query_plan = toQueryPlanImpl(table, partition_filter_operators, query_options);

--- a/src/silo/query_engine/actions/action.h
+++ b/src/silo/query_engine/actions/action.h
@@ -51,8 +51,7 @@ class Action {
 
    QueryPlan toQueryPlan(
       std::shared_ptr<const storage::Table> table,
-      std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
-         partition_filter_operators,
+      std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators,
       const config::QueryOptions& query_options
    );
 
@@ -78,8 +77,7 @@ class Action {
    // If this method is not overloaded, a LegacyResultProducer will be created instead
    virtual arrow::Result<QueryPlan> toQueryPlanImpl(
       std::shared_ptr<const storage::Table> table,
-      std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
-         partition_filter_operators,
+      std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators,
       const config::QueryOptions& query_options
    );
 

--- a/src/silo/query_engine/actions/action.h
+++ b/src/silo/query_engine/actions/action.h
@@ -51,7 +51,8 @@ class Action {
 
    QueryPlan toQueryPlan(
       std::shared_ptr<const storage::Table> table,
-      const std::vector<std::unique_ptr<filter::operators::Operator>>& partition_filter_operators,
+      std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
+         partition_filter_operators,
       const config::QueryOptions& query_options
    );
 
@@ -77,7 +78,8 @@ class Action {
    // If this method is not overloaded, a LegacyResultProducer will be created instead
    virtual arrow::Result<QueryPlan> toQueryPlanImpl(
       std::shared_ptr<const storage::Table> table,
-      const std::vector<std::unique_ptr<filter::operators::Operator>>& partition_filter_operators,
+      std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
+         partition_filter_operators,
       const config::QueryOptions& query_options
    );
 

--- a/src/silo/query_engine/actions/mutations.cpp
+++ b/src/silo/query_engine/actions/mutations.cpp
@@ -287,7 +287,7 @@ using silo::query_engine::filter::operators::Operator;
 template <typename SymbolType>
 arrow::Result<QueryPlan> Mutations<SymbolType>::toQueryPlanImpl(
    std::shared_ptr<const storage::Table> table,
-   std::shared_ptr<std::vector<std::unique_ptr<Operator>>> partition_filter_operators,
+   std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators,
    const config::QueryOptions& query_options
 ) {
    std::vector<std::string> sequence_names_to_evaluate;

--- a/src/silo/query_engine/actions/mutations.h
+++ b/src/silo/query_engine/actions/mutations.h
@@ -102,8 +102,7 @@ class Mutations : public Action {
 
    arrow::Result<QueryPlan> toQueryPlanImpl(
       std::shared_ptr<const storage::Table> table,
-      std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
-         partition_filter_operators,
+      std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators,
       const config::QueryOptions& query_options
    ) override;
 

--- a/src/silo/query_engine/actions/simple_select_action.cpp
+++ b/src/silo/query_engine/actions/simple_select_action.cpp
@@ -33,7 +33,8 @@ void SimpleSelectAction::validateOrderByFields(const schema::TableSchema& schema
 
 arrow::Result<QueryPlan> SimpleSelectAction::toQueryPlanImpl(
    std::shared_ptr<const storage::Table> table,
-   const std::vector<std::unique_ptr<filter::operators::Operator>>& partition_filter_operators,
+   std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
+      partition_filter_operators,
    const config::QueryOptions& query_options
 ) {
    validateOrderByFields(table->schema);

--- a/src/silo/query_engine/actions/simple_select_action.cpp
+++ b/src/silo/query_engine/actions/simple_select_action.cpp
@@ -33,8 +33,7 @@ void SimpleSelectAction::validateOrderByFields(const schema::TableSchema& schema
 
 arrow::Result<QueryPlan> SimpleSelectAction::toQueryPlanImpl(
    std::shared_ptr<const storage::Table> table,
-   std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
-      partition_filter_operators,
+   std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators,
    const config::QueryOptions& query_options
 ) {
    validateOrderByFields(table->schema);

--- a/src/silo/query_engine/actions/simple_select_action.h
+++ b/src/silo/query_engine/actions/simple_select_action.h
@@ -16,8 +16,7 @@ class SimpleSelectAction : public Action {
 
    arrow::Result<QueryPlan> toQueryPlanImpl(
       std::shared_ptr<const storage::Table> table,
-      std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
-         partition_filter_operators,
+      std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators,
       const config::QueryOptions& query_options
    ) override;
 };

--- a/src/silo/query_engine/actions/simple_select_action.h
+++ b/src/silo/query_engine/actions/simple_select_action.h
@@ -16,7 +16,8 @@ class SimpleSelectAction : public Action {
 
    arrow::Result<QueryPlan> toQueryPlanImpl(
       std::shared_ptr<const storage::Table> table,
-      const std::vector<std::unique_ptr<filter::operators::Operator>>& partition_filter_operators,
+      std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
+         partition_filter_operators,
       const config::QueryOptions& query_options
    ) override;
 };

--- a/src/silo/query_engine/exec_node/json_value_type_array_builder.cpp
+++ b/src/silo/query_engine/exec_node/json_value_type_array_builder.cpp
@@ -1,0 +1,87 @@
+#include "silo/query_engine/exec_node/json_value_type_array_builder.h"
+
+#include <arrow/datum.h>
+
+#include "silo/common/panic.h"
+
+namespace silo::query_engine::exec_node {
+
+JsonValueTypeArrayBuilder::JsonValueTypeArrayBuilder(std::shared_ptr<arrow::DataType> type) {
+   if (type == arrow::int32()) {
+      builder = arrow::Int32Builder{};
+   } else if (type == arrow::float64()) {
+      builder = arrow::DoubleBuilder{};
+   } else if (type == arrow::utf8()) {
+      builder = arrow::StringBuilder{};
+   } else if (type == arrow::boolean()) {
+      builder = arrow::BooleanBuilder{};
+   } else {
+      SILO_PANIC("Invalid type found: ", type->ToString());
+   }
+}
+
+arrow::Status JsonValueTypeArrayBuilder::insert(
+   const std::optional<std::variant<std::string, bool, int32_t, double>>& value
+) {
+   if (!value.has_value()) {
+      return std::visit(
+         [&](auto& b) {
+            ARROW_RETURN_NOT_OK(b.AppendNull());
+            return arrow::Status::OK();
+         },
+         builder
+      );
+   }
+
+   return std::visit(
+      [&](auto&& val) {
+         using T = std::decay_t<decltype(val)>;
+         return std::visit(
+            [&](auto& b) {
+               using B = std::decay_t<decltype(b)>;
+               if constexpr (std::is_same_v<T, int32_t> && std::is_same_v<B, arrow::Int32Builder>) {
+                  ARROW_RETURN_NOT_OK(b.Append(val));
+               } else if constexpr (std::is_same_v<T, double> && std::is_same_v<B, arrow::DoubleBuilder>) {
+                  ARROW_RETURN_NOT_OK(b.Append(val));
+               } else if constexpr (std::is_same_v<T, std::string> && std::is_same_v<B, arrow::StringBuilder>) {
+                  ARROW_RETURN_NOT_OK(b.Append(val));
+               } else if constexpr (std::is_same_v<T, bool> && std::is_same_v<B, arrow::BooleanBuilder>) {
+                  ARROW_RETURN_NOT_OK(b.Append(val));
+               } else {
+                  SILO_PANIC("Type mismatch between value and builder");
+               }
+               return arrow::Status::OK();
+            },
+            builder
+         );
+      },
+      value.value()
+   );
+}
+
+arrow::Result<arrow::Datum> JsonValueTypeArrayBuilder::toDatum() {
+   return std::visit(
+             [&](auto& b) {
+                using B = std::decay_t<decltype(b)>;
+                if constexpr (std::is_same_v<B, arrow::Int32Builder>) {
+                   auto& array = get<arrow::Int32Builder>(builder);
+                   return array.Finish();
+                } else if constexpr (std::is_same_v<B, arrow::DoubleBuilder>) {
+                   auto& array = get<arrow::DoubleBuilder>(builder);
+                   return array.Finish();
+                } else if constexpr (std::is_same_v<B, arrow::StringBuilder>) {
+                   auto& array = get<arrow::StringBuilder>(builder);
+                   return array.Finish();
+                } else if constexpr (std::is_same_v<B, arrow::BooleanBuilder>) {
+                   auto& array = get<arrow::BooleanBuilder>(builder);
+                   return array.Finish();
+                } else {
+                   SILO_PANIC("Type mismatch between value and builder");
+                }
+             },
+             builder
+   )
+      .Map([](auto&& x) { return arrow::Datum{x}; });
+}
+
+}  // namespace silo::query_engine::exec_node

--- a/src/silo/query_engine/exec_node/json_value_type_array_builder.h
+++ b/src/silo/query_engine/exec_node/json_value_type_array_builder.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <variant>
+
+#include <arrow/builder.h>
+
+namespace silo::query_engine::exec_node {
+
+class JsonValueTypeArrayBuilder {
+   std::variant<
+      arrow::Int32Builder,
+      arrow::DoubleBuilder,
+      arrow::StringBuilder,
+      arrow::BooleanBuilder>
+      builder;
+
+  public:
+   JsonValueTypeArrayBuilder(std::shared_ptr<arrow::DataType> type);
+
+   arrow::Status insert(const std::optional<std::variant<std::string, bool, int32_t, double>>& value
+   );
+
+   arrow::Result<arrow::Datum> toDatum();
+};
+
+}  // namespace silo::query_engine::exec_node

--- a/src/silo/query_engine/exec_node/legacy_result_producer.cpp
+++ b/src/silo/query_engine/exec_node/legacy_result_producer.cpp
@@ -10,7 +10,7 @@ using filter::expressions::Expression;
 using filter::operators::Operator;
 
 QueryResult createLegacyQueryResult(
-   const std::vector<std::unique_ptr<filter::operators::Operator>>& partition_filter_operators,
+   const filter::operators::OperatorVector& partition_filter_operators,
    const actions::Action* action,
    std::shared_ptr<const storage::Table> table
 ) {
@@ -27,8 +27,7 @@ LegacyResultProducer::LegacyResultProducer(
    arrow::acero::ExecPlan* plan,
    const std::vector<silo::schema::ColumnIdentifier>& columns,
    std::shared_ptr<const storage::Table> table,
-   std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
-      partition_filter_operators,
+   std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators,
    const actions::Action* action,
    size_t materialization_cutoff
 )

--- a/src/silo/query_engine/exec_node/legacy_result_producer.cpp
+++ b/src/silo/query_engine/exec_node/legacy_result_producer.cpp
@@ -23,95 +23,18 @@ QueryResult createLegacyQueryResult(
 }
 }  // namespace
 
-JsonValueTypeArrayBuilder::JsonValueTypeArrayBuilder(std::shared_ptr<arrow::DataType> type) {
-   if (type == arrow::int32()) {
-      builder = arrow::Int32Builder{};
-   } else if (type == arrow::float64()) {
-      builder = arrow::DoubleBuilder{};
-   } else if (type == arrow::utf8()) {
-      builder = arrow::StringBuilder{};
-   } else if (type == arrow::boolean()) {
-      builder = arrow::BooleanBuilder{};
-   } else {
-      SILO_PANIC("Invalid type found: ", type->ToString());
-   }
-}
-
-arrow::Status JsonValueTypeArrayBuilder::insert(
-   const std::optional<std::variant<std::string, bool, int32_t, double>>& value
-) {
-   if (!value.has_value()) {
-      return std::visit(
-         [&](auto& b) {
-            ARROW_RETURN_NOT_OK(b.AppendNull());
-            return arrow::Status::OK();
-         },
-         builder
-      );
-   }
-
-   return std::visit(
-      [&](auto&& val) {
-         using T = std::decay_t<decltype(val)>;
-         return std::visit(
-            [&](auto& b) {
-               using B = std::decay_t<decltype(b)>;
-               if constexpr (std::is_same_v<T, int32_t> && std::is_same_v<B, arrow::Int32Builder>) {
-                  ARROW_RETURN_NOT_OK(b.Append(val));
-               } else if constexpr (std::is_same_v<T, double> && std::is_same_v<B, arrow::DoubleBuilder>) {
-                  ARROW_RETURN_NOT_OK(b.Append(val));
-               } else if constexpr (std::is_same_v<T, std::string> && std::is_same_v<B, arrow::StringBuilder>) {
-                  ARROW_RETURN_NOT_OK(b.Append(val));
-               } else if constexpr (std::is_same_v<T, bool> && std::is_same_v<B, arrow::BooleanBuilder>) {
-                  ARROW_RETURN_NOT_OK(b.Append(val));
-               } else {
-                  SILO_PANIC("Type mismatch between value and builder");
-               }
-               return arrow::Status::OK();
-            },
-            builder
-         );
-      },
-      value.value()
-   );
-}
-
-arrow::Result<arrow::Datum> JsonValueTypeArrayBuilder::toDatum() {
-   return std::visit(
-             [&](auto& b) {
-                using B = std::decay_t<decltype(b)>;
-                if constexpr (std::is_same_v<B, arrow::Int32Builder>) {
-                   auto& array = get<arrow::Int32Builder>(builder);
-                   return array.Finish();
-                } else if constexpr (std::is_same_v<B, arrow::DoubleBuilder>) {
-                   auto& array = get<arrow::DoubleBuilder>(builder);
-                   return array.Finish();
-                } else if constexpr (std::is_same_v<B, arrow::StringBuilder>) {
-                   auto& array = get<arrow::StringBuilder>(builder);
-                   return array.Finish();
-                } else if constexpr (std::is_same_v<B, arrow::BooleanBuilder>) {
-                   auto& array = get<arrow::BooleanBuilder>(builder);
-                   return array.Finish();
-                } else {
-                   SILO_PANIC("Type mismatch between value and builder");
-                }
-             },
-             builder
-   )
-      .Map([](auto&& x) { return arrow::Datum{x}; });
-}
-
 LegacyResultProducer::LegacyResultProducer(
    arrow::acero::ExecPlan* plan,
    const std::vector<silo::schema::ColumnIdentifier>& columns,
    std::shared_ptr<const storage::Table> table,
-   const std::vector<std::unique_ptr<filter::operators::Operator>>& partition_filter_operators,
+   std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
+      partition_filter_operators,
    const actions::Action* action,
    size_t materialization_cutoff
 )
     : arrow::acero::ExecNode(plan, {}, {}, columnsToArrowSchema(columns)),
       materialization_cutoff(materialization_cutoff) {
-   query_result = createLegacyQueryResult(partition_filter_operators, action, table);
+   query_result = createLegacyQueryResult(*partition_filter_operators, action, table);
    for (auto& field : output_schema_->fields()) {
       field_names.emplace_back(&field->name());
    }

--- a/src/silo/query_engine/exec_node/legacy_result_producer.h
+++ b/src/silo/query_engine/exec_node/legacy_result_producer.h
@@ -29,8 +29,7 @@ class LegacyResultProducer : public arrow::acero::ExecNode {
       arrow::acero::ExecPlan* plan,
       const std::vector<silo::schema::ColumnIdentifier>& columns,
       std::shared_ptr<const storage::Table> table,
-      std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
-         partition_filter_operators,
+      std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators,
       const actions::Action* action,
       size_t materialization_cutoff
    );

--- a/src/silo/query_engine/exec_node/legacy_result_producer.h
+++ b/src/silo/query_engine/exec_node/legacy_result_producer.h
@@ -5,6 +5,7 @@
 #include <arrow/record_batch.h>
 #include <spdlog/spdlog.h>
 
+#include "silo/query_engine/exec_node/json_value_type_array_builder.h"
 #include "silo/query_engine/query.h"
 #include "silo/query_engine/query_result.h"
 
@@ -12,23 +13,6 @@ namespace silo::query_engine::exec_node {
 
 using filter::expressions::Expression;
 using filter::operators::Operator;
-
-class JsonValueTypeArrayBuilder {
-   std::variant<
-      arrow::Int32Builder,
-      arrow::DoubleBuilder,
-      arrow::StringBuilder,
-      arrow::BooleanBuilder>
-      builder;
-
-  public:
-   JsonValueTypeArrayBuilder(std::shared_ptr<arrow::DataType> type);
-
-   arrow::Status insert(const std::optional<std::variant<std::string, bool, int32_t, double>>& value
-   );
-
-   arrow::Result<arrow::Datum> toDatum();
-};
 
 class LegacyResultProducer : public arrow::acero::ExecNode {
    QueryResult query_result;
@@ -45,7 +29,8 @@ class LegacyResultProducer : public arrow::acero::ExecNode {
       arrow::acero::ExecPlan* plan,
       const std::vector<silo::schema::ColumnIdentifier>& columns,
       std::shared_ptr<const storage::Table> table,
-      const std::vector<std::unique_ptr<filter::operators::Operator>>& partition_filter_operators,
+      std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
+         partition_filter_operators,
       const actions::Action* action,
       size_t materialization_cutoff
    );

--- a/src/silo/query_engine/exec_node/table_scan.cpp
+++ b/src/silo/query_engine/exec_node/table_scan.cpp
@@ -184,7 +184,7 @@ arrow::Status TableScan::appendEntries(
 arrow::Status TableScan::produce() {
    SPDLOG_TRACE("TableScan::produce");
    for (size_t partition_idx = 0; partition_idx < table->getNumberOfPartitions(); ++partition_idx) {
-      auto& filter_for_partition = partition_filters.at(partition_idx);
+      auto filter_for_partition = partition_filter_operators->at(partition_idx)->evaluate();
       silo::query_engine::BatchedBitmapReader reader{filter_for_partition, batch_size_cutoff - 1};
       while (auto row_ids = reader.nextBatch()) {
          ARROW_RETURN_NOT_OK(appendEntries(table->getPartition(partition_idx), row_ids.value()));

--- a/src/silo/query_engine/exec_node/table_scan.h
+++ b/src/silo/query_engine/exec_node/table_scan.h
@@ -23,8 +23,7 @@ class TableScan : public arrow::acero::ExecNode {
    std::map<schema::ColumnType, std::map<std::string, std::unique_ptr<arrow::ArrayBuilder>>>
       array_builders;
 
-   std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
-      partition_filter_operators;
+   std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators;
 
    std::vector<silo::schema::ColumnIdentifier> output_fields;
    const std::shared_ptr<const storage::Table> table;
@@ -37,8 +36,7 @@ class TableScan : public arrow::acero::ExecNode {
    TableScan(
       arrow::acero::ExecPlan* plan,
       const std::vector<silo::schema::ColumnIdentifier>& columns,
-      std::shared_ptr<std::vector<std::unique_ptr<filter::operators::Operator>>>
-         partition_filter_operators,
+      std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators,
       std::shared_ptr<const storage::Table> table,
       size_t batch_size_cutoff
    )

--- a/src/silo/query_engine/filter/expressions/and.h
+++ b/src/silo/query_engine/filter/expressions/and.h
@@ -17,12 +17,9 @@ namespace silo::query_engine::filter::expressions {
 
 class And : public Expression {
   private:
-   std::vector<std::unique_ptr<Expression>> children;
+   ExpressionVector children;
 
-   std::tuple<
-      std::vector<std::unique_ptr<operators::Operator>>,
-      std::vector<std::unique_ptr<operators::Operator>>,
-      std::vector<std::unique_ptr<operators::Predicate>>>
+   std::tuple<operators::OperatorVector, operators::OperatorVector, operators::PredicateVector>
    compileChildren(
       const Database& database,
       const storage::TablePartition& database_partition,
@@ -30,7 +27,7 @@ class And : public Expression {
    ) const;
 
   public:
-   explicit And(std::vector<std::unique_ptr<Expression>>&& children);
+   explicit And(ExpressionVector&& children);
 
    std::string toString() const override;
 

--- a/src/silo/query_engine/filter/expressions/date_between.cpp
+++ b/src/silo/query_engine/filter/expressions/date_between.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<operators::Operator> DateBetween::compile(
    const auto& date_column = database_partition.columns.date_columns.at(column_name);
 
    if (!date_column.isSorted()) {
-      std::vector<std::unique_ptr<operators::Predicate>> predicates;
+      operators::PredicateVector predicates;
       predicates.emplace_back(
          std::make_unique<operators::CompareToValueSelection<silo::common::Date>>(
             date_column.getValues(),

--- a/src/silo/query_engine/filter/expressions/expression.h
+++ b/src/silo/query_engine/filter/expressions/expression.h
@@ -38,4 +38,6 @@ void from_json(const nlohmann::json& json, std::unique_ptr<Expression>& filter);
 
 Expression::AmbiguityMode invertMode(Expression::AmbiguityMode mode);
 
+using ExpressionVector = std::vector<std::unique_ptr<Expression>>;
+
 }  // namespace silo::query_engine::filter::expressions

--- a/src/silo/query_engine/filter/expressions/float_between.cpp
+++ b/src/silo/query_engine/filter/expressions/float_between.cpp
@@ -44,7 +44,7 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> FloatBetween::c
    );
    const auto& float_column = database_partition.columns.float_columns.at(column_name);
 
-   std::vector<std::unique_ptr<operators::Predicate>> predicates;
+   operators::PredicateVector predicates;
    if (from.has_value()) {
       predicates.emplace_back(std::make_unique<operators::CompareToValueSelection<double>>(
          float_column.getValues(), operators::Comparator::HIGHER_OR_EQUALS, from.value()

--- a/src/silo/query_engine/filter/expressions/has_mutation.cpp
+++ b/src/silo/query_engine/filter/expressions/has_mutation.cpp
@@ -81,7 +81,7 @@ std::unique_ptr<operators::Operator> HasMutation<SymbolType>::compile(
          std::erase(symbols, symbol);
       }
    }
-   std::vector<std::unique_ptr<Expression>> symbol_filters;
+   ExpressionVector symbol_filters;
    std::ranges::transform(
       symbols,
       std::back_inserter(symbol_filters),

--- a/src/silo/query_engine/filter/expressions/int_between.cpp
+++ b/src/silo/query_engine/filter/expressions/int_between.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> IntBetween::com
 
    const auto& int_column = database_partition.columns.int_columns.at(column_name);
 
-   std::vector<std::unique_ptr<operators::Predicate>> predicates;
+   operators::PredicateVector predicates;
    predicates.emplace_back(std::make_unique<operators::CompareToValueSelection<int32_t>>(
       int_column.getValues(), operators::Comparator::HIGHER_OR_EQUALS, from.value_or(INT32_MIN + 1)
    ));

--- a/src/silo/query_engine/filter/expressions/nof.h
+++ b/src/silo/query_engine/filter/expressions/nof.h
@@ -16,15 +16,11 @@ namespace silo::query_engine::filter::expressions {
 
 class NOf : public Expression {
   private:
-   std::vector<std::unique_ptr<Expression>> children;
+   ExpressionVector children;
    int number_of_matchers;
    bool match_exactly;
 
-   std::tuple<
-      std::vector<std::unique_ptr<operators::Operator>>,
-      std::vector<std::unique_ptr<operators::Operator>>,
-      int>
-   mapChildExpressions(
+   std::tuple<operators::OperatorVector, operators::OperatorVector, int> mapChildExpressions(
       const silo::Database& database,
       const storage::TablePartition& database_partition,
       AmbiguityMode mode
@@ -37,11 +33,7 @@ class NOf : public Expression {
    ) const;
 
   public:
-   explicit NOf(
-      std::vector<std::unique_ptr<Expression>>&& children,
-      int number_of_matchers,
-      bool match_exactly
-   );
+   explicit NOf(ExpressionVector&& children, int number_of_matchers, bool match_exactly);
 
    std::string toString() const override;
 

--- a/src/silo/query_engine/filter/expressions/or.cpp
+++ b/src/silo/query_engine/filter/expressions/or.cpp
@@ -19,9 +19,9 @@
 
 namespace silo::query_engine::filter::expressions {
 
-using OperatorVector = std::vector<std::unique_ptr<operators::Operator>>;
+using operators::OperatorVector;
 
-Or::Or(std::vector<std::unique_ptr<Expression>>&& children)
+Or::Or(ExpressionVector&& children)
     : children(std::move(children)) {}
 
 std::string Or::toString() const {
@@ -93,7 +93,7 @@ void from_json(const nlohmann::json& json, std::unique_ptr<Or>& filter) {
    CHECK_SILO_QUERY(
       json["children"].is_array(), "The field 'children' in an Or expression needs to be an array"
    );
-   auto children = json["children"].get<std::vector<std::unique_ptr<Expression>>>();
+   auto children = json["children"].get<ExpressionVector>();
    filter = std::make_unique<Or>(std::move(children));
 }
 

--- a/src/silo/query_engine/filter/expressions/or.h
+++ b/src/silo/query_engine/filter/expressions/or.h
@@ -14,10 +14,10 @@
 namespace silo::query_engine::filter::expressions {
 
 class Or : public Expression {
-   std::vector<std::unique_ptr<Expression>> children;
+   ExpressionVector children;
 
   public:
-   Or(std::vector<std::unique_ptr<Expression>>&& children);
+   Or(ExpressionVector&& children);
 
    std::string toString() const override;
 

--- a/src/silo/query_engine/filter/expressions/symbol_equals.cpp
+++ b/src/silo/query_engine/filter/expressions/symbol_equals.cpp
@@ -103,7 +103,7 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> SymbolEquals<Sy
    );
    if (mode == UPPER_BOUND) {
       auto symbols_to_match = SymbolType::AMBIGUITY_SYMBOLS.at(symbol);
-      std::vector<std::unique_ptr<Expression>> symbol_filters;
+      ExpressionVector symbol_filters;
       std::ranges::transform(
          symbols_to_match,
          std::back_inserter(symbol_filters),
@@ -160,7 +160,7 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> SymbolEquals<Sy
          SymbolType::SYMBOLS.begin(), SymbolType::SYMBOLS.end()
       );
       std::erase(symbols, symbol);
-      std::vector<std::unique_ptr<Expression>> symbol_filters;
+      ExpressionVector symbol_filters;
       std::ranges::transform(
          symbols,
          std::back_inserter(symbol_filters),

--- a/src/silo/query_engine/filter/operators/complement.cpp
+++ b/src/silo/query_engine/filter/operators/complement.cpp
@@ -19,7 +19,7 @@ Complement::Complement(std::unique_ptr<Operator> child, uint32_t row_count)
 
 Complement::~Complement() noexcept = default;
 
-using OperatorVector = std::vector<std::unique_ptr<Operator>>;
+using operators::OperatorVector;
 
 std::unique_ptr<Complement> Complement::fromDeMorgan(
    OperatorVector disjunction,

--- a/src/silo/query_engine/filter/operators/complement.h
+++ b/src/silo/query_engine/filter/operators/complement.h
@@ -19,10 +19,7 @@ class Complement : public Operator {
   public:
    explicit Complement(std::unique_ptr<Operator> child, uint32_t row_count);
 
-   static std::unique_ptr<Complement> fromDeMorgan(
-      std::vector<std::unique_ptr<Operator>> disjunction,
-      uint32_t row_count
-   );
+   static std::unique_ptr<Complement> fromDeMorgan(OperatorVector disjunction, uint32_t row_count);
 
    ~Complement() noexcept override;
 

--- a/src/silo/query_engine/filter/operators/intersection.cpp
+++ b/src/silo/query_engine/filter/operators/intersection.cpp
@@ -14,8 +14,8 @@
 namespace silo::query_engine::filter::operators {
 
 Intersection::Intersection(
-   std::vector<std::unique_ptr<Operator>>&& children,
-   std::vector<std::unique_ptr<Operator>>&& negated_children,
+   OperatorVector&& children,
+   OperatorVector&& negated_children,
    uint32_t row_count
 )
     : children(std::move(children)),

--- a/src/silo/query_engine/filter/operators/intersection.h
+++ b/src/silo/query_engine/filter/operators/intersection.h
@@ -20,14 +20,14 @@ class Intersection : public Operator {
    friend class silo::query_engine::filter::expressions::And;
    friend class silo::query_engine::filter::expressions::NOf;
 
-   std::vector<std::unique_ptr<Operator>> children;
-   std::vector<std::unique_ptr<Operator>> negated_children;
+   OperatorVector children;
+   OperatorVector negated_children;
    uint32_t row_count;
 
   public:
    explicit Intersection(
-      std::vector<std::unique_ptr<Operator>>&& children,
-      std::vector<std::unique_ptr<Operator>>&& negated_children,
+      OperatorVector&& children,
+      OperatorVector&& negated_children,
       uint32_t row_count
    );
 

--- a/src/silo/query_engine/filter/operators/intersection.test.cpp
+++ b/src/silo/query_engine/filter/operators/intersection.test.cpp
@@ -9,8 +9,7 @@
 using silo::query_engine::filter::operators::IndexScan;
 using silo::query_engine::filter::operators::Intersection;
 using silo::query_engine::filter::operators::Operator;
-
-using OperatorVector = std::vector<std::unique_ptr<Operator>>;
+using silo::query_engine::filter::operators::OperatorVector;
 
 namespace {
 OperatorVector generateTestInput(const std::vector<roaring::Roaring>& bitmaps, uint32_t row_count) {

--- a/src/silo/query_engine/filter/operators/operator.h
+++ b/src/silo/query_engine/filter/operators/operator.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "silo/query_engine/copy_on_write_bitmap.h"
 
@@ -36,5 +37,7 @@ class Operator {
 
    static std::unique_ptr<Operator> negate(std::unique_ptr<Operator>&& some_operator);
 };
+
+using OperatorVector = std::vector<std::unique_ptr<filter::operators::Operator>>;
 
 }  // namespace silo::query_engine::filter::operators

--- a/src/silo/query_engine/filter/operators/selection.h
+++ b/src/silo/query_engine/filter/operators/selection.h
@@ -26,6 +26,8 @@ class Predicate {
    [[nodiscard]] virtual std::unique_ptr<Predicate> negate() const = 0;
 };
 
+using PredicateVector = std::vector<std::unique_ptr<Predicate>>;
+
 enum class Comparator { EQUALS, LESS, HIGHER, LESS_OR_EQUALS, HIGHER_OR_EQUALS, NOT_EQUALS };
 
 template <typename T>

--- a/src/silo/query_engine/filter/operators/threshold.cpp
+++ b/src/silo/query_engine/filter/operators/threshold.cpp
@@ -14,8 +14,8 @@
 namespace silo::query_engine::filter::operators {
 
 Threshold::Threshold(
-   std::vector<std::unique_ptr<Operator>>&& non_negated_children,
-   std::vector<std::unique_ptr<Operator>>&& negated_children,
+   OperatorVector&& non_negated_children,
+   OperatorVector&& negated_children,
    uint32_t number_of_matchers,
    bool match_exactly,
    uint32_t row_count

--- a/src/silo/query_engine/filter/operators/threshold.h
+++ b/src/silo/query_engine/filter/operators/threshold.h
@@ -12,16 +12,16 @@ namespace silo::query_engine::filter::operators {
 
 class Threshold : public Operator {
   private:
-   std::vector<std::unique_ptr<Operator>> non_negated_children;
-   std::vector<std::unique_ptr<Operator>> negated_children;
+   OperatorVector non_negated_children;
+   OperatorVector negated_children;
    uint32_t number_of_matchers;
    bool match_exactly;
    uint32_t row_count;
 
   public:
    Threshold(
-      std::vector<std::unique_ptr<Operator>>&& non_negated_children,
-      std::vector<std::unique_ptr<Operator>>&& negated_children,
+      OperatorVector&& non_negated_children,
+      OperatorVector&& negated_children,
       uint32_t number_of_matchers,
       bool match_exactly,
       uint32_t row_count

--- a/src/silo/query_engine/filter/operators/threshold.test.cpp
+++ b/src/silo/query_engine/filter/operators/threshold.test.cpp
@@ -10,7 +10,7 @@ using silo::query_engine::filter::operators::IndexScan;
 using silo::query_engine::filter::operators::Operator;
 using silo::query_engine::filter::operators::Threshold;
 
-using OperatorVector = std::vector<std::unique_ptr<Operator>>;
+using silo::query_engine::filter::operators::OperatorVector;
 
 namespace {
 OperatorVector generateTestInput(

--- a/src/silo/query_engine/filter/operators/union.cpp
+++ b/src/silo/query_engine/filter/operators/union.cpp
@@ -12,7 +12,7 @@
 
 namespace silo::query_engine::filter::operators {
 
-Union::Union(std::vector<std::unique_ptr<Operator>>&& children, uint32_t row_count)
+Union::Union(OperatorVector&& children, uint32_t row_count)
     : children(std::move(children)),
       row_count(row_count) {}
 

--- a/src/silo/query_engine/filter/operators/union.h
+++ b/src/silo/query_engine/filter/operators/union.h
@@ -20,11 +20,11 @@ class Union : public Operator {
    friend class silo::query_engine::filter::expressions::Or;
    friend class silo::query_engine::filter::expressions::NOf;
 
-   std::vector<std::unique_ptr<Operator>> children;
+   OperatorVector children;
    uint32_t row_count;
 
   public:
-   explicit Union(std::vector<std::unique_ptr<Operator>>&& children, uint32_t row_count);
+   explicit Union(OperatorVector&& children, uint32_t row_count);
 
    ~Union() noexcept override;
 

--- a/src/silo/query_engine/filter/operators/union.test.cpp
+++ b/src/silo/query_engine/filter/operators/union.test.cpp
@@ -10,7 +10,7 @@ using silo::query_engine::filter::operators::IndexScan;
 using silo::query_engine::filter::operators::Operator;
 using silo::query_engine::filter::operators::Union;
 
-using OperatorVector = std::vector<std::unique_ptr<Operator>>;
+using silo::query_engine::filter::operators::OperatorVector;
 
 namespace {
 OperatorVector generateTestInput(const std::vector<roaring::Roaring>& bitmaps, uint32_t row_count) {

--- a/src/silo/query_engine/query.cpp
+++ b/src/silo/query_engine/query.cpp
@@ -38,8 +38,7 @@ QueryPlan Query::toQueryPlan(
 ) const {
    SPDLOG_DEBUG("Parsed filter: {}", filter->toString());
 
-   auto partition_filter_operators =
-      std::make_shared<std::vector<std::unique_ptr<filter::operators::Operator>>>();
+   auto partition_filter_operators = std::make_shared<filter::operators::OperatorVector>();
    partition_filter_operators->reserve(database->table->getNumberOfPartitions());
    for (size_t partition_index = 0; partition_index < database->table->getNumberOfPartitions();
         partition_index++) {

--- a/src/silo/query_engine/query.cpp
+++ b/src/silo/query_engine/query.cpp
@@ -38,11 +38,12 @@ QueryPlan Query::toQueryPlan(
 ) const {
    SPDLOG_DEBUG("Parsed filter: {}", filter->toString());
 
-   std::vector<std::unique_ptr<filter::operators::Operator>> partition_filter_operators;
-   partition_filter_operators.reserve(database->table->getNumberOfPartitions());
+   auto partition_filter_operators =
+      std::make_shared<std::vector<std::unique_ptr<filter::operators::Operator>>>();
+   partition_filter_operators->reserve(database->table->getNumberOfPartitions());
    for (size_t partition_index = 0; partition_index < database->table->getNumberOfPartitions();
         partition_index++) {
-      partition_filter_operators.emplace_back(filter->compile(
+      partition_filter_operators->emplace_back(filter->compile(
          *database,
          database->table->getPartition(partition_index),
          filter::expressions::Expression::AmbiguityMode::NONE
@@ -50,7 +51,7 @@ QueryPlan Query::toQueryPlan(
       SPDLOG_DEBUG(
          "Simplified query for partition {}: {}",
          partition_index,
-         partition_filter_operators.back()->toString()
+         partition_filter_operators->back()->toString()
       );
    };
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #769

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This was a rather straight-forward implementation, moving the custom implementation to a `arrow::acero::SourceNode`.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
