### PR TITLE
fix: missing initialization of uint32_t in config struct. Set default value in ConfigSpecification instead.

### DIFF
--- a/src/silo/config/runtime_config.cpp
+++ b/src/silo/config/runtime_config.cpp
@@ -94,9 +94,9 @@ ConfigSpecification RuntimeConfig::getConfigSpecification() {
                "As long as no database is loaded yet, SILO will throw a 503 error. \n"
                "This option allows SILO to compute a Retry-After header for the 503 response."
             ),
-            ConfigAttributeSpecification::createWithoutDefault(
+            ConfigAttributeSpecification::createWithDefault(
                softMemoryLimitOptionKey(),
-               ConfigValueType::UINT32,
+               ConfigValue::fromUint32(0),
                "A soft-limit on the memory usage. If the rss of the process is higher than \n"
                "this value, malloc_trim is called. \n"
                "Only supported on Linux."


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

The struct did not initialize the field, therefore it contained random bytes, when no value was given. I talked with Chaoran and we think setting it to 0 by default is best for users. (no need for configuration in e.g. Loculus)

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
