### PR TITLE
feat: add randomize to streaming query engine

### DIFF
--- a/endToEndTests/test/queries/nOf_2of3_details.json
+++ b/endToEndTests/test/queries/nOf_2of3_details.json
@@ -3,7 +3,9 @@
   "query": {
     "action": {
       "type": "Details",
-      "orderByFields": ["date"]
+      "randomize": {
+        "seed": 321
+      }
     },
     "filterExpression": {
       "type": "N-Of",
@@ -30,16 +32,16 @@
   },
   "expectedQueryResult": [
     {
-      "age": 50,
+      "age": 58,
       "country": "Switzerland",
-      "date": "2020-11-13",
-      "division": "Solothurn",
-      "gisaid_epi_isl": "EPI_ISL_1005148",
-      "pango_lineage": "B.1.221",
-      "qc_value": 0.92,
+      "date": "2021-04-28",
+      "division": "Basel-Stadt",
+      "gisaid_epi_isl": "EPI_ISL_2019235",
+      "pango_lineage": "B.1.1.7",
+      "qc_value": 0.9,
       "region": "Europe",
-      "test_boolean_column": null,
-      "unsorted_date": "2020-12-17"
+      "test_boolean_column": false,
+      "unsorted_date": "2021-01-22"
     },
     {
       "age": 50,
@@ -66,16 +68,16 @@
       "unsorted_date": "2021-02-10"
     },
     {
-      "age": 58,
+      "age": 50,
       "country": "Switzerland",
-      "date": "2021-04-28",
-      "division": "Basel-Stadt",
-      "gisaid_epi_isl": "EPI_ISL_2019235",
-      "pango_lineage": "B.1.1.7",
-      "qc_value": 0.9,
+      "date": "2020-11-13",
+      "division": "Solothurn",
+      "gisaid_epi_isl": "EPI_ISL_1005148",
+      "pango_lineage": "B.1.221",
+      "qc_value": 0.92,
       "region": "Europe",
-      "test_boolean_column": false,
-      "unsorted_date": "2021-01-22"
+      "test_boolean_column": null,
+      "unsorted_date": "2020-12-17"
     }
   ]
 }

--- a/src/silo/query_engine/actions/action.h
+++ b/src/silo/query_engine/actions/action.h
@@ -55,20 +55,13 @@ class Action {
       const silo::schema::TableSchema& table_schema
    ) const = 0;
 
-  private:
-   virtual arrow::Result<QueryPlan> toQueryPlanImpl(
-      std::shared_ptr<const storage::Table> table,
-      std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators,
-      const config::QueryOptions& query_options
-   ) const = 0;
-
-  protected:
-   arrow::Result<arrow::acero::ExecNode*> addSortNode(
+   arrow::Result<arrow::acero::ExecNode*> addOrderingNodes(
       arrow::acero::ExecPlan* arrow_plan,
       arrow::acero::ExecNode* node,
       const silo::schema::TableSchema& table_schema
    ) const;
 
+  protected:
    arrow::Result<arrow::acero::ExecNode*> addLimitAndOffsetNode(
       arrow::acero::ExecPlan* arrow_plan,
       arrow::acero::ExecNode* node
@@ -79,6 +72,27 @@ class Action {
       arrow::acero::ExecNode* node,
       const silo::schema::TableSchema& table_schema
    ) const;
+
+  private:
+   virtual arrow::Result<QueryPlan> toQueryPlanImpl(
+      std::shared_ptr<const storage::Table> table,
+      std::shared_ptr<filter::operators::OperatorVector> partition_filter_operators,
+      const config::QueryOptions& query_options
+   ) const = 0;
+
+   static arrow::Result<arrow::acero::ExecNode*> addSortNode(
+      arrow::acero::ExecPlan* arrow_plan,
+      arrow::acero::ExecNode* node,
+      const std::vector<schema::ColumnIdentifier>& output_fields,
+      const arrow::Ordering ordering,
+      std::optional<size_t> num_rows_to_produce
+   );
+
+   static arrow::Result<arrow::acero::ExecNode*> addRandomizeColumn(
+      arrow::acero::ExecPlan* arrow_plan,
+      arrow::acero::ExecNode* node,
+      size_t randomize_seed
+   );
 };
 
 std::optional<uint32_t> parseLimit(const nlohmann::json& json);

--- a/src/silo/query_engine/actions/aggregated.cpp
+++ b/src/silo/query_engine/actions/aggregated.cpp
@@ -166,7 +166,7 @@ arrow::Result<QueryPlan> Aggregated::makeAggregateWithGrouping(
       arrow::acero::MakeExecNode("aggregate", arrow_plan.get(), {node}, aggregate_node_options)
    );
 
-   ARROW_ASSIGN_OR_RAISE(node, addSortNode(arrow_plan.get(), node, table->schema));
+   ARROW_ASSIGN_OR_RAISE(node, addOrderingNodes(arrow_plan.get(), node, table->schema));
 
    ARROW_ASSIGN_OR_RAISE(node, addLimitAndOffsetNode(arrow_plan.get(), node));
 

--- a/src/silo/query_engine/actions/insertions.cpp
+++ b/src/silo/query_engine/actions/insertions.cpp
@@ -275,7 +275,7 @@ arrow::Result<QueryPlan> InsertionAggregation<SymbolType>::toQueryPlanImpl(
       auto node, arrow::acero::MakeExecNode("source", arrow_plan.get(), {}, options)
    );
 
-   ARROW_ASSIGN_OR_RAISE(node, addSortNode(arrow_plan.get(), node, table->schema));
+   ARROW_ASSIGN_OR_RAISE(node, addOrderingNodes(arrow_plan.get(), node, table->schema));
 
    ARROW_ASSIGN_OR_RAISE(node, addLimitAndOffsetNode(arrow_plan.get(), node));
 

--- a/src/silo/query_engine/actions/mutations.cpp
+++ b/src/silo/query_engine/actions/mutations.cpp
@@ -380,7 +380,7 @@ arrow::Result<QueryPlan> Mutations<SymbolType>::toQueryPlanImpl(
       auto node, arrow::acero::MakeExecNode("source", arrow_plan.get(), {}, options)
    );
 
-   ARROW_ASSIGN_OR_RAISE(node, addSortNode(arrow_plan.get(), node, table->schema));
+   ARROW_ASSIGN_OR_RAISE(node, addOrderingNodes(arrow_plan.get(), node, table->schema));
 
    ARROW_ASSIGN_OR_RAISE(node, addLimitAndOffsetNode(arrow_plan.get(), node));
 

--- a/src/silo/query_engine/actions/simple_select_action.cpp
+++ b/src/silo/query_engine/actions/simple_select_action.cpp
@@ -44,7 +44,7 @@ arrow::Result<QueryPlan> SimpleSelectAction::toQueryPlanImpl(
       query_options.materialization_cutoff
    );
 
-   ARROW_ASSIGN_OR_RAISE(node, addSortNode(arrow_plan.get(), node, table->schema));
+   ARROW_ASSIGN_OR_RAISE(node, addOrderingNodes(arrow_plan.get(), node, table->schema));
 
    ARROW_ASSIGN_OR_RAISE(node, addLimitAndOffsetNode(arrow_plan.get(), node));
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #794 


### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
This adds back randomization to the arrow query engine. Afterall, I found a solution that did still allow fully featured sorting

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [ ] The implemented feature is covered by an appropriate test.
