### PR TITLE
fix: improve error messages when ndjson file is invalid

### DIFF
--- a/src/silo/append/ndjson_line_reader.h
+++ b/src/silo/append/ndjson_line_reader.h
@@ -2,6 +2,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include "silo/append/append_exception.h"
+
 namespace silo::append {
 
 class NdjsonLineReader {
@@ -33,7 +35,13 @@ class NdjsonLineReader {
          while (std::getline(*stream_, line)) {
             if (line.empty())
                continue;
-            json_buffer = nlohmann::json::parse(line);
+            try {
+               json_buffer = nlohmann::json::parse(line);
+            } catch (const nlohmann::json::parse_error& parse_error) {
+               throw silo::append::AppendException(
+                  "Error while parsing ndjson file: {}", parse_error.what()
+               );
+            }
             ++line_number;
             return *this;
          }

--- a/src/silo/append/ndjson_line_reader.test.cpp
+++ b/src/silo/append/ndjson_line_reader.test.cpp
@@ -1,0 +1,31 @@
+#include "silo/append/ndjson_line_reader.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using silo::append::AppendException;
+using silo::append::NdjsonLineReader;
+
+TEST(NdjsonLineReader, throwsAppendErrorOnInvalidJson) {
+   std::string invalid_json = "{}\n{";
+   std::stringstream invalid_json_stream{invalid_json};
+   NdjsonLineReader reader{invalid_json_stream};
+   EXPECT_THAT(
+      [&]() { (void)reader.begin()++; },
+      ThrowsMessage<silo::append::AppendException>(
+         ::testing::HasSubstr("Error while parsing ndjson file")
+      )
+   );
+}
+
+TEST(NdjsonLineReader, throwsAppendErrorOnInvalidJsonString) {
+   std::string invalid_json = "{}\n{\"test\":\"}";
+   std::stringstream invalid_json_stream{invalid_json};
+   NdjsonLineReader reader{invalid_json_stream};
+   EXPECT_THAT(
+      [&]() { (void)reader.begin()++; },
+      ThrowsMessage<silo::append::AppendException>(
+         ::testing::HasSubstr("Error while parsing ndjson file")
+      )
+   );
+}

--- a/src/silo/storage/column_group.cpp
+++ b/src/silo/storage/column_group.cpp
@@ -195,7 +195,7 @@ class ColumnValueInserter {
       const schema::ColumnIdentifier& column,
       const nlohmann::json& value
    ) {
-      auto column_value = value["metadata"][column.name];
+      auto column_value = value.at("metadata").at(column.name);
       if (column_value.is_null()) {
          columns.getColumns<ColumnType>().at(column.name).insertNull();
       } else {
@@ -210,7 +210,7 @@ void ColumnValueInserter::operator()<column::BoolColumnPartition>(
    const schema::ColumnIdentifier& column,
    const nlohmann::json& value
 ) {
-   auto column_value = value["metadata"][column.name];
+   auto column_value = value.at("metadata").at(column.name);
    if (column_value.is_null()) {
       columns.getColumns<column::BoolColumnPartition>().at(column.name).insertNull();
    } else {


### PR DESCRIPTION


### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

The bad (/missing) error messages bubbled yesterday when @corneliusroemer was debugging silo preprocessing in a loculus PR. This PR adds checks for proper error messaged in both the schema validation and the json parsing.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [X] The implemented feature is covered by an appropriate test.
