### PR TITLE
Poco throw if port in use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+## While this script is running, you will see a file `running_silo.flag` created in the current directory.
+## It will contain the PID of the running silo API server.
+## If something fails during execution, it might be necessary to kill the daemon using `make clean-api`.
+SILO_EXECUTABLE=./build/Debug/silo
+RUNNING_SILO_FLAG=running_silo.flag
+
+ci: format all-tests
+
+${SILO_EXECUTABLE}: $(shell find src -type f)
+	python3 build_with_conan.py
+
+output: ${SILO_EXECUTABLE}
+	${SILO_EXECUTABLE} preprocessing --database-config database_config.yaml --preprocessing-config testBaseData/test_preprocessing_config.yaml
+
+
+${RUNNING_SILO_FLAG}: ${SILO_EXECUTABLE} output
+	@{ \
+		if lsof -i :8081 > /dev/null 2>&1; then \
+			echo "Error: Port 8081 is already in use. Another SILO instance might already be running."; \
+			exit 1; \
+		fi; \
+		${SILO_EXECUTABLE} api & \
+		pid=$$!; \
+		echo "Waiting for silo (PID $$pid) to be ready..."; \
+		until curl -s -o /dev/null -w "%{http_code}" http://localhost:8081/info | grep -q "200"; do \
+			sleep 0.2; \
+		done; \
+		echo $$pid > ${RUNNING_SILO_FLAG}; \
+		echo "Silo is running with PID $$pid"; \
+	}
+
+e2e: ${RUNNING_SILO_FLAG}
+	trap 'make clean-api' EXIT; \
+	(cd endToEndTests && SILO_URL=localhost:8081 npm run test)
+
+test: ${SILO_EXECUTABLE}
+	build/Debug/silo_test --gtest_filter=* --gtest_color=no
+
+all-tests: test e2e
+
+format:
+	find src -iname '*.h' -o -iname '*.cpp' | xargs clang-format -i
+
+clean-api:
+	@if [ -f ${RUNNING_SILO_FLAG} ]; then \
+    		kill $$(cat ${RUNNING_SILO_FLAG}) || true; \
+    		rm -f ${RUNNING_SILO_FLAG}; \
+    	fi
+
+clean: clean-api
+	rm -rf output logs
+
+full-clean: clean
+	rm -rf build
+
+.PHONY:
+	full-clean clean clean-api e2e format all test all-tests format ci

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ or see [Conventional Commits](#conventional-commits) below.
 
 # Testing
 
+Before committing, run `make ci` to execute the formatter and all tests (unit and e2e) locally.
+
 ## Unit Tests
 
 For testing, we use the framework [gtest](http://google.github.io/googletest/)

--- a/src/silo/api/api.cpp
+++ b/src/silo/api/api.cpp
@@ -2,6 +2,7 @@
 
 #include <Poco/Net/HTTPServer.h>
 #include <Poco/Net/HTTPServerParams.h>
+#include <Poco/Net/NetException.h>
 #include <Poco/Net/ServerSocket.h>
 #include <spdlog/spdlog.h>
 
@@ -16,7 +17,16 @@ namespace silo::api {
 int Api::runApi(const silo::config::RuntimeConfig& runtime_config) {
    SPDLOG_INFO("Starting SILO API");
 
-   const Poco::Net::ServerSocket server_socket(runtime_config.api_options.port);
+   Poco::Net::SocketAddress address(runtime_config.api_options.port);
+
+   Poco::Net::ServerSocket server_socket;
+   try {
+      server_socket.bind(address);
+      server_socket.listen();
+   } catch (const Poco::Net::NetException& e) {
+      SPDLOG_ERROR("Failed to bind to port {}", runtime_config.api_options.port);
+      return EXIT_FAILURE;
+   }
 
    auto* const poco_parameter = new Poco::Net::HTTPServerParams;
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

In #841, we noticed that SILO did not error, when the port is already in use.

The issue was that Poco's `ServerSocket` constructor and `HTTPServer.start()` don't throw exceptions when the port is already in use - they fail silently. 

Instead explicitly binding the address in `ServerSocket` does throw an exception


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
