### PR TITLE
fix: use arrow::acero::SourceNode when constructing a TableScan

### DIFF
--- a/src/silo/config/runtime_config.cpp
+++ b/src/silo/config/runtime_config.cpp
@@ -50,6 +50,9 @@ ConfigKeyPath queryMaterializationOptionKey() {
 
 namespace silo::config {
 
+// arrow::acero::SourceNode reslices batches if they are bigger than 32768
+const uint32_t DEFAULT_ARROW_BATCH_SIZE = 32767;
+
 ConfigSpecification RuntimeConfig::getConfigSpecification() {
    return {
       .program_name = "silo api",
@@ -103,7 +106,7 @@ ConfigSpecification RuntimeConfig::getConfigSpecification() {
             ),
             ConfigAttributeSpecification::createWithDefault(
                queryMaterializationOptionKey(),
-               ConfigValue::fromUint32(50000),
+               ConfigValue::fromUint32(DEFAULT_ARROW_BATCH_SIZE),
                "If a query results in fewer rows, the query result will be collected \n"
                "in memory before sending it to the client. If it affects more rows, \n"
                "it will be streamed by constructing the result items lazily."

--- a/src/silo/query_engine/actions/aggregated.cpp
+++ b/src/silo/query_engine/actions/aggregated.cpp
@@ -144,12 +144,16 @@ arrow::Result<QueryPlan> Aggregated::makeAggregateWithGrouping(
    std::vector<schema::ColumnIdentifier> group_by_fields_identifiers =
       bindGroupByFields(table->schema, group_by_fields);
 
-   arrow::acero::ExecNode* node = arrow_plan->EmplaceNode<exec_node::TableScan>(
-      arrow_plan.get(),
-      group_by_fields_identifiers,
-      partition_filters,
-      table,
-      query_options.materialization_cutoff
+   arrow::acero::ExecNode* node;
+   ARROW_ASSIGN_OR_RAISE(
+      node,
+      exec_node::makeTableScan(
+         arrow_plan.get(),
+         group_by_fields_identifiers,
+         partition_filters,
+         table,
+         query_options.materialization_cutoff
+      )
    );
 
    auto count_options =

--- a/src/silo/query_engine/actions/simple_select_action.cpp
+++ b/src/silo/query_engine/actions/simple_select_action.cpp
@@ -35,12 +35,17 @@ arrow::Result<QueryPlan> SimpleSelectAction::toQueryPlanImpl(
    const config::QueryOptions& query_options
 ) const {
    ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
-   arrow::acero::ExecNode* node = arrow_plan->EmplaceNode<exec_node::TableScan>(
-      arrow_plan.get(),
-      getOutputSchema(table->schema),
-      partition_filters,
-      table,
-      query_options.materialization_cutoff
+
+   arrow::acero::ExecNode* node;
+   ARROW_ASSIGN_OR_RAISE(
+      node,
+      exec_node::makeTableScan(
+         arrow_plan.get(),
+         getOutputSchema(table->schema),
+         partition_filters,
+         table,
+         query_options.materialization_cutoff
+      )
    );
 
    ARROW_ASSIGN_OR_RAISE(node, addOrderingNodes(arrow_plan.get(), node, table->schema));

--- a/src/silo/query_engine/exec_node/ndjson_sink.cpp
+++ b/src/silo/query_engine/exec_node/ndjson_sink.cpp
@@ -92,7 +92,9 @@ arrow::Status createGenerator(
    arrow::acero::ExecNode* input,
    arrow::AsyncGenerator<std::optional<arrow::ExecBatch>>* generator
 ) {
-   arrow::acero::SinkNodeOptions options{generator};
+   arrow::acero::SinkNodeOptions options{
+      generator, arrow::acero::BackpressureOptions::DefaultBackpressure()
+   };
    ARROW_RETURN_NOT_OK(
       arrow::acero::MakeExecNode(std::string{"sink"}, plan, {input}, options).status()
    );

--- a/src/silo/query_engine/exec_node/table_scan.h
+++ b/src/silo/query_engine/exec_node/table_scan.h
@@ -3,12 +3,14 @@
 #include <vector>
 
 #include <arrow/acero/exec_plan.h>
+#include <arrow/acero/options.h>
 #include <arrow/builder.h>
 #include <arrow/record_batch.h>
 #include <spdlog/spdlog.h>
 #include <nlohmann/json_fwd.hpp>
 
 #include "silo/query_engine/bad_request.h"
+#include "silo/query_engine/batched_bitmap_reader.h"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/exec_node/arrow_util.h"
 #include "silo/storage/column/column_type_visitor.h"
@@ -16,34 +18,13 @@
 
 namespace silo::query_engine::exec_node {
 
-class TableScan : public arrow::acero::ExecNode {
-   std::map<schema::ColumnType, std::map<std::string, std::unique_ptr<arrow::ArrayBuilder>>>
+class ExecBatchBuilder {
+   std::map<schema::ColumnType, std::map<std::string, std::shared_ptr<arrow::ArrayBuilder>>>
       array_builders;
-
-   std::vector<CopyOnWriteBitmap> partition_filters;
-
    std::vector<silo::schema::ColumnIdentifier> output_fields;
-   const std::shared_ptr<const storage::Table> table;
-   size_t batch_size_cutoff;
-
-   // We need to tell the consumer how many batches we produced in total
-   size_t num_batches_produced = 0;
 
   public:
-   TableScan(
-      arrow::acero::ExecPlan* plan,
-      const std::vector<silo::schema::ColumnIdentifier>& columns,
-      std::vector<CopyOnWriteBitmap> partition_filters,
-      std::shared_ptr<const storage::Table> table,
-      size_t batch_size_cutoff
-   )
-       : arrow::acero::ExecNode(plan, {}, {}, columnsToInternalArrowSchema(columns)),
-         partition_filters(std::move(partition_filters)),
-         output_fields(columns),
-         table(table),
-         batch_size_cutoff(batch_size_cutoff) {
-      prepareOutputArrays();
-   }
+   ExecBatchBuilder(std::vector<silo::schema::ColumnIdentifier> output_fields);
 
    template <storage::column::Column Column>
    std::map<std::string, ArrowBuilder<Column>*> getColumnTypeArrayBuilders() {
@@ -54,49 +35,61 @@ class TableScan : public arrow::acero::ExecNode {
       return result;
    }
 
-  private:
-   void prepareOutputArrays();
-
-   const arrow::Ordering& ordering() const override { return arrow::Ordering::Implicit(); }
-
-   const char* kind_name() const override { return "TableScan"; }
-
-   arrow::Status InputReceived(ExecNode* input, arrow::ExecBatch batch) override {
-      SILO_PANIC("TableScan does not support having inputs.");
-   }
-
-   arrow::Status InputFinished(ExecNode* input, int total_batches) override {
-      SILO_PANIC("TableScan does not support having inputs.");
-   }
-
-   arrow::Status StartProducing() override {
-      SPDLOG_TRACE("TableScan::StartProducing");
-      try {
-         ARROW_RETURN_NOT_OK(produce());
-         return arrow::Status::OK();
-      } catch (const std::exception& exception) {
-         return arrow::Status::ExecutionError(exception.what());
-      }
-   }
-
-   arrow::Status StopProducingImpl() override {
-      SPDLOG_TRACE("TableScan::StopProducingImpl");
-      return arrow::Status::OK();
-   }
-
-   void PauseProducing(arrow::acero::ExecNode* output, int32_t counter) override {}
-
-   void ResumeProducing(arrow::acero::ExecNode* output, int32_t counter) override {}
-
-  private:
-   arrow::Status flushOutput();
-
-   arrow::Status produce();
-
    arrow::Status appendEntries(
       const storage::TablePartition& table_partition,
       const roaring::Roaring& row_ids
    );
+
+   arrow::Result<arrow::ExecBatch> finishBatch();
 };
+
+class TableScanGenerator {
+   ExecBatchBuilder exec_batch_builder;
+
+   std::vector<CopyOnWriteBitmap> partition_filters;
+
+   std::optional<BatchedBitmapReader> current_bitmap_reader;
+   size_t current_partition_idx;
+
+   const std::shared_ptr<const storage::Table> table;
+   size_t batch_size_cutoff;
+
+  public:
+   TableScanGenerator(
+      const std::vector<silo::schema::ColumnIdentifier>& columns,
+      std::vector<CopyOnWriteBitmap> partition_filters_,
+      std::shared_ptr<const storage::Table> table,
+      size_t batch_size_cutoff
+   )
+       : exec_batch_builder(columns),
+         partition_filters(std::move(partition_filters_)),
+         table(table),
+         batch_size_cutoff(batch_size_cutoff) {
+      current_partition_idx = 0;
+      if (!partition_filters.empty()) {
+         current_bitmap_reader = BatchedBitmapReader{partition_filters.front(), batch_size_cutoff};
+      }
+   }
+
+   arrow::Future<std::optional<arrow::ExecBatch>> operator()() {
+      SPDLOG_TRACE("TableScanGenerator::operator()");
+      try {
+         return produceNextBatch();
+      } catch (const std::exception& exception) {
+         return arrow::Status::ExecutionError(exception.what());
+      }
+   };
+
+  private:
+   arrow::Result<std::optional<arrow::ExecBatch>> produceNextBatch();
+};
+
+arrow::Result<arrow::acero::ExecNode*> makeTableScan(
+   arrow::acero::ExecPlan* plan,
+   const std::vector<silo::schema::ColumnIdentifier>& columns,
+   std::vector<CopyOnWriteBitmap> partition_filters_,
+   std::shared_ptr<const storage::Table> table,
+   size_t batch_size_cutoff
+);
 
 }  // namespace silo::query_engine::exec_node

--- a/src/silo/query_engine/query_plan.cpp
+++ b/src/silo/query_engine/query_plan.cpp
@@ -66,11 +66,15 @@ arrow::Status QueryPlan::executeAndWriteImpl(std::ostream* output_stream) {
 void QueryPlan::executeAndWrite(std::ostream* output_stream) {
    auto status = executeAndWriteImpl(output_stream);
    if (!status.ok()) {
-      throw std::runtime_error(fmt::format(
-         "Internal server error. Please notify developers. SILO constructed an invalid arrow plan. "
-         "It is likely that more user-input validation needs to be added: {}",
-         status.ToString()
-      ));
+      if (status.IsIOError()) {
+         SPDLOG_ERROR("The request {} encountered an IO Error when sending the response");
+      } else {
+         throw std::runtime_error(fmt::format(
+            "Internal server error. Please notify developers. SILO likely constructed an invalid "
+            "arrow plan and more user-input validation needs to be added: {}",
+            status.ToString()
+         ));
+      }
    }
 }
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #862

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

The problem was that the `StartProducing` method was blocking. This means that while the results were already streamed through the execution plan (which is what I validated manually), the actual http response only started sending after `TableScan::StartProducing` terminated (see `src/silo/query_engine/query_plan.cpp:29` for the precise blocking line).

This means that memory consumption skyrocketed when requesting a large number of sequences. (Up until 1-2 million this was still not too noticable)

This fix makes use of a custom generator object in a generic `SinkNode` instead of rolling our own `TableScan` exec node. This is preferrable, as we do not need to concern ourselves with the following two details:
- Backpressure forwarding: The generic sink node already has backpressure forwarding implemented. Therefore, the SourceNode will stop producing batches, when they are not consumed fast enough downstream
- Async execution: Our generator will be called asynchronously by the generic node

The arrow::acero::SourceNode reslices batches if they are bigger than 32768. We want to avoid this and therefore change the default batch size to this value for now. While it is possible to pass more config options to the arrow nodes, this should be done in a separate commit

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
