### PR TITLE
fix(benchmarking): only depend on WisePulse for running, not the data

### DIFF
--- a/benchmarking/Makefile
+++ b/benchmarking/Makefile
@@ -86,7 +86,8 @@ dependencies: $(API_QUERY) $(WISEPULSE)
 
 # ---- Sorting input -----------------------------------------------------------
 
-$(BENCHMARK_DATASET_DIR)/sorted_input_file.ndjson.zst: $(BENCHMARK_DATASET_DIR)/input_file.ndjson.zst $(WISEPULSE)
+$(BENCHMARK_DATASET_DIR)/sorted_input_file.ndjson.zst: $(BENCHMARK_DATASET_DIR)/input_file.ndjson.zst
+	make $(WISEPULSE)
 	rm -rf sorted_chunks merger_tmp 
 	zstdcat $(BENCHMARK_DATASET_DIR)/input_file.ndjson.zst \
 	    | $(WISEPULSE_BIN)/split_into_sorted_chunks --output-path sorted_chunks --chunk-size 100000 --sort-field date \


### PR DESCRIPTION
The resulting data doesn't depend on the data in
WisePulse/target/release/split_into_sorted_chunks--it should not be recreated just because the modification time on that executable changed!

This led to unnecessary CPU investment / latency for jobs.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
