### PR TITLE
benchmarking: hack to save the benchmarking output file from the preprocessing phase

### DIFF
--- a/benchmarking/Makefile
+++ b/benchmarking/Makefile
@@ -108,6 +108,7 @@ $(SILO):
 
 $(PREPROCESSING_STAMP): $(SILO) $(INPUT_FILE)
 	$(SILO) preprocessing --ndjson-input-filename $(INPUT_FILE) --output-directory $(OUTPUT_DIR)
+	mv -f $(EVOBENCH_LOG) $(EVOBENCH_LOG)-preprocessing.log
 	touch $(PREPROCESSING_STAMP)
 
 .silo.pid: $(PREPROCESSING_STAMP)

--- a/benchmarking/Makefile
+++ b/benchmarking/Makefile
@@ -107,8 +107,7 @@ $(SILO):
 	bin/build-silo
 
 $(PREPROCESSING_STAMP): $(SILO) $(INPUT_FILE)
-	$(SILO) preprocessing --ndjson-input-filename $(INPUT_FILE) \
-	             --output-directory $(OUTPUT_DIR)
+	$(SILO) preprocessing --ndjson-input-filename $(INPUT_FILE) --output-directory $(OUTPUT_DIR)
 	touch $(PREPROCESSING_STAMP)
 
 .silo.pid: $(PREPROCESSING_STAMP)


### PR DESCRIPTION

### Summary

Pending a more proper new feature in evobench-run (https://github.com/GenSpectrum/evobench/issues/20), this allows us to save the evobench.log file from the preprocessing phase (if it ran).



## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted or there is an issue to do so.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
