### PR TITLE
fix(silo): correctly deduplicate requested fields

### DIFF
--- a/src/silo/query_engine/actions/action.cpp
+++ b/src/silo/query_engine/actions/action.cpp
@@ -139,6 +139,19 @@ std::optional<uint32_t> parseRandomizeSeed(const nlohmann::json& json) {
    return json["randomize"]["seed"].get<uint32_t>();
 }
 
+std::vector<std::string> Action::deduplicateOrderPreserving(const std::vector<std::string>& fields
+) {
+   std::vector<std::string> unique_fields;
+   std::unordered_set<std::string> seen;
+
+   for (const auto& field : fields) {
+      if (seen.insert(field).second) {
+         unique_fields.push_back(field);
+      }
+   }
+   return unique_fields;
+}
+
 // NOLINTNEXTLINE(readability-identifier-naming)
 void from_json(const nlohmann::json& json, std::unique_ptr<Action>& action) {
    CHECK_SILO_QUERY(json.contains("type"), "The field 'type' is required in any action");

--- a/src/silo/query_engine/actions/action.h
+++ b/src/silo/query_engine/actions/action.h
@@ -61,6 +61,9 @@ class Action {
       const silo::schema::TableSchema& table_schema
    ) const;
 
+   static std::vector<std::string> deduplicateOrderPreserving(const std::vector<std::string>& fields
+   );
+
   protected:
    arrow::Result<arrow::acero::ExecNode*> addLimitAndOffsetNode(
       arrow::acero::ExecPlan* arrow_plan,

--- a/src/silo/query_engine/actions/aggregated.h
+++ b/src/silo/query_engine/actions/aggregated.h
@@ -18,7 +18,7 @@ struct GroupByField {
 
 class Aggregated : public Action {
   public:
-   Aggregated(std::vector<GroupByField> group_by_fields);
+   Aggregated(std::vector<std::string> group_by_fields);
 
    std::vector<schema::ColumnIdentifier> getOutputSchema(const schema::TableSchema& table_schema
    ) const override;
@@ -46,9 +46,6 @@ class Aggregated : public Action {
       const config::QueryOptions& query_options
    ) const;
 };
-
-// NOLINTNEXTLINE(readability-identifier-naming)
-void from_json(const nlohmann::json& json, GroupByField& action);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 void from_json(const nlohmann::json& json, std::unique_ptr<Aggregated>& action);

--- a/src/silo/query_engine/actions/aggregated.test.cpp
+++ b/src/silo/query_engine/actions/aggregated.test.cpp
@@ -313,6 +313,34 @@ const QueryTestScenario AGGREGATE_NULLABLE = {
    )
 };
 
+const QueryTestScenario DUPLICATE_AGGREGATE = {
+   .name = "DUPLICATE_AGGREGATE",
+   .query = nlohmann::json::parse(
+      R"(
+{
+  "action": {
+    "type": "Aggregated",
+    "groupByFields": [
+      "age", "age"
+    ],
+    "orderByFields": [
+      "count", {"field": "age", "order": "descending"}
+    ]
+  },
+  "filterExpression": {
+    "type": "True"
+  }
+})"
+   ),
+   .expected_query_result = nlohmann::json::parse(
+      R"(
+[{"age":19,"count":1},
+{"age":13,"count":1},
+{"age":7,"count":1},
+{"age":null,"count":3}])"
+   )
+};
+
 const QueryTestScenario INVALID_GROUP_BY_FIELD_OBJECT = {
    .name = "INVALID_GROUP_BY_FIELD_OBJECT",
    .query = nlohmann::json::parse(
@@ -404,6 +432,7 @@ QUERY_TEST(
       AGGREGATE_UNIQUE,
       AGGREGATE_ONE,
       AGGREGATE_NULLABLE,
+      DUPLICATE_AGGREGATE,
       INVALID_GROUP_BY_FIELD_OBJECT,
       INVALID_GROUP_BY_FIELDS,
       INVALID_ORDER_BY_FIELD_OBJECT,

--- a/src/silo/query_engine/actions/details.cpp
+++ b/src/silo/query_engine/actions/details.cpp
@@ -44,7 +44,7 @@ std::vector<schema::ColumnIdentifier> Details::getOutputSchema(
 // NOLINTNEXTLINE(readability-identifier-naming)
 void from_json(const nlohmann::json& json, std::unique_ptr<Details>& action) {
    const std::vector<std::string> fields = json.value("fields", std::vector<std::string>());
-   action = std::make_unique<Details>(fields);
+   action = std::make_unique<Details>(Action::deduplicateOrderPreserving(fields));
 }
 
 }  // namespace silo::query_engine::actions

--- a/src/silo/query_engine/actions/details.test.cpp
+++ b/src/silo/query_engine/actions/details.test.cpp
@@ -206,6 +206,36 @@ const QueryTestScenario ALL_DATES_AND_COUNTRIES = {
    )
 };
 
+const QueryTestScenario DUPLICATE_COUNTRY = {
+   .name = "DUPLICATE_COUNTRY",
+   .query = nlohmann::json::parse(
+      R"(
+{
+  "action": {
+    "type": "Details",
+    "fields": [
+      "country", "country"
+    ],
+    "orderByFields": [
+      {"field": "country", "order": "descending"}
+    ]
+  },
+  "filterExpression": {
+    "type": "True"
+  }
+})"
+   ),
+   .expected_query_result = nlohmann::json::parse(
+      R"(
+[{"country":"Switzerland"},
+{"country":"Switzerland"},
+{"country":"Switzerland"},
+{"country":"Switzerland"},
+{"country":"Germany"},
+{"country":"Germany"}])"
+   )
+};
+
 const QueryTestScenario LIMIT = {
    .name = "LIMIT",
    .query = nlohmann::json::parse(
@@ -420,6 +450,7 @@ QUERY_TEST(
       LIMIT_OFFSET,
       ALL_DATES,
       ALL_DATES_AND_COUNTRIES,
+      DUPLICATE_COUNTRY,
       LIMIT,
       LIMIT_0,
       LIMIT_LARGE,

--- a/src/silo/query_engine/actions/fasta.cpp
+++ b/src/silo/query_engine/actions/fasta.cpp
@@ -92,7 +92,10 @@ void from_json(const nlohmann::json& json, std::unique_ptr<Fasta>& action) {
          additional_fields.emplace_back(child.get<std::string>());
       }
    }
-   action = std::make_unique<Fasta>(std::move(sequence_names), std::move(additional_fields));
+   action = std::make_unique<Fasta>(
+      Action::deduplicateOrderPreserving(sequence_names),
+      Action::deduplicateOrderPreserving(additional_fields)
+   );
 }
 
 }  // namespace silo::query_engine::actions

--- a/src/silo/query_engine/actions/fasta_aligned.cpp
+++ b/src/silo/query_engine/actions/fasta_aligned.cpp
@@ -93,7 +93,10 @@ void from_json(const nlohmann::json& json, std::unique_ptr<FastaAligned>& action
          additional_fields.emplace_back(child.get<std::string>());
       }
    }
-   action = std::make_unique<FastaAligned>(std::move(sequence_names), std::move(additional_fields));
+   action = std::make_unique<FastaAligned>(
+      Action::deduplicateOrderPreserving(sequence_names),
+      Action::deduplicateOrderPreserving(additional_fields)
+   );
 }
 
 }  // namespace silo::query_engine::actions

--- a/src/silo/query_engine/actions/fasta_aligned.test.cpp
+++ b/src/silo/query_engine/actions/fasta_aligned.test.cpp
@@ -138,6 +138,40 @@ const QueryTestScenario FASTA_ALIGNED_ADDITIONAL_HEADER = {
    )
 };
 
+const QueryTestScenario DUPLICATE_FIELDS = {
+   .name = "DUPLICATE_FIELDS",
+   .query = nlohmann::json::parse(
+      R"(
+{
+  "action": {
+    "type": "FastaAligned",
+    "sequenceNames": [
+      "segment1",
+      "segment1"
+    ],
+    "orderByFields": [
+      "primaryKey"
+    ],
+    "additionalFields": [
+      "country",
+      "country"
+    ]
+  },
+  "filterExpression": {
+    "type": "True"
+  }
+}
+)"
+   ),
+   .expected_query_result = nlohmann::json::parse(
+      R"(
+[{"country":"Switzerland","primaryKey":"id_0","segment1":"ATGCN"},
+{"country":"Switzerland","primaryKey":"id_1","segment1":"ATGCN"},
+{"country":"Switzerland","primaryKey":"id_2","segment1":"NNNNN"},
+{"country":"Switzerland","primaryKey":"id_3","segment1":"CATTT"}])"
+   )
+};
+
 const QueryTestScenario FASTA_ALIGNED_EXPLICIT_PRIMARY_KEY = {
    .name = "FASTA_ALIGNED_EXPLICIT_PRIMARY_KEY",
    .query = nlohmann::json::parse(
@@ -435,6 +469,7 @@ QUERY_TEST(
       FASTA_ALIGNED,
       FASTA_ALIGNED_ADDITIONAL_HEADER,
       FASTA_ALIGNED_DUPLICATE_HEADER,
+      DUPLICATE_FIELDS,
       FASTA_ALIGNED_EXPLICIT_PRIMARY_KEY,
       FASTA_ALIGNED_DESCENDING,
       FASTA_ALIGNED_SUBSET,

--- a/src/silo/test/fasta.test.cpp
+++ b/src/silo/test/fasta.test.cpp
@@ -185,6 +185,41 @@ const QueryTestScenario DOWNLOAD_ALL_DATA = {
    )
 };
 
+const QueryTestScenario DUPLICATE_FIELDS = {
+   .name = "DUPLICATE_FIELDS",
+   .query = nlohmann::json::parse(R"(
+{
+  "action": {
+    "type": "Fasta",
+    "orderByFields": [
+      "primaryKey"
+    ],
+    "sequenceNames": [
+      "unaligned_segment1",
+      "unaligned_segment2",
+      "unaligned_segment1"
+    ],
+    "additionalFields": [
+      "date",
+      "date"
+    ]
+  },
+  "filterExpression": {
+    "type": "True"
+  }
+}
+)"),
+   .expected_query_result = nlohmann::json::parse(R"(
+[{"date":"2024-08-05","primaryKey":"1","unaligned_segment1":null,"unaligned_segment2":"A"},
+{"date":"2024-08-03","primaryKey":"2","unaligned_segment1":null,"unaligned_segment2":null},
+{"date":"2024-08-02","primaryKey":"3","unaligned_segment1":null,"unaligned_segment2":"AA"},
+{"date":"2024-08-01","primaryKey":"bothSegments","unaligned_segment1":"A","unaligned_segment2":"G"},
+{"date":"2024-08-08","primaryKey":"noSegment","unaligned_segment1":null,"unaligned_segment2":null},
+{"date":"2024-08-03","primaryKey":"onlySegment1","unaligned_segment1":"T","unaligned_segment2":null},
+{"date":"2024-08-02","primaryKey":"onlySegment2","unaligned_segment1":null,"unaligned_segment2":"T"}])"
+   )
+};
+
 const QueryTestScenario ORDER_BY_NOT_IN_OUTPUT = {
    .name = "ORDER_BY_NOT_IN_OUTPUT",
    .query = nlohmann::json::parse(R"(
@@ -261,6 +296,7 @@ QUERY_TEST(
       DOWNLOAD_ALL_SEQUENCES_SCENARIO,
       DOWNLOAD_ALL_DATA,
       ORDER_BY_NOT_IN_OUTPUT,
-      ORDER_BY_ADDITIONAL_FIELD
+      ORDER_BY_ADDITIONAL_FIELD,
+      DUPLICATE_FIELDS
    )
 );


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #898

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

We duplicate the `fields`, `sequenceNames`, `additionalFields` and `groupByFields` after parsing them.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [X] The implemented feature is covered by an appropriate test.
