### PR TITLE
benchmarking: output dir dependency fixes

### DIFF
--- a/benchmarking/Makefile
+++ b/benchmarking/Makefile
@@ -1,6 +1,13 @@
 
 # Required env vars:
 
+# Added by evobench-run, and we rely on it
+ifeq ($(COMMIT_ID),)
+$(error "COMMIT_ID must be set")
+endif
+
+# Our custom parameters:
+
 # The name of a subfolder of `~/silo-benchmark-datasets/` where the
 # dataset is stored
 ifeq ($(DATASET),)
@@ -10,11 +17,11 @@ endif
 # Should sorted input be used?
 ifeq ($(SORTED),0)
 INPUT_FILE = $(BENCHMARK_DATASET_DIR)/input_file.ndjson.zst
-OUTPUT_DIR = $(DATASET)-output
+OUTPUT_DIR = $(DATASET)-$(COMMIT_ID)-output
 else ifeq ($(SORTED),1)
 # OK to write back into the $(BENCHMARK_DATASET_DIR)?
 INPUT_FILE = $(BENCHMARK_DATASET_DIR)/sorted_input_file.ndjson.zst
-OUTPUT_DIR = $(DATASET)-sorted_output
+OUTPUT_DIR = $(DATASET)-$(COMMIT_ID)-sorted_output
 else
 $(error "SORTED must be either 0 or 1, got '$(SORTED)'")
 endif
@@ -37,13 +44,6 @@ endif
 # Passed to api-query
 ifeq ($(REPEAT),)
 $(error "REPEAT must be a natural number, missing")
-endif
-
-
-# ---
-# Added by evobench-run, and we rely on it
-ifeq ($(COMMIT_ID),)
-$(error "COMMIT_ID must be set")
 endif
 
 

--- a/benchmarking/Makefile
+++ b/benchmarking/Makefile
@@ -16,11 +16,11 @@ endif
 
 # Should sorted input be used?
 ifeq ($(SORTED),0)
-INPUT_FILE = $(BENCHMARK_DATASET_DIR)/input_file.ndjson.zst
+INPUT_FILE = $(DATASET_DIR)/input_file.ndjson.zst
 OUTPUT_DIR = $(DATASET)-$(COMMIT_ID)-output
 else ifeq ($(SORTED),1)
-# OK to write back into the $(BENCHMARK_DATASET_DIR)?
-INPUT_FILE = $(BENCHMARK_DATASET_DIR)/sorted_input_file.ndjson.zst
+# OK to write back into the $(DATASET_DIR)?
+INPUT_FILE = $(DATASET_DIR)/sorted_input_file.ndjson.zst
 OUTPUT_DIR = $(DATASET)-$(COMMIT_ID)-sorted_output
 else
 $(error "SORTED must be either 0 or 1, got '$(SORTED)'")
@@ -49,11 +49,11 @@ endif
 
 # ---- General -----------------------------------------------------------------
 
-BENCHMARK_DATASET_DIR=$(HOME)/silo-benchmark-datasets/$(DATASET)
+DATASET_DIR=$(HOME)/silo-benchmark-datasets/$(DATASET)
 
-SILO_PREPROCESSING_CONFIG=$(BENCHMARK_DATASET_DIR)/preprocessing_config.yaml
+SILO_PREPROCESSING_CONFIG=$(DATASET_DIR)/preprocessing_config.yaml
 export SILO_PREPROCESSING_CONFIG
-SILO_INPUT_DIRECTORY=$(BENCHMARK_DATASET_DIR)
+SILO_INPUT_DIRECTORY=$(DATASET_DIR)
 export SILO_INPUT_DIRECTORY
 
 all: bench
@@ -101,14 +101,14 @@ dependencies: $(API_QUERY) $(WISEPULSE)
 
 # ---- Sorting input -----------------------------------------------------------
 
-$(BENCHMARK_DATASET_DIR)/sorted_input_file.ndjson.zst: $(BENCHMARK_DATASET_DIR)/input_file.ndjson.zst
+$(DATASET_DIR)/sorted_input_file.ndjson.zst: $(DATASET_DIR)/input_file.ndjson.zst
 	make $(WISEPULSE)
 	rm -rf sorted_chunks merger_tmp 
-	zstdcat $(BENCHMARK_DATASET_DIR)/input_file.ndjson.zst \
+	zstdcat $(DATASET_DIR)/input_file.ndjson.zst \
 	    | $(WISEPULSE_BIN)/split_into_sorted_chunks --output-path sorted_chunks --chunk-size 100000 --sort-field date \
 	    | $(WISEPULSE_BIN)/merge_sorted_chunks --tmp-directory merger_tmp --sort-field date \
-	    | zstd > $(BENCHMARK_DATASET_DIR)/sorted_input_file.ndjson.zst.tmp
-	mv $(BENCHMARK_DATASET_DIR)/sorted_input_file.ndjson.zst.tmp $(BENCHMARK_DATASET_DIR)/sorted_input_file.ndjson.zst
+	    | zstd > $(DATASET_DIR)/sorted_input_file.ndjson.zst.tmp
+	mv $(DATASET_DIR)/sorted_input_file.ndjson.zst.tmp $(DATASET_DIR)/sorted_input_file.ndjson.zst
 
 # ---- Running silo -----------------------------------------------------------
 
@@ -134,10 +134,10 @@ $(PREPROCESSING_STAMP): $(SILO) $(INPUT_FILE)
 	bin/stop-silo
 	touch .silo.stopped
 
-bench: $(BENCHMARK_DATASET_DIR)/silo_queries.ndjson $(API_QUERY) .silo.stopped
+bench: $(DATASET_DIR)/silo_queries.ndjson $(API_QUERY) .silo.stopped
 	@echo "running benchmark"
 	make .silo.pid
-	$(API_QUERY) iter $(API_QUERY_OPTS) --repeat $(REPEAT) $(BENCHMARK_DATASET_DIR)/silo_queries.ndjson --drop --concurrency $(CONCURRENCY)
+	$(API_QUERY) iter $(API_QUERY_OPTS) --repeat $(REPEAT) $(DATASET_DIR)/silo_queries.ndjson --drop --concurrency $(CONCURRENCY)
 	make .silo.stopped
 
 clean:

--- a/benchmarking/Makefile
+++ b/benchmarking/Makefile
@@ -1,14 +1,20 @@
 
 # Required env vars:
 
+# The name of a subfolder of `~/silo-benchmark-datasets/` where the
+# dataset is stored
+ifeq ($(DATASET),)
+$(error "DATASET must be a subfolder name, got '$(DATASET)'")
+endif
+
 # Should sorted input be used?
 ifeq ($(SORTED),0)
 INPUT_FILE = $(BENCHMARK_DATASET_DIR)/input_file.ndjson.zst
-OUTPUT_DIR = output
+OUTPUT_DIR = $(DATASET)-output
 else ifeq ($(SORTED),1)
 # OK to write back into the $(BENCHMARK_DATASET_DIR)?
 INPUT_FILE = $(BENCHMARK_DATASET_DIR)/sorted_input_file.ndjson.zst
-OUTPUT_DIR = sorted_output
+OUTPUT_DIR = $(DATASET)-sorted_output
 else
 $(error "SORTED must be either 0 or 1, got '$(SORTED)'")
 endif
@@ -31,13 +37,6 @@ endif
 # Passed to api-query
 ifeq ($(REPEAT),)
 $(error "REPEAT must be a natural number, missing")
-endif
-
-
-# The name of a subfolder of `~/silo-benchmark-datasets/` where the
-# dataset is stored
-ifeq ($(DATASET),)
-$(error "DATASET must be a subfolder name, got '$(DATASET)'")
 endif
 
 
@@ -142,7 +141,7 @@ bench: $(BENCHMARK_DATASET_DIR)/silo_queries.ndjson $(API_QUERY) .silo.stopped
 	make .silo.stopped
 
 clean:
-	rm -rf output sorted_output logs sorted_chunks merger_tmp
+	rm -rf *-output/ *-sorted_output/ logs sorted_chunks merger_tmp
 
 clean-fully: clean
 	rm -rf ../build


### PR DESCRIPTION


### Summary

There were 2 missing pieces of information in the preprocessing output directory names to safely separate them between working directory re-uses.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted or there is an issue to do so.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
