### PR TITLE
feat(silo): add an endpoint to export a newick of the nodes in the filter

### DIFF
--- a/documentation/phylogenetic_queries.md
+++ b/documentation/phylogenetic_queries.md
@@ -49,3 +49,28 @@ The result of such a query is a ndjson with a single row, where `missingFromTree
   "missingFromTree": "MISSING_NODE1,MISSING_NODE2"
 }
 ```
+
+### Subtree
+
+```json
+"action": {
+  "type": "Subtree",
+  "columnName": "COLUMN_NAME",
+  "printNodesNotInTree": true,
+  "contractUnaryNodes": true
+}
+```
+
+Returns a subtree of all sequences in the filter it is applied to in newick format (`.nwk`). The subtree is produced from the phylogenetic tree, leaf nodes are only shown in the newick if they were included in the filter. Internal nodes are included if they are part of the subtree created from the leaves in the filter, where the root is the most recent common ancestor that includes all nodes. To contract unary internal nodes in the output newick set `contractUnaryNodes` to true.
+
+If sequences included in the filter do not exist in the phylogenetic tree they are ignored and the count of such missing sequences is added as a field `missingNodeCount`. Additionally, if desired, a list of all missing nodes can be returned as a comma-separated list by setting `printNodesNotInTree` to true (default is false). Note in the query shown above `COLUMN_NAME` must correspond to the name of a STRING column with the `phyloTreeNodeIdentifier` and a corresponding tree.
+
+The result of such a query is a ndjson with a single row. `subtreeNewick` is a valid nwk string, `missingFromTree` is only added if `printNodesNotInTree` is set to true:
+
+```json
+{
+  "subtreeNewick": "SUBTREE_NEWICK",
+  "missingNodeCount": "INT",
+  "missingFromTree": "MISSING_NODE1,MISSING_NODE2"
+}
+```

--- a/documentation/phylogenetic_queries.md
+++ b/documentation/phylogenetic_queries.md
@@ -50,11 +50,11 @@ The result of such a query is a ndjson with a single row, where `missingFromTree
 }
 ```
 
-### Subtree
+### PhyloSubtree
 
 ```json
 "action": {
-  "type": "Subtree",
+  "type": "PhyloSubtree",
   "columnName": "COLUMN_NAME",
   "printNodesNotInTree": true,
   "contractUnaryNodes": true

--- a/documentation/phylogenetic_queries.md
+++ b/documentation/phylogenetic_queries.md
@@ -61,7 +61,7 @@ The result of such a query is a ndjson with a single row, where `missingFromTree
 }
 ```
 
-Returns a subtree of all sequences in the filter it is applied to in newick format (`.nwk`). The subtree is produced from the phylogenetic tree, leaf nodes are only shown in the newick if they were included in the filter. Internal nodes are included if they are part of the subtree created from the leaves in the filter, where the root is the most recent common ancestor that includes all nodes. To contract unary internal nodes in the output newick set `contractUnaryNodes` to true.
+Returns a subtree of all sequences in the filter it is applied to in newick format (`.nwk`). The subtree is produced from the phylogenetic tree, leaf nodes are only shown in the newick if they were included in the filter. Internal nodes are included if they are part of the subtree created from the leaves in the filter, where the root is the most recent common ancestor that includes all nodes. By default unary nodes are contracted, to not contract unary nodes (i.e. to better preserve the structure of the subtree) set `contractUnaryNodes` to false.
 
 If sequences included in the filter do not exist in the phylogenetic tree they are ignored and the count of such missing sequences is added as a field `missingNodeCount`. Additionally, if desired, a list of all missing nodes can be returned as a comma-separated list by setting `printNodesNotInTree` to true (default is false). Note in the query shown above `COLUMN_NAME` must correspond to the name of a STRING column with the `phyloTreeNodeIdentifier` and a corresponding tree.
 

--- a/endToEndTests/test/invalidQueries/MostRecentCommonAncestor_invalidColumn.json
+++ b/endToEndTests/test/invalidQueries/MostRecentCommonAncestor_invalidColumn.json
@@ -15,6 +15,6 @@
   },
   "expectedError": {
     "error": "Bad request",
-    "message": "MRCA action cannot be called on Column 'country' as it does not have a phylogenetic tree associated with it"
+    "message": "MostRecentCommonAncestor action cannot be called on Column 'country' as it does not have a phylogenetic tree associated with it"
   }
 }

--- a/endToEndTests/test/invalidQueries/Subtree_invalidColumn.json
+++ b/endToEndTests/test/invalidQueries/Subtree_invalidColumn.json
@@ -1,0 +1,20 @@
+{
+  "testCaseName": "Subtree action on column not labelled as phyloTreeNodeIdentifier",
+  "query": {
+    "action": {
+      "type": "Subtree",
+      "columnName": "country",
+      "orderByFields": ["subtreeNewick"],
+      "printNodesNotInTree": true
+    },
+    "filterExpression": {
+      "type": "StringEquals",
+      "column": "country",
+      "value": "Switzerland"
+    }
+  },
+  "expectedError": {
+    "error": "Bad request",
+    "message": "Subtree action cannot be called on Column 'country' as it does not have a phylogenetic tree associated with it"
+  }
+}

--- a/endToEndTests/test/invalidQueries/Subtree_invalidColumn.json
+++ b/endToEndTests/test/invalidQueries/Subtree_invalidColumn.json
@@ -1,8 +1,8 @@
 {
-  "testCaseName": "Subtree action on column not labelled as phyloTreeNodeIdentifier",
+  "testCaseName": "PhyloSubtree action on column not labelled as phyloTreeNodeIdentifier",
   "query": {
     "action": {
-      "type": "Subtree",
+      "type": "PhyloSubtree",
       "columnName": "country",
       "orderByFields": ["subtreeNewick"],
       "printNodesNotInTree": true
@@ -15,6 +15,6 @@
   },
   "expectedError": {
     "error": "Bad request",
-    "message": "Subtree action cannot be called on Column 'country' as it does not have a phylogenetic tree associated with it"
+    "message": "PhyloSubtree action cannot be called on Column 'country' as it does not have a phylogenetic tree associated with it"
   }
 }

--- a/endToEndTests/test/queries/Subtree_onlyMissingNodes.json
+++ b/endToEndTests/test/queries/Subtree_onlyMissingNodes.json
@@ -1,8 +1,8 @@
 {
-  "testCaseName": "Subtree query returns correct nwk with only missing nodes",
+  "testCaseName": "PhyloSubtree query returns correct nwk with only missing nodes",
   "query": {
     "action": {
-      "type": "Subtree",
+      "type": "PhyloSubtree",
       "columnName": "gisaid_epi_isl",
       "orderByFields": ["subtreeNewick"],
       "printNodesNotInTree": true

--- a/endToEndTests/test/queries/Subtree_onlyMissingNodes.json
+++ b/endToEndTests/test/queries/Subtree_onlyMissingNodes.json
@@ -1,0 +1,33 @@
+{
+  "testCaseName": "Subtree query returns correct nwk with only missing nodes",
+  "query": {
+    "action": {
+      "type": "Subtree",
+      "columnName": "gisaid_epi_isl",
+      "orderByFields": ["subtreeNewick"],
+      "printNodesNotInTree": true
+    },
+    "filterExpression": {
+      "type": "Or",
+      "children": [
+        {
+          "type": "StringEquals",
+          "column": "gisaid_epi_isl",
+          "value": "EPI_ISL_1001493"
+        },
+        {
+          "type": "StringEquals",
+          "column": "gisaid_epi_isl",
+          "value": "EPI_ISL_1747752"
+        }
+      ]
+    }
+  },
+  "expectedQueryResult": [
+    {
+      "subtreeNewick": "",
+      "missingNodeCount": 2,
+      "missingFromTree": "EPI_ISL_1001493,EPI_ISL_1747752"
+    }
+  ]
+}

--- a/endToEndTests/test/queries/Subtree_simpleQuery.json
+++ b/endToEndTests/test/queries/Subtree_simpleQuery.json
@@ -1,0 +1,31 @@
+{
+  "testCaseName": "Subtree query returns correct nwk",
+  "query": {
+    "action": {
+      "type": "Subtree",
+      "columnName": "gisaid_epi_isl",
+      "orderByFields": ["subtreeNewick"]
+    },
+    "filterExpression": {
+      "type": "Or",
+      "children": [
+        {
+          "type": "StringEquals",
+          "column": "gisaid_epi_isl",
+          "value": "EPI_ISL_3247294"
+        },
+        {
+          "type": "StringEquals",
+          "column": "gisaid_epi_isl",
+          "value": "EPI_ISL_3465732"
+        }
+      ]
+    }
+  },
+  "expectedQueryResult": [
+    {
+      "subtreeNewick": "((EPI_ISL_3247294)NODE_0000077,((((EPI_ISL_3465732)NODE_0000082)NODE_0000081)NODE_0000080)NODE_0000079)NODE_0000076;",
+      "missingNodeCount": 0
+    }
+  ]
+}

--- a/endToEndTests/test/queries/Subtree_simpleQuery.json
+++ b/endToEndTests/test/queries/Subtree_simpleQuery.json
@@ -4,7 +4,8 @@
     "action": {
       "type": "Subtree",
       "columnName": "gisaid_epi_isl",
-      "orderByFields": ["subtreeNewick"]
+      "orderByFields": ["subtreeNewick"],
+      "contractUnaryNodes": false
     },
     "filterExpression": {
       "type": "Or",

--- a/endToEndTests/test/queries/Subtree_simpleQuery.json
+++ b/endToEndTests/test/queries/Subtree_simpleQuery.json
@@ -1,8 +1,8 @@
 {
-  "testCaseName": "Subtree query returns correct nwk",
+  "testCaseName": "PhyloSubtree query returns correct nwk",
   "query": {
     "action": {
-      "type": "Subtree",
+      "type": "PhyloSubtree",
       "columnName": "gisaid_epi_isl",
       "orderByFields": ["subtreeNewick"],
       "contractUnaryNodes": false

--- a/endToEndTests/test/queries/Subtree_simple_query_without_unary_nodes.json
+++ b/endToEndTests/test/queries/Subtree_simple_query_without_unary_nodes.json
@@ -1,8 +1,8 @@
 {
-  "testCaseName": "Subtree query returns correct nwk without unary nodes",
+  "testCaseName": "PhyloSubtree query returns correct nwk without unary nodes",
   "query": {
     "action": {
-      "type": "Subtree",
+      "type": "PhyloSubtree",
       "columnName": "gisaid_epi_isl",
       "orderByFields": ["subtreeNewick"],
       "contractUnaryNodes": true

--- a/endToEndTests/test/queries/Subtree_simple_query_without_unary_nodes.json
+++ b/endToEndTests/test/queries/Subtree_simple_query_without_unary_nodes.json
@@ -1,0 +1,32 @@
+{
+  "testCaseName": "Subtree query returns correct nwk without unary nodes",
+  "query": {
+    "action": {
+      "type": "Subtree",
+      "columnName": "gisaid_epi_isl",
+      "orderByFields": ["subtreeNewick"],
+      "contractUnaryNodes": true
+    },
+    "filterExpression": {
+      "type": "Or",
+      "children": [
+        {
+          "type": "StringEquals",
+          "column": "gisaid_epi_isl",
+          "value": "EPI_ISL_3247294"
+        },
+        {
+          "type": "StringEquals",
+          "column": "gisaid_epi_isl",
+          "value": "EPI_ISL_3465732"
+        }
+      ]
+    }
+  },
+  "expectedQueryResult": [
+    {
+      "subtreeNewick": "(EPI_ISL_3247294,EPI_ISL_3465732)NODE_0000076;",
+      "missingNodeCount": 0
+    }
+  ]
+}

--- a/endToEndTests/test/queries/Subtree_withMissingNode.json
+++ b/endToEndTests/test/queries/Subtree_withMissingNode.json
@@ -1,8 +1,8 @@
 {
-  "testCaseName": "Subtree query returns correct nwk with missingNode",
+  "testCaseName": "PhyloSubtree query returns correct nwk with missingNode",
   "query": {
     "action": {
-      "type": "Subtree",
+      "type": "PhyloSubtree",
       "columnName": "gisaid_epi_isl",
       "orderByFields": ["subtreeNewick"],
       "printNodesNotInTree": true

--- a/endToEndTests/test/queries/Subtree_withMissingNode.json
+++ b/endToEndTests/test/queries/Subtree_withMissingNode.json
@@ -1,0 +1,43 @@
+{
+  "testCaseName": "Subtree query returns correct nwk with missingNode",
+  "query": {
+    "action": {
+      "type": "Subtree",
+      "columnName": "gisaid_epi_isl",
+      "orderByFields": ["subtreeNewick"],
+      "printNodesNotInTree": true
+    },
+    "filterExpression": {
+      "type": "Or",
+      "children": [
+        {
+          "type": "StringEquals",
+          "column": "gisaid_epi_isl",
+          "value": "EPI_ISL_1001493"
+        },
+        {
+          "type": "StringEquals",
+          "column": "gisaid_epi_isl",
+          "value": "EPI_ISL_1004495"
+        },
+        {
+          "type": "StringEquals",
+          "column": "gisaid_epi_isl",
+          "value": "EPI_ISL_1003373"
+        },
+        {
+          "type": "StringEquals",
+          "column": "gisaid_epi_isl",
+          "value": "EPI_ISL_1747752"
+        }
+      ]
+    }
+  },
+  "expectedQueryResult": [
+    {
+      "subtreeNewick": "(EPI_ISL_1003373,EPI_ISL_1004495)NODE_0000096;",
+      "missingNodeCount": 2,
+      "missingFromTree": "EPI_ISL_1001493,EPI_ISL_1747752"
+    }
+  ]
+}

--- a/src/silo/common/phylo_tree.cpp
+++ b/src/silo/common/phylo_tree.cpp
@@ -512,7 +512,7 @@ NewickResponse PhyloTree::toNewickString(
          filter_in_tree.push_back(node_label);
       }
    }
-   if (filter_in_tree.empty()) { 
+   if (filter_in_tree.empty()) {
       response.newick_string = "";
       return response;
    }

--- a/src/silo/common/phylo_tree.cpp
+++ b/src/silo/common/phylo_tree.cpp
@@ -428,4 +428,117 @@ MRCAResponse PhyloTree::getMRCA(const std::vector<std::string>& node_labels) con
    return response;
 }
 
+bool isInFilter(const std::string& str, const std::vector<std::string>& filter) {
+   return std::find(filter.begin(), filter.end(), str) != filter.end();
+}
+
+std::string newickJoin(
+   const std::vector<std::optional<std::string>>& child_newick_strings,
+   const std::string& self_id
+) {
+   std::string result = "(";
+   bool has_value = false;
+   for (size_t i = 0; i < child_newick_strings.size(); ++i) {
+      // reverse the order of children to match the Newick format
+      if (!child_newick_strings[child_newick_strings.size() - i - 1].has_value()) {
+         continue;
+      }
+      if (has_value) {
+         result += ",";
+      }
+      result += child_newick_strings[child_newick_strings.size() - i - 1].value();
+      has_value = true;
+   }
+   if (!has_value) {
+      return self_id;
+   }
+   result += ")" + self_id;
+   return result;
+}
+
+std::optional<std::string> PhyloTree::partialNewickString(
+   const std::vector<std::string>& filter,
+   const TreeNodeId& ancestor,
+   bool contract_unary_nodes
+) const {
+   std::optional<std::string> response;
+
+   auto node_it = nodes.find(ancestor);
+   SILO_ASSERT(node_it != nodes.end());
+   std::vector<std::optional<std::string>> responses;
+   if (node_it->second->isLeaf()) {
+      response =
+         isInFilter(ancestor.string, filter) ? std::make_optional(ancestor.string) : std::nullopt;
+      return response;
+   }
+   for (const auto& child : node_it->second->children) {
+      responses.push_back(partialNewickString(filter, child, contract_unary_nodes));
+   }
+   std::erase_if(responses, [](const std::optional<std::string>& resp) {
+      return !resp.has_value();
+   });
+   if (responses.empty()) {
+      response = std::nullopt;
+      return response;
+   }
+   if (responses.size() == 1) {
+      if (contract_unary_nodes) {
+         response = responses[0];
+      } else {
+         response = newickJoin({responses[0]}, ancestor.string);
+      }
+      return response;
+   }
+   std::vector<std::optional<std::string>> strings;
+   strings.reserve(responses.size());
+   for (const auto& resp : responses) {
+      strings.push_back(resp);
+   }
+   response = newickJoin(strings, ancestor.string);
+   return response;
+}
+
+NewickResponse PhyloTree::toNewickString(
+   const std::vector<std::string>& filter,
+   bool contract_unary_nodes
+) const {
+   NewickResponse response;
+   std::vector<std::string> filter_in_tree;
+   for (const auto& node_label : filter) {
+      auto node_it = nodes.find(TreeNodeId{node_label});
+      if (node_it == nodes.end()) {
+         response.not_in_tree.push_back(node_label);
+      } else {
+         filter_in_tree.push_back(node_label);
+      }
+   }
+   if (filter_in_tree.empty()) { 
+      response.newick_string = "";
+      return response;
+   }
+   if (filter_in_tree.size() == 1) {
+      response.newick_string = filter_in_tree[0] + ";";
+      return response;
+   }
+   MRCAResponse mrca = getMRCA(filter_in_tree);
+   SILO_ASSERT(mrca.mrca_node_id.has_value());
+   std::vector<std::optional<std::string>> responses;
+   auto mrca_node = nodes.find(mrca.mrca_node_id.value());
+   for (const auto& child : mrca_node->second->children) {
+      responses.push_back(partialNewickString(filter_in_tree, child, contract_unary_nodes));
+   }
+   std::erase_if(responses, [](const std::optional<std::string>& resp) {
+      return !resp.has_value();
+   });
+   SILO_ASSERT(!responses.empty());
+   SILO_ASSERT(responses.size() > 1);
+   std::vector<std::optional<std::string>> strings;
+   strings.reserve(responses.size());
+   for (const auto& resp : responses) {
+      strings.push_back(resp);
+   }
+   response.newick_string = newickJoin(strings, mrca_node->first.string) + ";";
+   return response;
+}
+
 }  // namespace silo::common

--- a/src/silo/common/phylo_tree.cpp
+++ b/src/silo/common/phylo_tree.cpp
@@ -522,22 +522,13 @@ NewickResponse PhyloTree::toNewickString(
    }
    MRCAResponse mrca = getMRCA(filter_in_tree);
    SILO_ASSERT(mrca.mrca_node_id.has_value());
-   std::vector<std::optional<std::string>> responses;
    auto mrca_node = nodes.find(mrca.mrca_node_id.value());
-   for (const auto& child : mrca_node->second->children) {
-      responses.push_back(partialNewickString(filter_in_tree, child, contract_unary_nodes));
-   }
-   std::erase_if(responses, [](const std::optional<std::string>& resp) {
-      return !resp.has_value();
-   });
-   SILO_ASSERT(!responses.empty());
-   SILO_ASSERT(responses.size() > 1);
-   std::vector<std::optional<std::string>> strings;
-   strings.reserve(responses.size());
-   for (const auto& resp : responses) {
-      strings.push_back(resp);
-   }
-   response.newick_string = newickJoin(strings, mrca_node->first.string) + ";";
+   SILO_ASSERT(mrca_node != nodes.end());
+
+   std::optional<std::string> newick_string =
+      partialNewickString(filter_in_tree, mrca_node->first, contract_unary_nodes);
+   SILO_ASSERT(newick_string.has_value());
+   response.newick_string = newick_string.value() + ";";
    return response;
 }
 

--- a/src/silo/common/phylo_tree.cpp
+++ b/src/silo/common/phylo_tree.cpp
@@ -520,6 +520,8 @@ NewickResponse PhyloTree::toNewickString(
       response.newick_string = filter_in_tree[0] + ";";
       return response;
    }
+
+   // The MRCA will be the root of the subtree that contains all nodes in the filter.
    MRCAResponse mrca = getMRCA(filter_in_tree);
    SILO_ASSERT(mrca.mrca_node_id.has_value());
    auto mrca_node = nodes.find(mrca.mrca_node_id.value());

--- a/src/silo/common/phylo_tree.h
+++ b/src/silo/common/phylo_tree.h
@@ -48,6 +48,12 @@ class MRCAResponse {
    std::vector<std::string> not_in_tree;
 };
 
+class NewickResponse {
+  public:
+   std::string newick_string;
+   std::vector<std::string> not_in_tree;
+};
+
 class PhyloTree {
   public:
    std::unordered_map<TreeNodeId, std::shared_ptr<TreeNode>> nodes;
@@ -72,6 +78,17 @@ class PhyloTree {
    roaring::Roaring getDescendants(const TreeNodeId& node_id);
 
    MRCAResponse getMRCA(const std::vector<std::string>& node_labels) const;
+
+   NewickResponse toNewickString(
+      const std::vector<std::string>& filter,
+      bool contract_unary_nodes = false
+   ) const;
+
+   std::optional<std::string> partialNewickString(
+      const std::vector<std::string>& filter,
+      const TreeNodeId& ancestor,
+      bool contract_unary_nodes = false
+   ) const;
 
    void getSetOfAncestorsAtDepth(
       const std::set<TreeNodeId>& nodes_to_group,

--- a/src/silo/common/phylo_tree.h
+++ b/src/silo/common/phylo_tree.h
@@ -81,13 +81,13 @@ class PhyloTree {
 
    NewickResponse toNewickString(
       const std::vector<std::string>& filter,
-      bool contract_unary_nodes = false
+      bool contract_unary_nodes = true
    ) const;
 
    std::optional<std::string> partialNewickString(
       const std::vector<std::string>& filter,
       const TreeNodeId& ancestor,
-      bool contract_unary_nodes = false
+      bool contract_unary_nodes = true
    ) const;
 
    void getSetOfAncestorsAtDepth(

--- a/src/silo/common/phylo_tree.test.cpp
+++ b/src/silo/common/phylo_tree.test.cpp
@@ -167,16 +167,18 @@ TEST(PhyloTree, correctlyReturnsMRCA) {
 TEST(PhyloTree, correctlyReturnsSubTreeNewick) {
    auto phylo_tree =
       PhyloTree::fromNewickString("(((A1.1, A1.2)A1,(A2.1)A2)A,(B1,(B2.1,B2.2)B2)B)R;");
-   auto subtree_left_side = phylo_tree.toNewickString({"A1.1", "A1.2", "A2.1"}).newick_string;
+   auto subtree_left_side =
+      phylo_tree.toNewickString({"A1.1", "A1.2", "A2.1"}, false).newick_string;
    ASSERT_EQ(subtree_left_side, "((A1.1,A1.2)A1,(A2.1)A2)A;");
-   auto subtree_right_side = phylo_tree.toNewickString({"B1", "B2.1", "B2.2"}).newick_string;
+   auto subtree_right_side = phylo_tree.toNewickString({"B1", "B2.1", "B2.2"}, false).newick_string;
    ASSERT_EQ(subtree_right_side, "(B1,(B2.1,B2.2)B2)B;");
    auto subtree_full =
-      phylo_tree.toNewickString({"A1.1", "A1.2", "A2.1", "B1", "B2.1", "B2.2"}).newick_string;
+      phylo_tree.toNewickString({"A1.1", "A1.2", "A2.1", "B1", "B2.1", "B2.2"}, false)
+         .newick_string;
    ASSERT_EQ(subtree_full, "(((A1.1,A1.2)A1,(A2.1)A2)A,(B1,(B2.1,B2.2)B2)B)R;");
-   auto subtree_empty = phylo_tree.toNewickString({"NOT_IN_TREE"}).newick_string;
+   auto subtree_empty = phylo_tree.toNewickString({"NOT_IN_TREE"}, false).newick_string;
    ASSERT_EQ(subtree_empty, "");
-   auto subtree_one_node = phylo_tree.toNewickString({"A1.1"}).newick_string;
+   auto subtree_one_node = phylo_tree.toNewickString({"A1.1"}, false).newick_string;
    ASSERT_EQ(subtree_one_node, "A1.1;");
 }
 

--- a/src/silo/common/phylo_tree.test.cpp
+++ b/src/silo/common/phylo_tree.test.cpp
@@ -163,3 +163,35 @@ TEST(PhyloTree, correctlyReturnsMRCA) {
       mrca_response.not_in_tree[1] == "NOT_IN_TREE2"
    );
 }
+
+TEST(PhyloTree, correctlyReturnsSubTreeNewick) {
+   auto phylo_tree =
+      PhyloTree::fromNewickString("(((A1.1, A1.2)A1,(A2.1)A2)A,(B1,(B2.1,B2.2)B2)B)R;");
+   auto subtree_left_side = phylo_tree.toNewickString({"A1.1", "A1.2", "A2.1"}).newick_string;
+   ASSERT_EQ(subtree_left_side, "((A1.1,A1.2)A1,(A2.1)A2)A;");
+   auto subtree_right_side = phylo_tree.toNewickString({"B1", "B2.1", "B2.2"}).newick_string;
+   ASSERT_EQ(subtree_right_side, "(B1,(B2.1,B2.2)B2)B;");
+   auto subtree_full =
+      phylo_tree.toNewickString({"A1.1", "A1.2", "A2.1", "B1", "B2.1", "B2.2"}).newick_string;
+   ASSERT_EQ(subtree_full, "(((A1.1,A1.2)A1,(A2.1)A2)A,(B1,(B2.1,B2.2)B2)B)R;");
+   auto subtree_empty = phylo_tree.toNewickString({"NOT_IN_TREE"}).newick_string;
+   ASSERT_EQ(subtree_empty, "");
+   auto subtree_one_node = phylo_tree.toNewickString({"A1.1"}).newick_string;
+   ASSERT_EQ(subtree_one_node, "A1.1;");
+}
+
+TEST(PhyloTree, correctlyReturnsSubTreeNewickWithContractUnaryNodes) {
+   auto phylo_tree =
+      PhyloTree::fromNewickString("(((A1.1, A1.2)A1,(A2.1)A2)A,(B1,(B2.1,B2.2)B2)B)R;");
+   auto subtree_left_side = phylo_tree.toNewickString({"A1.1", "A1.2", "A2.1"}, true).newick_string;
+   ASSERT_EQ(subtree_left_side, "((A1.1,A1.2)A1,A2.1)A;");
+   auto subtree_right_side = phylo_tree.toNewickString({"B1", "B2.1", "B2.2"}, true).newick_string;
+   ASSERT_EQ(subtree_right_side, "(B1,(B2.1,B2.2)B2)B;");
+   auto subtree_full =
+      phylo_tree.toNewickString({"A1.1", "A1.2", "A2.1", "B1", "B2.1", "B2.2"}, true).newick_string;
+   ASSERT_EQ(subtree_full, "(((A1.1,A1.2)A1,A2.1)A,(B1,(B2.1,B2.2)B2)B)R;");
+   auto subtree_empty = phylo_tree.toNewickString({"NOT_IN_TREE"}, true).newick_string;
+   ASSERT_EQ(subtree_empty, "");
+   auto subtree_one_node = phylo_tree.toNewickString({"A1.1"}, true).newick_string;
+   ASSERT_EQ(subtree_one_node, "A1.1;");
+}

--- a/src/silo/query_engine/actions/action.cpp
+++ b/src/silo/query_engine/actions/action.cpp
@@ -23,7 +23,7 @@
 #include "silo/query_engine/actions/insertions.h"
 #include "silo/query_engine/actions/most_recent_common_ancestor.h"
 #include "silo/query_engine/actions/mutations.h"
-#include "silo/query_engine/actions/subtree.h"
+#include "silo/query_engine/actions/phylo_subtree.h"
 #include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/exec_node/arrow_util.h"
@@ -166,8 +166,8 @@ void from_json(const nlohmann::json& json, std::unique_ptr<Action>& action) {
       action = json.get<std::unique_ptr<Aggregated>>();
    } else if (expression_type == "MostRecentCommonAncestor") {
       action = json.get<std::unique_ptr<MostRecentCommonAncestor>>();
-   } else if (expression_type == "Subtree") {
-      action = json.get<std::unique_ptr<Subtree>>();
+   } else if (expression_type == "PhyloSubtree") {
+      action = json.get<std::unique_ptr<PhyloSubtree>>();
    } else if (expression_type == "Mutations") {
       action = json.get<std::unique_ptr<Mutations<Nucleotide>>>();
    } else if (expression_type == "Details") {

--- a/src/silo/query_engine/actions/action.cpp
+++ b/src/silo/query_engine/actions/action.cpp
@@ -23,6 +23,7 @@
 #include "silo/query_engine/actions/insertions.h"
 #include "silo/query_engine/actions/most_recent_common_ancestor.h"
 #include "silo/query_engine/actions/mutations.h"
+#include "silo/query_engine/actions/subtree.h"
 #include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/exec_node/arrow_util.h"
@@ -165,6 +166,8 @@ void from_json(const nlohmann::json& json, std::unique_ptr<Action>& action) {
       action = json.get<std::unique_ptr<Aggregated>>();
    } else if (expression_type == "MostRecentCommonAncestor") {
       action = json.get<std::unique_ptr<MostRecentCommonAncestor>>();
+   } else if (expression_type == "Subtree") {
+      action = json.get<std::unique_ptr<Subtree>>();
    } else if (expression_type == "Mutations") {
       action = json.get<std::unique_ptr<Mutations<Nucleotide>>>();
    } else if (expression_type == "Details") {

--- a/src/silo/query_engine/actions/phylo_subtree.cpp
+++ b/src/silo/query_engine/actions/phylo_subtree.cpp
@@ -1,4 +1,4 @@
-#include "silo/query_engine/actions/subtree.h"
+#include "silo/query_engine/actions/phylo_subtree.h"
 
 #include <optional>
 #include <string>
@@ -27,13 +27,17 @@ using silo::common::NewickResponse;
 using silo::common::TreeNodeId;
 using silo::schema::ColumnType;
 
-Subtree::Subtree(std::string column_name, bool print_nodes_not_in_tree, bool contract_unary_nodes)
+PhyloSubtree::PhyloSubtree(
+   std::string column_name,
+   bool print_nodes_not_in_tree,
+   bool contract_unary_nodes
+)
     : TreeAction(std::move(column_name), print_nodes_not_in_tree),
       contract_unary_nodes(contract_unary_nodes) {}
 
 using silo::query_engine::filter::operators::Operator;
 
-arrow::Status Subtree::addResponseToBuilder(
+arrow::Status PhyloSubtree::addResponseToBuilder(
    std::vector<std::string>& all_node_ids,
    std::unordered_map<std::string_view, exec_node::JsonValueTypeArrayBuilder>& output_builder,
    const storage::column::StringColumnMetadata* metadata,
@@ -57,7 +61,7 @@ arrow::Status Subtree::addResponseToBuilder(
    return arrow::Status::OK();
 }
 
-std::vector<schema::ColumnIdentifier> Subtree::getOutputSchema(
+std::vector<schema::ColumnIdentifier> PhyloSubtree::getOutputSchema(
    const schema::TableSchema& table_schema
 ) const {
    auto base = makeBaseOutputSchema();
@@ -66,30 +70,32 @@ std::vector<schema::ColumnIdentifier> Subtree::getOutputSchema(
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-void from_json(const nlohmann::json& json, std::unique_ptr<Subtree>& action) {
+void from_json(const nlohmann::json& json, std::unique_ptr<PhyloSubtree>& action) {
    CHECK_SILO_QUERY(
-      json.contains("columnName"), "error: 'columnName' field is required in Subtree action"
+      json.contains("columnName"), "error: 'columnName' field is required in PhyloSubtree action"
    );
    CHECK_SILO_QUERY(
-      json["columnName"].is_string(), "error: 'columnName' field in Subtree action must be a string"
+      json["columnName"].is_string(),
+      "error: 'columnName' field in PhyloSubtree action must be a string"
    );
    if (json.contains("printNodesNotInTree")) {
       CHECK_SILO_QUERY(
          json["printNodesNotInTree"].is_boolean(),
-         "error: 'printNodesNotInTree' field in Subtree action must be a boolean"
+         "error: 'printNodesNotInTree' field in PhyloSubtree action must be a boolean"
       );
    }
    if (json.contains("contractUnaryNodes")) {
       CHECK_SILO_QUERY(
          json["contractUnaryNodes"].is_boolean(),
-         "error: 'contractUnaryNodes' field in Subtree action must be a boolean"
+         "error: 'contractUnaryNodes' field in PhyloSubtree action must be a boolean"
       );
    }
    bool print_nodes_not_in_tree = json.value("printNodesNotInTree", false);
    bool contract_unary_nodes = json.value("contractUnaryNodes", true);
    std::string column_name = json["columnName"].get<std::string>();
 
-   action = std::make_unique<Subtree>(column_name, print_nodes_not_in_tree, contract_unary_nodes);
+   action =
+      std::make_unique<PhyloSubtree>(column_name, print_nodes_not_in_tree, contract_unary_nodes);
 }
 
 }  // namespace silo::query_engine::actions

--- a/src/silo/query_engine/actions/phylo_subtree.h
+++ b/src/silo/query_engine/actions/phylo_subtree.h
@@ -14,10 +14,10 @@
 
 namespace silo::query_engine::actions {
 
-class Subtree : public TreeAction {
+class PhyloSubtree : public TreeAction {
   public:
    bool contract_unary_nodes = false;
-   Subtree(std::string column_name, bool print_nodes_not_in_tree, bool contract_unary_nodes);
+   PhyloSubtree(std::string column_name, bool print_nodes_not_in_tree, bool contract_unary_nodes);
 
    arrow::Status addResponseToBuilder(
       std::vector<std::string>& all_node_ids,
@@ -29,11 +29,11 @@ class Subtree : public TreeAction {
    std::vector<schema::ColumnIdentifier> getOutputSchema(const schema::TableSchema& table_schema
    ) const override;
 
-   std::string_view getType() const override { return "Subtree"; }
+   std::string_view getType() const override { return "PhyloSubtree"; }
    std::string_view myResultFieldName() const override { return "subtreeNewick"; }
 };
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-void from_json(const nlohmann::json& json, std::unique_ptr<Subtree>& action);
+void from_json(const nlohmann::json& json, std::unique_ptr<PhyloSubtree>& action);
 
 }  // namespace silo::query_engine::actions

--- a/src/silo/query_engine/actions/subtree.cpp
+++ b/src/silo/query_engine/actions/subtree.cpp
@@ -1,4 +1,4 @@
-#include "silo/query_engine/actions/most_recent_common_ancestor.h"
+#include "silo/query_engine/actions/subtree.h"
 
 #include <optional>
 #include <string>
@@ -10,7 +10,6 @@
 #include <fmt/ranges.h>
 #include <nlohmann/json.hpp>
 
-#include "evobench/evobench.hpp"
 #include "silo/common/phylo_tree.h"
 #include "silo/common/tree_node_id.h"
 #include "silo/config/database_config.h"
@@ -24,32 +23,27 @@
 #include "silo/storage/table.h"
 
 namespace silo::query_engine::actions {
-using silo::common::MRCAResponse;
+using silo::common::NewickResponse;
 using silo::common::TreeNodeId;
 using silo::schema::ColumnType;
 
-MostRecentCommonAncestor::MostRecentCommonAncestor(
-   std::string column_name,
-   bool print_nodes_not_in_tree
-)
-    : TreeAction(std::move(column_name), print_nodes_not_in_tree) {}
+Subtree::Subtree(std::string column_name, bool print_nodes_not_in_tree, bool contract_unary_nodes)
+    : TreeAction(std::move(column_name), print_nodes_not_in_tree),
+      contract_unary_nodes(contract_unary_nodes) {}
 
 using silo::query_engine::filter::operators::Operator;
 
-arrow::Status MostRecentCommonAncestor::addResponseToBuilder(
+arrow::Status Subtree::addResponseToBuilder(
    std::vector<std::string>& all_node_ids,
    std::unordered_map<std::string_view, exec_node::JsonValueTypeArrayBuilder>& output_builder,
    const storage::column::StringColumnMetadata* metadata,
    bool print_nodes_not_in_tree
 ) const {
-   MRCAResponse response = metadata->phylo_tree->getMRCA(all_node_ids);
-   std::optional<std::string> mrca_node =
-      response.mrca_node_id.has_value()
-         ? std::make_optional<std::string>(response.mrca_node_id.value().string)
-         : std::nullopt;
+   NewickResponse response =
+      metadata->phylo_tree->toNewickString(all_node_ids, contract_unary_nodes);
 
-   if (auto builder = output_builder.find("mrcaNode"); builder != output_builder.end()) {
-      ARROW_RETURN_NOT_OK(builder->second.insert(mrca_node));
+   if (auto builder = output_builder.find("subtreeNewick"); builder != output_builder.end()) {
+      ARROW_RETURN_NOT_OK(builder->second.insert(response.newick_string));
    }
    if (auto builder = output_builder.find("missingNodeCount"); builder != output_builder.end()) {
       ARROW_RETURN_NOT_OK(builder->second.insert(static_cast<int32_t>(response.not_in_tree.size()))
@@ -63,34 +57,39 @@ arrow::Status MostRecentCommonAncestor::addResponseToBuilder(
    return arrow::Status::OK();
 }
 
-std::vector<schema::ColumnIdentifier> MostRecentCommonAncestor::getOutputSchema(
+std::vector<schema::ColumnIdentifier> Subtree::getOutputSchema(
    const schema::TableSchema& table_schema
 ) const {
    auto base = makeBaseOutputSchema();
-   base.emplace_back("mrcaNode", schema::ColumnType::STRING);
+   base.emplace_back("subtreeNewick", schema::ColumnType::STRING);
    return base;
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-void from_json(const nlohmann::json& json, std::unique_ptr<MostRecentCommonAncestor>& action) {
+void from_json(const nlohmann::json& json, std::unique_ptr<Subtree>& action) {
    CHECK_SILO_QUERY(
-      json.contains("columnName"),
-      "error: 'columnName' field is required in MostRecentCommonAncestor action"
+      json.contains("columnName"), "error: 'columnName' field is required in Subtree action"
    );
    CHECK_SILO_QUERY(
-      json["columnName"].is_string(),
-      "error: 'columnName' field in MostRecentCommonAncestor action must be a string"
+      json["columnName"].is_string(), "error: 'columnName' field in Subtree action must be a string"
    );
    if (json.contains("printNodesNotInTree")) {
       CHECK_SILO_QUERY(
          json["printNodesNotInTree"].is_boolean(),
-         "error: 'printNodesNotInTree' field in MostRecentCommonAncestor action must be a boolean"
+         "error: 'printNodesNotInTree' field in Subtree action must be a boolean"
+      );
+   }
+   if (json.contains("contractUnaryNodes")) {
+      CHECK_SILO_QUERY(
+         json["contractUnaryNodes"].is_boolean(),
+         "error: 'contractUnaryNodes' field in Subtree action must be a boolean"
       );
    }
    bool print_nodes_not_in_tree = json.value("printNodesNotInTree", false);
+   bool contract_unary_nodes = json.value("contractUnaryNodes", false);
    std::string column_name = json["columnName"].get<std::string>();
 
-   action = std::make_unique<MostRecentCommonAncestor>(column_name, print_nodes_not_in_tree);
+   action = std::make_unique<Subtree>(column_name, print_nodes_not_in_tree, contract_unary_nodes);
 }
 
 }  // namespace silo::query_engine::actions

--- a/src/silo/query_engine/actions/subtree.cpp
+++ b/src/silo/query_engine/actions/subtree.cpp
@@ -86,7 +86,7 @@ void from_json(const nlohmann::json& json, std::unique_ptr<Subtree>& action) {
       );
    }
    bool print_nodes_not_in_tree = json.value("printNodesNotInTree", false);
-   bool contract_unary_nodes = json.value("contractUnaryNodes", false);
+   bool contract_unary_nodes = json.value("contractUnaryNodes", true);
    std::string column_name = json["columnName"].get<std::string>();
 
    action = std::make_unique<Subtree>(column_name, print_nodes_not_in_tree, contract_unary_nodes);

--- a/src/silo/query_engine/actions/subtree.h
+++ b/src/silo/query_engine/actions/subtree.h
@@ -14,9 +14,10 @@
 
 namespace silo::query_engine::actions {
 
-class MostRecentCommonAncestor : public TreeAction {
+class Subtree : public TreeAction {
   public:
-   MostRecentCommonAncestor(std::string column_name, bool print_nodes_not_in_tree);
+   bool contract_unary_nodes = false;
+   Subtree(std::string column_name, bool print_nodes_not_in_tree, bool contract_unary_nodes);
 
    arrow::Status addResponseToBuilder(
       std::vector<std::string>& all_node_ids,
@@ -28,12 +29,11 @@ class MostRecentCommonAncestor : public TreeAction {
    std::vector<schema::ColumnIdentifier> getOutputSchema(const schema::TableSchema& table_schema
    ) const override;
 
-   std::string_view getType() const override { return "MostRecentCommonAncestor"; }
-
-   std::string_view myResultFieldName() const override { return "mrcaNode"; }
+   std::string_view getType() const override { return "Subtree"; }
+   std::string_view myResultFieldName() const override { return "subtreeNewick"; }
 };
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-void from_json(const nlohmann::json& json, std::unique_ptr<MostRecentCommonAncestor>& action);
+void from_json(const nlohmann::json& json, std::unique_ptr<Subtree>& action);
 
 }  // namespace silo::query_engine::actions

--- a/src/silo/query_engine/actions/tree_action.cpp
+++ b/src/silo/query_engine/actions/tree_action.cpp
@@ -1,0 +1,171 @@
+#include "silo/query_engine/actions/tree_action.h"
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <arrow/acero/options.h>
+#include <arrow/compute/exec.h>
+#include <fmt/ranges.h>
+#include <nlohmann/json.hpp>
+
+#include "evobench/evobench.hpp"
+#include "silo/common/phylo_tree.h"
+#include "silo/common/tree_node_id.h"
+#include "silo/config/database_config.h"
+#include "silo/query_engine/actions/action.h"
+#include "silo/query_engine/bad_request.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
+#include "silo/schema/database_schema.h"
+#include "silo/storage/column_group.h"
+#include "silo/storage/table.h"
+
+namespace silo::query_engine::actions {
+using silo::schema::ColumnType;
+
+TreeAction::TreeAction(std::string column_name, bool print_nodes_not_in_tree)
+    : column_name(std::move(column_name)),
+      print_nodes_not_in_tree(print_nodes_not_in_tree) {}
+
+using silo::query_engine::filter::operators::Operator;
+
+void TreeAction::validateOrderByFields(const schema::TableSchema& schema) const {
+   std::vector<std::string_view> allowed{myResultFieldName(), "missingNodeCount"};
+   if (print_nodes_not_in_tree) {
+      allowed.push_back("missingFromTree");
+   }
+
+   for (const auto& field : order_by_fields) {
+      bool ok = std::ranges::any_of(allowed, [&](std::string_view f) { return f == field.name; });
+      CHECK_SILO_QUERY(
+         ok,
+         "OrderByField {} is not contained in the result of this operation. "
+         "Allowed values are {}.",
+         field.name,
+         fmt::join(allowed, ", ")
+      );
+   }
+}
+
+std::vector<std::string> TreeAction::getNodeValues(
+   std::shared_ptr<const storage::Table> table,
+   const std::string& column_name,
+   std::vector<CopyOnWriteBitmap>& bitmap_filter
+) const {
+   std::vector<std::string> all_tree_node_ids;
+   for (size_t i = 0; i < table->getNumberOfPartitions(); ++i) {
+      const storage::TablePartition& table_partition = table->getPartition(i);
+      const auto& string_column = table_partition.columns.string_columns.at(column_name);
+
+      CopyOnWriteBitmap& filter = bitmap_filter[i];
+      const size_t cardinality = filter->cardinality();
+      if (cardinality == 0) {
+         continue;
+      }
+      for (uint32_t row_in_table_partition : *filter) {
+         auto value =
+            string_column.lookupValue(string_column.getValues().at(row_in_table_partition));
+         if (!value.empty()) {
+            all_tree_node_ids.push_back(value);
+         }
+      }
+   }
+   return all_tree_node_ids;
+}
+
+arrow::Result<QueryPlan> TreeAction::toQueryPlanImpl(
+   std::shared_ptr<const storage::Table> table,
+   std::vector<CopyOnWriteBitmap> partition_filters,
+   const config::QueryOptions& query_options
+) const {
+   CHECK_SILO_QUERY(
+      table->schema.getColumn(column_name).has_value(),
+      "Column '{}' not found in table schema",
+      column_name
+   );
+   CHECK_SILO_QUERY(
+      table->schema.getColumn(column_name).has_value() &&
+         table->schema.getColumn(column_name).value().type == ColumnType::STRING,
+      "{} action cannot be called on column '{}' as it is not a column of type STRING",
+      getType(),
+      column_name
+   );
+   const auto& optional_table_metadata =
+      table->schema.getColumnMetadata<storage::column::StringColumnPartition>(column_name);
+   CHECK_SILO_QUERY(
+      optional_table_metadata.has_value() &&
+         optional_table_metadata.value()->phylo_tree.has_value(),
+      "{} action cannot be called on Column '{}' as it does not have a phylogenetic tree "
+      "associated with it",
+      getType(),
+      column_name
+   );
+   auto table_metadata = optional_table_metadata.value();
+   auto output_fields = getOutputSchema(table->schema);
+   auto evaluated_partition_filters = partition_filters;
+
+   auto column_name_to_evaluate = column_name;
+   auto print_missing_nodes = print_nodes_not_in_tree;
+
+   std::function<arrow::Future<std::optional<arrow::ExecBatch>>()> producer =
+      [this,
+       table,
+       column_name_to_evaluate,
+       output_fields,
+       evaluated_partition_filters,
+       table_metadata,
+       produced = false,
+       print_missing_nodes]() mutable -> arrow::Future<std::optional<arrow::ExecBatch>> {
+      EVOBENCH_SCOPE("TreeAction", "producer");
+      if (produced == true) {
+         std::optional<arrow::ExecBatch> result = std::nullopt;
+         return arrow::Future{result};
+      }
+      produced = true;
+
+      std::unordered_map<std::string_view, exec_node::JsonValueTypeArrayBuilder> output_builder;
+      for (const auto& output_field : output_fields) {
+         output_builder.emplace(
+            output_field.name, exec_node::columnTypeToArrowType(output_field.type)
+         );
+      }
+
+      auto all_node_ids =
+         this->getNodeValues(table, column_name_to_evaluate, evaluated_partition_filters);
+
+      ARROW_RETURN_NOT_OK(this->addResponseToBuilder(
+         all_node_ids, output_builder, table_metadata, print_missing_nodes
+      ));
+
+      // Order of result_columns is relevant as it needs to be consistent with vector in schema
+      std::vector<arrow::Datum> result_columns;
+      for (const auto& output_field : output_fields) {
+         if (auto array_builder = output_builder.find(output_field.name);
+             array_builder != output_builder.end()) {
+            arrow::Datum datum;
+            ARROW_ASSIGN_OR_RAISE(datum, array_builder->second.toDatum());
+            result_columns.push_back(std::move(datum));
+         }
+      }
+      ARROW_ASSIGN_OR_RAISE(
+         std::optional<arrow::ExecBatch> result, arrow::ExecBatch::Make(result_columns)
+      );
+      return arrow::Future{result};
+   };
+
+   ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
+
+   arrow::acero::SourceNodeOptions options{
+      exec_node::columnsToArrowSchema(getOutputSchema(table->schema)),
+      std::move(producer),
+      arrow::Ordering::Implicit()
+   };
+   ARROW_ASSIGN_OR_RAISE(
+      auto node, arrow::acero::MakeExecNode("source", arrow_plan.get(), {}, options)
+   );
+
+   return QueryPlan::makeQueryPlan(arrow_plan, node);
+}
+
+}  // namespace silo::query_engine::actions

--- a/src/silo/query_engine/actions/tree_action.h
+++ b/src/silo/query_engine/actions/tree_action.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <arrow/result.h>
+
+#include <nlohmann/json_fwd.hpp>
+
+#include <arrow/compute/exec.h>
+#include "silo/query_engine/actions/action.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
+#include "silo/storage/table.h"
+
+#include <silo/query_engine/bad_request.h>
+#include "silo/query_engine/exec_node/arrow_util.h"
+#include "silo/query_engine/exec_node/json_value_type_array_builder.h"
+
+namespace silo::query_engine::actions {
+
+class TreeAction : public Action {
+  private:
+   std::string column_name;
+   bool print_nodes_not_in_tree;
+
+  protected:
+   virtual std::string_view myResultFieldName() const = 0;
+
+   std::vector<schema::ColumnIdentifier> makeBaseOutputSchema() const {
+      std::vector<schema::ColumnIdentifier> fields;
+      fields.emplace_back("missingNodeCount", schema::ColumnType::INT32);
+      if (print_nodes_not_in_tree) {
+         fields.emplace_back("missingFromTree", schema::ColumnType::STRING);
+      }
+      return fields;
+   }
+
+   void validateOrderByFields(const schema::TableSchema& schema) const override;
+
+  public:
+   TreeAction(std::string column_name, bool print_nodes_not_in_tree);
+
+   std::vector<std::string> getNodeValues(
+      std::shared_ptr<const storage::Table> table,
+      const std::string& column_name,
+      std::vector<CopyOnWriteBitmap>& bitmap_filter
+   ) const;
+
+   virtual arrow::Status addResponseToBuilder(
+      std::vector<std::string>& all_node_ids,
+      std::unordered_map<std::string_view, exec_node::JsonValueTypeArrayBuilder>& output_builder,
+      const storage::column::StringColumnMetadata* metadata,
+      bool print_nodes_not_in_tree
+   ) const = 0;
+
+   arrow::Result<QueryPlan> toQueryPlanImpl(
+      std::shared_ptr<const storage::Table> table,
+      std::vector<CopyOnWriteBitmap> partition_filters,
+      const config::QueryOptions& query_options
+   ) const override;
+};
+
+}  // namespace silo::query_engine::actions

--- a/src/silo/storage/column/string_column.h
+++ b/src/silo/storage/column/string_column.h
@@ -18,7 +18,6 @@
 #include "silo/storage/column/column_metadata.h"
 
 namespace silo::storage::column {
-using silo::common::MRCAResponse;
 using silo::common::TreeNodeId;
 
 class StringColumnMetadata : public ColumnMetadata {
@@ -56,16 +55,6 @@ class StringColumnMetadata : public ColumnMetadata {
    [[nodiscard]] std::optional<common::String<silo::common::STRING_SIZE>> embedString(
       const std::string& string
    ) const;
-
-   inline MRCAResponse getMRCA(const std::vector<std::string>& node_labels) const {
-      if (!phylo_tree.has_value()) {
-         return MRCAResponse{
-            std::nullopt,
-            {},
-         };
-      }
-      return phylo_tree->getMRCA(node_labels);
-   }
 };
 
 class StringColumnPartition {


### PR DESCRIPTION
resolves https://github.com/GenSpectrum/LAPIS-SILO/issues/910, https://github.com/GenSpectrum/LAPIS-SILO/issues/908

2. Adds functions to create a newick from a phylo tree where only nodes in the filter should be seen in the newick
3. Adds tests

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
