### PR TITLE
refactor: do not access optional phylo_tree unsafely

### DIFF
--- a/src/silo/query_engine/actions/most_recent_common_ancestor.cpp
+++ b/src/silo/query_engine/actions/most_recent_common_ancestor.cpp
@@ -25,6 +25,7 @@
 
 namespace silo::query_engine::actions {
 using silo::common::MRCAResponse;
+using silo::common::PhyloTree;
 using silo::common::TreeNodeId;
 using silo::schema::ColumnType;
 
@@ -39,10 +40,10 @@ using silo::query_engine::filter::operators::Operator;
 arrow::Status MostRecentCommonAncestor::addResponseToBuilder(
    std::vector<std::string>& all_node_ids,
    std::unordered_map<std::string_view, exec_node::JsonValueTypeArrayBuilder>& output_builder,
-   const storage::column::StringColumnMetadata* metadata,
+   const PhyloTree& phylo_tree,
    bool print_nodes_not_in_tree
 ) const {
-   MRCAResponse response = metadata->phylo_tree->getMRCA(all_node_ids);
+   MRCAResponse response = phylo_tree.getMRCA(all_node_ids);
    std::optional<std::string> mrca_node =
       response.mrca_node_id.has_value()
          ? std::make_optional<std::string>(response.mrca_node_id.value().string)

--- a/src/silo/query_engine/actions/most_recent_common_ancestor.h
+++ b/src/silo/query_engine/actions/most_recent_common_ancestor.h
@@ -21,7 +21,7 @@ class MostRecentCommonAncestor : public TreeAction {
    arrow::Status addResponseToBuilder(
       std::vector<std::string>& all_node_ids,
       std::unordered_map<std::string_view, exec_node::JsonValueTypeArrayBuilder>& output_builder,
-      const storage::column::StringColumnMetadata* metadata,
+      const common::PhyloTree& phylo_tree,
       bool print_nodes_not_in_tree
    ) const override;
 

--- a/src/silo/query_engine/actions/phylo_subtree.cpp
+++ b/src/silo/query_engine/actions/phylo_subtree.cpp
@@ -24,6 +24,7 @@
 
 namespace silo::query_engine::actions {
 using silo::common::NewickResponse;
+using silo::common::PhyloTree;
 using silo::common::TreeNodeId;
 using silo::schema::ColumnType;
 
@@ -40,11 +41,10 @@ using silo::query_engine::filter::operators::Operator;
 arrow::Status PhyloSubtree::addResponseToBuilder(
    std::vector<std::string>& all_node_ids,
    std::unordered_map<std::string_view, exec_node::JsonValueTypeArrayBuilder>& output_builder,
-   const storage::column::StringColumnMetadata* metadata,
+   const PhyloTree& phylo_tree,
    bool print_nodes_not_in_tree
 ) const {
-   NewickResponse response =
-      metadata->phylo_tree->toNewickString(all_node_ids, contract_unary_nodes);
+   NewickResponse response = phylo_tree.toNewickString(all_node_ids, contract_unary_nodes);
 
    if (auto builder = output_builder.find("subtreeNewick"); builder != output_builder.end()) {
       ARROW_RETURN_NOT_OK(builder->second.insert(response.newick_string));

--- a/src/silo/query_engine/actions/phylo_subtree.h
+++ b/src/silo/query_engine/actions/phylo_subtree.h
@@ -22,7 +22,7 @@ class PhyloSubtree : public TreeAction {
    arrow::Status addResponseToBuilder(
       std::vector<std::string>& all_node_ids,
       std::unordered_map<std::string_view, exec_node::JsonValueTypeArrayBuilder>& output_builder,
-      const storage::column::StringColumnMetadata* metadata,
+      const common::PhyloTree& phylo_tree,
       bool print_nodes_not_in_tree
    ) const override;
 

--- a/src/silo/query_engine/actions/tree_action.cpp
+++ b/src/silo/query_engine/actions/tree_action.cpp
@@ -101,7 +101,7 @@ arrow::Result<QueryPlan> TreeAction::toQueryPlanImpl(
       getType(),
       column_name
    );
-   auto table_metadata = optional_table_metadata.value();
+   const auto& phylo_tree = optional_table_metadata.value()->phylo_tree.value();
    auto output_fields = getOutputSchema(table->schema);
    auto evaluated_partition_filters = partition_filters;
 
@@ -114,7 +114,7 @@ arrow::Result<QueryPlan> TreeAction::toQueryPlanImpl(
        column_name_to_evaluate,
        output_fields,
        evaluated_partition_filters,
-       table_metadata,
+       &phylo_tree,
        produced = false,
        print_missing_nodes]() mutable -> arrow::Future<std::optional<arrow::ExecBatch>> {
       EVOBENCH_SCOPE("TreeAction", "producer");
@@ -134,9 +134,9 @@ arrow::Result<QueryPlan> TreeAction::toQueryPlanImpl(
       auto all_node_ids =
          this->getNodeValues(table, column_name_to_evaluate, evaluated_partition_filters);
 
-      ARROW_RETURN_NOT_OK(this->addResponseToBuilder(
-         all_node_ids, output_builder, table_metadata, print_missing_nodes
-      ));
+      ARROW_RETURN_NOT_OK(
+         this->addResponseToBuilder(all_node_ids, output_builder, phylo_tree, print_missing_nodes)
+      );
 
       // Order of result_columns is relevant as it needs to be consistent with vector in schema
       std::vector<arrow::Datum> result_columns;

--- a/src/silo/query_engine/actions/tree_action.h
+++ b/src/silo/query_engine/actions/tree_action.h
@@ -50,7 +50,7 @@ class TreeAction : public Action {
    virtual arrow::Status addResponseToBuilder(
       std::vector<std::string>& all_node_ids,
       std::unordered_map<std::string_view, exec_node::JsonValueTypeArrayBuilder>& output_builder,
-      const storage::column::StringColumnMetadata* metadata,
+      const common::PhyloTree& phylo_tree,
       bool print_nodes_not_in_tree
    ) const = 0;
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

A small detail I missed in #911. The `->` operator on optional should not be used, as it is undefined behavior when the `optional` is `nullopt` (instead of a handled crash which occurs with `.value()`). We should try to avoid this


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [ ] The implemented feature is covered by an appropriate test.
