### PR TITLE
fix(ci): do not cancel in-progress runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,6 @@ on:
     types: [completed]
     branches: [main]
 
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   DOCKER_DEPENDENCY_IMAGE_NAME: ghcr.io/genspectrum/lapis-silo-dependencies
   DOCKER_IMAGE_NAME: ghcr.io/genspectrum/lapis-silo


### PR DESCRIPTION
This was able to lead releases without images of the released version, as the re-run of the CI on main, which generates the released image, can be cancelled.

In general, CI times have gotten faster and we do not gain anything by cancelling in-progress CI runs
