### PR TITLE
Bugfix – limit without order

### DIFF
--- a/src/silo/query_engine/actions/action.cpp
+++ b/src/silo/query_engine/actions/action.cpp
@@ -377,6 +377,12 @@ arrow::Result<arrow::acero::ExecNode*> Action::addLimitAndOffsetNode(
    arrow::acero::ExecNode* node
 ) const {
    if (limit.has_value() || offset.has_value()) {
+      CHECK_SILO_QUERY(
+         !node->ordering().is_unordered(),
+         "Offset and limit can only be applied if the output of the operation has some ordering. "
+         "Implicit ordering such as in the case of Details/Fasta is also allowed, Aggregated "
+         "however produces unordered results."
+      );
       arrow::acero::FetchNodeOptions fetch_options(offset.value_or(0), limit.value_or(UINT32_MAX));
       return arrow::acero::MakeExecNode(
          std::string{arrow::acero::FetchNodeOptions::kName}, arrow_plan, {node}, fetch_options

--- a/src/silo/query_engine/actions/aggregated.test.cpp
+++ b/src/silo/query_engine/actions/aggregated.test.cpp
@@ -201,7 +201,14 @@ const QueryTestScenario AGGREGATED_LIMIT_OFFSET = {
       R"(
 {
   "action": {
-    "type": "Details",
+    "type": "Aggregated",
+    "groupByFields": [
+      "age",
+      "country",
+      "coverage",
+      "date",
+      "primaryKey"
+    ],
     "orderByFields": [
       "primaryKey"
     ],
@@ -215,10 +222,31 @@ const QueryTestScenario AGGREGATED_LIMIT_OFFSET = {
    ),
    .expected_query_result = nlohmann::json::parse(
       R"(
-[{"age":null,"country":"Germany","coverage":0.9,"date":"2000-03-07","primaryKey":"id_1"},
-{"age":13,"country":"Germany","coverage":0.9,"date":"2009-06-07","primaryKey":"id_2"},
-{"age":null,"country":"Switzerland","coverage":0.9,"date":"2003-07-02","primaryKey":"id_3"}])"
+[{"age":null,"count":1,"country":"Germany","coverage":0.9,"date":"2000-03-07","primaryKey":"id_1"},
+{"age":13,"count":1,"country":"Germany","coverage":0.9,"date":"2009-06-07","primaryKey":"id_2"},
+{"age":null,"count":1,"country":"Switzerland","coverage":0.9,"date":"2003-07-02","primaryKey":"id_3"}])"
    )
+};
+
+const QueryTestScenario AGGREGATED_LIMIT_WITHOUT_ORDER = {
+   .name = "AGGREGATED_LIMIT_WITHOUT_ORDER",
+   .query = nlohmann::json::parse(
+      R"(
+{
+  "action": {
+    "type": "Aggregated",
+    "groupByFields": ["primaryKey"],
+    "limit": 1
+  },
+  "filterExpression": {
+    "type": "True"
+  }
+})"
+   ),
+   .expected_error_message =
+      "Offset and limit can only be applied if the output of the operation has some ordering. "
+      "Implicit ordering such as in the case of Details/Fasta is also allowed, Aggregated "
+      "however produces unordered results."
 };
 
 const QueryTestScenario AGGREGATE_UNIQUE = {
@@ -421,6 +449,7 @@ QUERY_TEST(
       AGGREGATE_ALMOST_ALL,
       AGGREGATE_SOME,
       AGGREGATED_LIMIT_OFFSET,
+      AGGREGATED_LIMIT_WITHOUT_ORDER,
       AGGREGATE_UNIQUE,
       AGGREGATE_ONE,
       AGGREGATE_NULLABLE,

--- a/src/silo/query_engine/query_plan.cpp
+++ b/src/silo/query_engine/query_plan.cpp
@@ -20,6 +20,7 @@ arrow::Result<QueryPlan> QueryPlan::makeQueryPlan(
       exec_node::createGenerator(arrow_plan.get(), root, &query_plan.results_generator)
    );
    query_plan.results_schema = root->output_schema();
+   ARROW_RETURN_NOT_OK(query_plan.arrow_plan->Validate());
    return query_plan;
 }
 

--- a/src/silo/test/query_fixture.test.h
+++ b/src/silo/test/query_fixture.test.h
@@ -116,7 +116,7 @@ class QueryTestFixture : public ::testing::TestWithParam<QueryTestScenario> {
             std::stringstream buffer;
             auto query_plan = query->toQueryPlan(shared_database, query_options);
             query_plan.executeAndWrite(&buffer);
-            FAIL() << "Expected an error in test case, but noting was thrown";
+            FAIL() << "Expected an error in test case, but nothing was thrown";
          } catch (const std::exception& e) {
             EXPECT_EQ(std::string(e.what()), scenario.expected_error_message);
          }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

SILO silently crashed requests when a limit was provided without orderByFields in an aggregated query. This fixes that problem and also adds a arrow plan validation before the plan is executed