### PR TITLE
feat(silo): include null values in phyloTree column in missingNodeCount

### DIFF
--- a/endToEndTests/test/invalidQueries/phyloDescendantOf_invalidNode.json
+++ b/endToEndTests/test/invalidQueries/phyloDescendantOf_invalidNode.json
@@ -6,12 +6,12 @@
     },
     "filterExpression": {
       "type": "PhyloDescendantOf",
-      "column": "gisaid_epi_isl",
+      "column": "usherTree",
       "internalNode": "NON_EXISTING_NODE"
     }
   },
   "expectedError": {
     "error": "Bad request",
-    "message": "The node 'NON_EXISTING_NODE' does not exist in the phylogenetic tree of column 'gisaid_epi_isl'"
+    "message": "The node 'NON_EXISTING_NODE' does not exist in the phylogenetic tree of column 'usherTree'"
   }
 }

--- a/endToEndTests/test/queries/DetailsOrderBy.json
+++ b/endToEndTests/test/queries/DetailsOrderBy.json
@@ -33,7 +33,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-08-04"
+      "unsorted_date": "2021-08-04",
+      "usherTree": "EPI_ISL_1080536"
     },
     {
       "age": 59,
@@ -45,7 +46,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-03-18"
+      "unsorted_date": "2021-03-18",
+      "usherTree": "EPI_ISL_1119315"
     },
     {
       "age": 54,
@@ -57,7 +59,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-07"
+      "unsorted_date": "2021-05-07",
+      "usherTree": "EPI_ISL_1129663"
     },
     {
       "age": 50,
@@ -69,7 +72,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-07-04"
+      "unsorted_date": "2021-07-04",
+      "usherTree": "EPI_ISL_1195052"
     },
     {
       "age": 51,
@@ -81,7 +85,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-18"
+      "unsorted_date": "2021-05-18",
+      "usherTree": "EPI_ISL_1273458"
     },
     {
       "age": 57,
@@ -93,7 +98,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-01-03"
+      "unsorted_date": "2021-01-03",
+      "usherTree": "EPI_ISL_1360935"
     },
     {
       "age": 50,
@@ -105,7 +111,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-01-20"
+      "unsorted_date": "2021-01-20",
+      "usherTree": "EPI_ISL_1361468"
     },
     {
       "age": 55,
@@ -117,7 +124,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-01-16"
+      "unsorted_date": "2021-01-16",
+      "usherTree": "EPI_ISL_1407962"
     },
     {
       "age": 50,
@@ -129,7 +137,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-11-24"
+      "unsorted_date": "2020-11-24",
+      "usherTree": "EPI_ISL_1408062"
     },
     {
       "age": 4,
@@ -141,7 +150,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": null
+      "unsorted_date": null,
+      "usherTree": null
     },
     {
       "age": 51,
@@ -153,7 +163,8 @@
       "qc_value": 0.96,
       "region": null,
       "test_boolean_column": true,
-      "unsorted_date": "2021-01-25"
+      "unsorted_date": "2021-01-25",
+      "usherTree": "EPI_ISL_1597890"
     },
     {
       "age": 54,
@@ -165,7 +176,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-02-10"
+      "unsorted_date": "2021-02-10",
+      "usherTree": "EPI_ISL_1597932"
     },
     {
       "age": 50,
@@ -177,7 +189,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-03-21"
+      "unsorted_date": "2021-03-21",
+      "usherTree": "EPI_ISL_1747752"
     },
     {
       "age": 59,
@@ -189,7 +202,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-03-03"
+      "unsorted_date": "2021-03-03",
+      "usherTree": "EPI_ISL_1747885"
     },
     {
       "age": 52,
@@ -201,7 +215,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-12-15"
+      "unsorted_date": "2020-12-15",
+      "usherTree": "EPI_ISL_1748215"
     },
     {
       "age": null,
@@ -213,7 +228,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-11-24"
+      "unsorted_date": "2020-11-24",
+      "usherTree": "EPI_ISL_1748243"
     },
     {
       "age": 53,
@@ -225,7 +241,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-04-27"
+      "unsorted_date": "2021-04-27",
+      "usherTree": "EPI_ISL_1748395"
     },
     {
       "age": 4,
@@ -237,7 +254,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2020-12-24"
+      "unsorted_date": "2020-12-24",
+      "usherTree": "EPI_ISL_1749892"
     },
     {
       "age": 5,
@@ -249,7 +267,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-03-08"
+      "unsorted_date": "2020-03-08",
+      "usherTree": "EPI_ISL_1749899"
     },
     {
       "age": 59,
@@ -261,7 +280,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-02-03"
+      "unsorted_date": "2021-02-03",
+      "usherTree": "EPI_ISL_1749960"
     },
     {
       "age": 54,
@@ -273,7 +293,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-04-23"
+      "unsorted_date": "2021-04-23",
+      "usherTree": "EPI_ISL_1760534"
     },
     {
       "age": 56,
@@ -285,7 +306,8 @@
       "qc_value": 0.96,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-10"
+      "unsorted_date": "2021-05-10",
+      "usherTree": "EPI_ISL_1840634"
     },
     {
       "age": 6,
@@ -297,7 +319,8 @@
       "qc_value": 0.96,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-01-29"
+      "unsorted_date": "2021-01-29",
+      "usherTree": "EPI_ISL_2016901"
     },
     {
       "age": 56,
@@ -309,7 +332,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-03-09"
+      "unsorted_date": "2021-03-09",
+      "usherTree": "EPI_ISL_2017036"
     },
     {
       "age": 58,
@@ -321,7 +345,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-01-22"
+      "unsorted_date": "2021-01-22",
+      "usherTree": "EPI_ISL_2019235"
     },
     {
       "age": 55,
@@ -333,7 +358,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2020-12-21"
+      "unsorted_date": "2020-12-21",
+      "usherTree": "EPI_ISL_2019350"
     },
     {
       "age": 59,
@@ -345,7 +371,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2020-08-17"
+      "unsorted_date": "2020-08-17",
+      "usherTree": "EPI_ISL_2180023"
     },
     {
       "age": 57,
@@ -357,7 +384,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-05-25"
+      "unsorted_date": "2021-05-25",
+      "usherTree": "EPI_ISL_2180995"
     },
     {
       "age": 58,
@@ -369,7 +397,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2020-10-08"
+      "unsorted_date": "2020-10-08",
+      "usherTree": "EPI_ISL_2181005"
     },
     {
       "age": 51,
@@ -381,7 +410,8 @@
       "qc_value": null,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-04-12"
+      "unsorted_date": "2021-04-12",
+      "usherTree": "EPI_ISL_2213804"
     },
     {
       "age": 53,
@@ -393,7 +423,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-04-23"
+      "unsorted_date": "2021-04-23",
+      "usherTree": "EPI_ISL_2213934"
     },
     {
       "age": 54,
@@ -405,7 +436,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-09"
+      "unsorted_date": "2021-05-09",
+      "usherTree": "EPI_ISL_2213984"
     },
     {
       "age": 58,
@@ -417,7 +449,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2020-11-13"
+      "unsorted_date": "2020-11-13",
+      "usherTree": "EPI_ISL_2214128"
     },
     {
       "age": 50,
@@ -429,7 +462,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-08"
+      "unsorted_date": "2021-05-08",
+      "usherTree": "EPI_ISL_2270139"
     },
     {
       "age": 52,
@@ -441,7 +475,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-05-08"
+      "unsorted_date": "2021-05-08",
+      "usherTree": "EPI_ISL_2307766"
     },
     {
       "age": 55,
@@ -453,7 +488,8 @@
       "qc_value": 0.96,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-23"
+      "unsorted_date": "2021-05-23",
+      "usherTree": "EPI_ISL_2307888"
     },
     {
       "age": 57,
@@ -465,7 +501,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2020-12-09"
+      "unsorted_date": "2020-12-09",
+      "usherTree": "EPI_ISL_2308054"
     },
     {
       "age": 57,
@@ -477,7 +514,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-03-10"
+      "unsorted_date": "2021-03-10",
+      "usherTree": "EPI_ISL_2360326"
     },
     {
       "age": 54,
@@ -489,7 +527,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-06-05"
+      "unsorted_date": "2021-06-05",
+      "usherTree": "EPI_ISL_2374969"
     },
     {
       "age": 59,
@@ -501,7 +540,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-10-22"
+      "unsorted_date": "2020-10-22",
+      "usherTree": "EPI_ISL_2375097"
     },
     {
       "age": 58,
@@ -513,7 +553,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2020-10-28"
+      "unsorted_date": "2020-10-28",
+      "usherTree": "EPI_ISL_2375165"
     },
     {
       "age": 56,
@@ -525,7 +566,8 @@
       "qc_value": null,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-11"
+      "unsorted_date": "2021-05-11",
+      "usherTree": "EPI_ISL_2375247"
     },
     {
       "age": 53,
@@ -537,7 +579,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-06-10"
+      "unsorted_date": "2021-06-10",
+      "usherTree": "EPI_ISL_2375490"
     },
     {
       "age": 58,
@@ -549,7 +592,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-06-01"
+      "unsorted_date": "2021-06-01",
+      "usherTree": "EPI_ISL_2379651"
     },
     {
       "age": 52,
@@ -561,7 +605,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-04-28"
+      "unsorted_date": "2021-04-28",
+      "usherTree": "EPI_ISL_2405276"
     },
     {
       "age": 59,
@@ -573,7 +618,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-03-02"
+      "unsorted_date": "2021-03-02",
+      "usherTree": "EPI_ISL_2408472"
     },
     {
       "age": 56,
@@ -585,7 +631,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-12"
+      "unsorted_date": "2021-05-12",
+      "usherTree": "EPI_ISL_2544226"
     },
     {
       "age": 51,
@@ -597,7 +644,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-05-13"
+      "unsorted_date": "2021-05-13",
+      "usherTree": "EPI_ISL_2544332"
     },
     {
       "age": 50,
@@ -609,7 +657,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-24"
+      "unsorted_date": "2021-05-24",
+      "usherTree": "EPI_ISL_2544452"
     },
     {
       "age": 55,
@@ -621,7 +670,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-05"
+      "unsorted_date": "2021-05-05",
+      "usherTree": "EPI_ISL_2574088"
     },
     {
       "age": null,
@@ -633,7 +683,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-01-16"
+      "unsorted_date": "2021-01-16",
+      "usherTree": "EPI_ISL_3016465"
     }
   ]
 }

--- a/endToEndTests/test/queries/DetailsOrderByLimit.json
+++ b/endToEndTests/test/queries/DetailsOrderByLimit.json
@@ -35,7 +35,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": null
+      "unsorted_date": null,
+      "usherTree": null
     },
     {
       "age": 51,
@@ -47,7 +48,8 @@
       "qc_value": 0.96,
       "region": null,
       "test_boolean_column": true,
-      "unsorted_date": "2021-01-25"
+      "unsorted_date": "2021-01-25",
+      "usherTree": "EPI_ISL_1597890"
     }
   ]
 }

--- a/endToEndTests/test/queries/LimitLargerThanTable.json
+++ b/endToEndTests/test/queries/LimitLargerThanTable.json
@@ -34,7 +34,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-08-04"
+      "unsorted_date": "2021-08-04",
+      "usherTree": "EPI_ISL_1080536"
     },
     {
       "age": 59,
@@ -46,7 +47,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-03-18"
+      "unsorted_date": "2021-03-18",
+      "usherTree": "EPI_ISL_1119315"
     },
     {
       "age": 54,
@@ -58,7 +60,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-07"
+      "unsorted_date": "2021-05-07",
+      "usherTree": "EPI_ISL_1129663"
     },
     {
       "age": 50,
@@ -70,7 +73,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-07-04"
+      "unsorted_date": "2021-07-04",
+      "usherTree": "EPI_ISL_1195052"
     },
     {
       "age": 51,
@@ -82,7 +86,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-18"
+      "unsorted_date": "2021-05-18",
+      "usherTree": "EPI_ISL_1273458"
     },
     {
       "age": 57,
@@ -94,7 +99,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-01-03"
+      "unsorted_date": "2021-01-03",
+      "usherTree": "EPI_ISL_1360935"
     },
     {
       "age": 50,
@@ -106,7 +112,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-01-20"
+      "unsorted_date": "2021-01-20",
+      "usherTree": "EPI_ISL_1361468"
     },
     {
       "age": 55,
@@ -118,7 +125,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-01-16"
+      "unsorted_date": "2021-01-16",
+      "usherTree": "EPI_ISL_1407962"
     },
     {
       "age": 50,
@@ -130,7 +138,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-11-24"
+      "unsorted_date": "2020-11-24",
+      "usherTree": "EPI_ISL_1408062"
     },
     {
       "age": 4,
@@ -142,7 +151,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": null
+      "unsorted_date": null,
+      "usherTree": null
     },
     {
       "age": 51,
@@ -154,7 +164,8 @@
       "qc_value": 0.96,
       "region": null,
       "test_boolean_column": true,
-      "unsorted_date": "2021-01-25"
+      "unsorted_date": "2021-01-25",
+      "usherTree": "EPI_ISL_1597890"
     },
     {
       "age": 54,
@@ -166,7 +177,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-02-10"
+      "unsorted_date": "2021-02-10",
+      "usherTree": "EPI_ISL_1597932"
     },
     {
       "age": 50,
@@ -178,7 +190,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-03-21"
+      "unsorted_date": "2021-03-21",
+      "usherTree": "EPI_ISL_1747752"
     },
     {
       "age": 59,
@@ -190,7 +203,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-03-03"
+      "unsorted_date": "2021-03-03",
+      "usherTree": "EPI_ISL_1747885"
     },
     {
       "age": 52,
@@ -202,7 +216,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-12-15"
+      "unsorted_date": "2020-12-15",
+      "usherTree": "EPI_ISL_1748215"
     },
     {
       "age": null,
@@ -214,7 +229,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-11-24"
+      "unsorted_date": "2020-11-24",
+      "usherTree": "EPI_ISL_1748243"
     },
     {
       "age": 53,
@@ -226,7 +242,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-04-27"
+      "unsorted_date": "2021-04-27",
+      "usherTree": "EPI_ISL_1748395"
     },
     {
       "age": 4,
@@ -238,7 +255,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2020-12-24"
+      "unsorted_date": "2020-12-24",
+      "usherTree": "EPI_ISL_1749892"
     },
     {
       "age": 5,
@@ -250,7 +268,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-03-08"
+      "unsorted_date": "2020-03-08",
+      "usherTree": "EPI_ISL_1749899"
     },
     {
       "age": 59,
@@ -262,7 +281,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-02-03"
+      "unsorted_date": "2021-02-03",
+      "usherTree": "EPI_ISL_1749960"
     },
     {
       "age": 54,
@@ -274,7 +294,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-04-23"
+      "unsorted_date": "2021-04-23",
+      "usherTree": "EPI_ISL_1760534"
     },
     {
       "age": 56,
@@ -286,7 +307,8 @@
       "qc_value": 0.96,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-10"
+      "unsorted_date": "2021-05-10",
+      "usherTree": "EPI_ISL_1840634"
     },
     {
       "age": 6,
@@ -298,7 +320,8 @@
       "qc_value": 0.96,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-01-29"
+      "unsorted_date": "2021-01-29",
+      "usherTree": "EPI_ISL_2016901"
     },
     {
       "age": 56,
@@ -310,7 +333,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-03-09"
+      "unsorted_date": "2021-03-09",
+      "usherTree": "EPI_ISL_2017036"
     },
     {
       "age": 58,
@@ -322,7 +346,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-01-22"
+      "unsorted_date": "2021-01-22",
+      "usherTree": "EPI_ISL_2019235"
     },
     {
       "age": 55,
@@ -334,7 +359,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2020-12-21"
+      "unsorted_date": "2020-12-21",
+      "usherTree": "EPI_ISL_2019350"
     },
     {
       "age": 59,
@@ -346,7 +372,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2020-08-17"
+      "unsorted_date": "2020-08-17",
+      "usherTree": "EPI_ISL_2180023"
     },
     {
       "age": 57,
@@ -358,7 +385,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-05-25"
+      "unsorted_date": "2021-05-25",
+      "usherTree": "EPI_ISL_2180995"
     },
     {
       "age": 58,
@@ -370,7 +398,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2020-10-08"
+      "unsorted_date": "2020-10-08",
+      "usherTree": "EPI_ISL_2181005"
     },
     {
       "age": 51,
@@ -382,7 +411,8 @@
       "qc_value": null,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-04-12"
+      "unsorted_date": "2021-04-12",
+      "usherTree": "EPI_ISL_2213804"
     },
     {
       "age": 53,
@@ -394,7 +424,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-04-23"
+      "unsorted_date": "2021-04-23",
+      "usherTree": "EPI_ISL_2213934"
     },
     {
       "age": 54,
@@ -406,7 +437,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-09"
+      "unsorted_date": "2021-05-09",
+      "usherTree": "EPI_ISL_2213984"
     },
     {
       "age": 58,
@@ -418,7 +450,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2020-11-13"
+      "unsorted_date": "2020-11-13",
+      "usherTree": "EPI_ISL_2214128"
     },
     {
       "age": 50,
@@ -430,7 +463,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-08"
+      "unsorted_date": "2021-05-08",
+      "usherTree": "EPI_ISL_2270139"
     },
     {
       "age": 52,
@@ -442,7 +476,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-05-08"
+      "unsorted_date": "2021-05-08",
+      "usherTree": "EPI_ISL_2307766"
     },
     {
       "age": 55,
@@ -454,7 +489,8 @@
       "qc_value": 0.96,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-23"
+      "unsorted_date": "2021-05-23",
+      "usherTree": "EPI_ISL_2307888"
     },
     {
       "age": 57,
@@ -466,7 +502,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2020-12-09"
+      "unsorted_date": "2020-12-09",
+      "usherTree": "EPI_ISL_2308054"
     },
     {
       "age": 57,
@@ -478,7 +515,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-03-10"
+      "unsorted_date": "2021-03-10",
+      "usherTree": "EPI_ISL_2360326"
     },
     {
       "age": 54,
@@ -490,7 +528,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-06-05"
+      "unsorted_date": "2021-06-05",
+      "usherTree": "EPI_ISL_2374969"
     },
     {
       "age": 59,
@@ -502,7 +541,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-10-22"
+      "unsorted_date": "2020-10-22",
+      "usherTree": "EPI_ISL_2375097"
     },
     {
       "age": 58,
@@ -514,7 +554,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2020-10-28"
+      "unsorted_date": "2020-10-28",
+      "usherTree": "EPI_ISL_2375165"
     },
     {
       "age": 56,
@@ -526,7 +567,8 @@
       "qc_value": null,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-11"
+      "unsorted_date": "2021-05-11",
+      "usherTree": "EPI_ISL_2375247"
     },
     {
       "age": 53,
@@ -538,7 +580,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-06-10"
+      "unsorted_date": "2021-06-10",
+      "usherTree": "EPI_ISL_2375490"
     },
     {
       "age": 58,
@@ -550,7 +593,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-06-01"
+      "unsorted_date": "2021-06-01",
+      "usherTree": "EPI_ISL_2379651"
     },
     {
       "age": 52,
@@ -562,7 +606,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-04-28"
+      "unsorted_date": "2021-04-28",
+      "usherTree": "EPI_ISL_2405276"
     },
     {
       "age": 59,
@@ -574,7 +619,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-03-02"
+      "unsorted_date": "2021-03-02",
+      "usherTree": "EPI_ISL_2408472"
     },
     {
       "age": 56,
@@ -586,7 +632,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-12"
+      "unsorted_date": "2021-05-12",
+      "usherTree": "EPI_ISL_2544226"
     },
     {
       "age": 51,
@@ -598,7 +645,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-05-13"
+      "unsorted_date": "2021-05-13",
+      "usherTree": "EPI_ISL_2544332"
     },
     {
       "age": 50,
@@ -610,7 +658,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-24"
+      "unsorted_date": "2021-05-24",
+      "usherTree": "EPI_ISL_2544452"
     },
     {
       "age": 55,
@@ -622,7 +671,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-05"
+      "unsorted_date": "2021-05-05",
+      "usherTree": "EPI_ISL_2574088"
     },
     {
       "age": null,
@@ -634,7 +684,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-01-16"
+      "unsorted_date": "2021-01-16",
+      "usherTree": "EPI_ISL_3016465"
     }
   ]
 }

--- a/endToEndTests/test/queries/MostRecentCommonAncestor_SimpleQuery.json
+++ b/endToEndTests/test/queries/MostRecentCommonAncestor_SimpleQuery.json
@@ -11,12 +11,12 @@
       "children": [
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_1003849"
         },
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_1260480"
         }
       ]

--- a/endToEndTests/test/queries/MostRecentCommonAncestor_SimpleQuery.json
+++ b/endToEndTests/test/queries/MostRecentCommonAncestor_SimpleQuery.json
@@ -3,7 +3,7 @@
   "query": {
     "action": {
       "type": "MostRecentCommonAncestor",
-      "columnName": "gisaid_epi_isl",
+      "columnName": "usherTree",
       "orderByFields": ["mrcaNode"]
     },
     "filterExpression": {
@@ -11,12 +11,12 @@
       "children": [
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1003849"
         },
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1260480"
         }
       ]

--- a/endToEndTests/test/queries/MostRecentCommonAncestor_onlyMissingNodes.json
+++ b/endToEndTests/test/queries/MostRecentCommonAncestor_onlyMissingNodes.json
@@ -26,7 +26,7 @@
   "expectedQueryResult": [
     {
       "mrcaNode": null,
-      "missingNodeCount": 3,
+      "missingNodeCount": 2,
       "missingFromTree": "EPI_ISL_1001493,EPI_ISL_1747752"
     }
   ]

--- a/endToEndTests/test/queries/MostRecentCommonAncestor_onlyMissingNodes.json
+++ b/endToEndTests/test/queries/MostRecentCommonAncestor_onlyMissingNodes.json
@@ -3,7 +3,7 @@
   "query": {
     "action": {
       "type": "MostRecentCommonAncestor",
-      "columnName": "gisaid_epi_isl",
+      "columnName": "usherTree",
       "orderByFields": ["mrcaNode"],
       "printNodesNotInTree": true
     },
@@ -12,12 +12,12 @@
       "children": [
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1001493"
         },
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1747752"
         }
       ]
@@ -26,7 +26,7 @@
   "expectedQueryResult": [
     {
       "mrcaNode": null,
-      "missingNodeCount": 2,
+      "missingNodeCount": 3,
       "missingFromTree": "EPI_ISL_1001493,EPI_ISL_1747752"
     }
   ]

--- a/endToEndTests/test/queries/MostRecentCommonAncestor_onlyMissingNodes.json
+++ b/endToEndTests/test/queries/MostRecentCommonAncestor_onlyMissingNodes.json
@@ -12,12 +12,12 @@
       "children": [
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_1001493"
         },
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_1747752"
         }
       ]

--- a/endToEndTests/test/queries/MostRecentCommonAncestor_withMissingNode.json
+++ b/endToEndTests/test/queries/MostRecentCommonAncestor_withMissingNode.json
@@ -3,7 +3,7 @@
   "query": {
     "action": {
       "type": "MostRecentCommonAncestor",
-      "columnName": "gisaid_epi_isl",
+      "columnName": "usherTree",
       "orderByFields": ["mrcaNode"],
       "printNodesNotInTree": true
     },
@@ -12,22 +12,22 @@
       "children": [
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1001493"
         },
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1004495"
         },
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1003373"
         },
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1747752"
         }
       ]

--- a/endToEndTests/test/queries/MostRecentCommonAncestor_withMissingNode.json
+++ b/endToEndTests/test/queries/MostRecentCommonAncestor_withMissingNode.json
@@ -12,23 +12,28 @@
       "children": [
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_1001493"
         },
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_1004495"
         },
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_1003373"
         },
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_1747752"
+        },
+        {
+          "type": "StringEquals",
+          "column": "gisaid_epi_isl",
+          "value": "EPI_ISL_1408408"
         }
       ]
     }
@@ -36,7 +41,7 @@
   "expectedQueryResult": [
     {
       "mrcaNode": "NODE_0000096",
-      "missingNodeCount": 2,
+      "missingNodeCount": 3,
       "missingFromTree": "EPI_ISL_1001493,EPI_ISL_1747752"
     }
   ]

--- a/endToEndTests/test/queries/Offset0.json
+++ b/endToEndTests/test/queries/Offset0.json
@@ -34,7 +34,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-08-04"
+      "unsorted_date": "2021-08-04",
+      "usherTree": "EPI_ISL_1080536"
     },
     {
       "age": 59,
@@ -46,7 +47,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-03-18"
+      "unsorted_date": "2021-03-18",
+      "usherTree": "EPI_ISL_1119315"
     },
     {
       "age": 54,
@@ -58,7 +60,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-07"
+      "unsorted_date": "2021-05-07",
+      "usherTree": "EPI_ISL_1129663"
     },
     {
       "age": 50,
@@ -70,7 +73,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-07-04"
+      "unsorted_date": "2021-07-04",
+      "usherTree": "EPI_ISL_1195052"
     },
     {
       "age": 51,
@@ -82,7 +86,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-18"
+      "unsorted_date": "2021-05-18",
+      "usherTree": "EPI_ISL_1273458"
     },
     {
       "age": 57,
@@ -94,7 +99,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-01-03"
+      "unsorted_date": "2021-01-03",
+      "usherTree": "EPI_ISL_1360935"
     },
     {
       "age": 50,
@@ -106,7 +112,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-01-20"
+      "unsorted_date": "2021-01-20",
+      "usherTree": "EPI_ISL_1361468"
     },
     {
       "age": 55,
@@ -118,7 +125,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-01-16"
+      "unsorted_date": "2021-01-16",
+      "usherTree": "EPI_ISL_1407962"
     },
     {
       "age": 50,
@@ -130,7 +138,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-11-24"
+      "unsorted_date": "2020-11-24",
+      "usherTree": "EPI_ISL_1408062"
     },
     {
       "age": 4,
@@ -142,7 +151,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": null
+      "unsorted_date": null,
+      "usherTree": null
     },
     {
       "age": 51,
@@ -154,7 +164,8 @@
       "qc_value": 0.96,
       "region": null,
       "test_boolean_column": true,
-      "unsorted_date": "2021-01-25"
+      "unsorted_date": "2021-01-25",
+      "usherTree": "EPI_ISL_1597890"
     },
     {
       "age": 54,
@@ -166,7 +177,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-02-10"
+      "unsorted_date": "2021-02-10",
+      "usherTree": "EPI_ISL_1597932"
     },
     {
       "age": 50,
@@ -178,7 +190,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-03-21"
+      "unsorted_date": "2021-03-21",
+      "usherTree": "EPI_ISL_1747752"
     },
     {
       "age": 59,
@@ -190,7 +203,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-03-03"
+      "unsorted_date": "2021-03-03",
+      "usherTree": "EPI_ISL_1747885"
     },
     {
       "age": 52,
@@ -202,7 +216,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-12-15"
+      "unsorted_date": "2020-12-15",
+      "usherTree": "EPI_ISL_1748215"
     },
     {
       "age": null,
@@ -214,7 +229,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-11-24"
+      "unsorted_date": "2020-11-24",
+      "usherTree": "EPI_ISL_1748243"
     },
     {
       "age": 53,
@@ -226,7 +242,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-04-27"
+      "unsorted_date": "2021-04-27",
+      "usherTree": "EPI_ISL_1748395"
     },
     {
       "age": 4,
@@ -238,7 +255,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2020-12-24"
+      "unsorted_date": "2020-12-24",
+      "usherTree": "EPI_ISL_1749892"
     },
     {
       "age": 5,
@@ -250,7 +268,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-03-08"
+      "unsorted_date": "2020-03-08",
+      "usherTree": "EPI_ISL_1749899"
     },
     {
       "age": 59,
@@ -262,7 +281,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-02-03"
+      "unsorted_date": "2021-02-03",
+      "usherTree": "EPI_ISL_1749960"
     },
     {
       "age": 54,
@@ -274,7 +294,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-04-23"
+      "unsorted_date": "2021-04-23",
+      "usherTree": "EPI_ISL_1760534"
     },
     {
       "age": 56,
@@ -286,7 +307,8 @@
       "qc_value": 0.96,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-10"
+      "unsorted_date": "2021-05-10",
+      "usherTree": "EPI_ISL_1840634"
     },
     {
       "age": 6,
@@ -298,7 +320,8 @@
       "qc_value": 0.96,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-01-29"
+      "unsorted_date": "2021-01-29",
+      "usherTree": "EPI_ISL_2016901"
     },
     {
       "age": 56,
@@ -310,7 +333,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-03-09"
+      "unsorted_date": "2021-03-09",
+      "usherTree": "EPI_ISL_2017036"
     },
     {
       "age": 58,
@@ -322,7 +346,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-01-22"
+      "unsorted_date": "2021-01-22",
+      "usherTree": "EPI_ISL_2019235"
     },
     {
       "age": 55,
@@ -334,7 +359,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2020-12-21"
+      "unsorted_date": "2020-12-21",
+      "usherTree": "EPI_ISL_2019350"
     },
     {
       "age": 59,
@@ -346,7 +372,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2020-08-17"
+      "unsorted_date": "2020-08-17",
+      "usherTree": "EPI_ISL_2180023"
     },
     {
       "age": 57,
@@ -358,7 +385,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-05-25"
+      "unsorted_date": "2021-05-25",
+      "usherTree": "EPI_ISL_2180995"
     },
     {
       "age": 58,
@@ -370,7 +398,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2020-10-08"
+      "unsorted_date": "2020-10-08",
+      "usherTree": "EPI_ISL_2181005"
     },
     {
       "age": 51,
@@ -382,7 +411,8 @@
       "qc_value": null,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-04-12"
+      "unsorted_date": "2021-04-12",
+      "usherTree": "EPI_ISL_2213804"
     },
     {
       "age": 53,
@@ -394,7 +424,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-04-23"
+      "unsorted_date": "2021-04-23",
+      "usherTree": "EPI_ISL_2213934"
     },
     {
       "age": 54,
@@ -406,7 +437,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-09"
+      "unsorted_date": "2021-05-09",
+      "usherTree": "EPI_ISL_2213984"
     },
     {
       "age": 58,
@@ -418,7 +450,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2020-11-13"
+      "unsorted_date": "2020-11-13",
+      "usherTree": "EPI_ISL_2214128"
     },
     {
       "age": 50,
@@ -430,7 +463,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-08"
+      "unsorted_date": "2021-05-08",
+      "usherTree": "EPI_ISL_2270139"
     },
     {
       "age": 52,
@@ -442,7 +476,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-05-08"
+      "unsorted_date": "2021-05-08",
+      "usherTree": "EPI_ISL_2307766"
     },
     {
       "age": 55,
@@ -454,7 +489,8 @@
       "qc_value": 0.96,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-23"
+      "unsorted_date": "2021-05-23",
+      "usherTree": "EPI_ISL_2307888"
     },
     {
       "age": 57,
@@ -466,7 +502,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2020-12-09"
+      "unsorted_date": "2020-12-09",
+      "usherTree": "EPI_ISL_2308054"
     },
     {
       "age": 57,
@@ -478,7 +515,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-03-10"
+      "unsorted_date": "2021-03-10",
+      "usherTree": "EPI_ISL_2360326"
     },
     {
       "age": 54,
@@ -490,7 +528,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-06-05"
+      "unsorted_date": "2021-06-05",
+      "usherTree": "EPI_ISL_2374969"
     },
     {
       "age": 59,
@@ -502,7 +541,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2020-10-22"
+      "unsorted_date": "2020-10-22",
+      "usherTree": "EPI_ISL_2375097"
     },
     {
       "age": 58,
@@ -514,7 +554,8 @@
       "qc_value": 0.93,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2020-10-28"
+      "unsorted_date": "2020-10-28",
+      "usherTree": "EPI_ISL_2375165"
     },
     {
       "age": 56,
@@ -526,7 +567,8 @@
       "qc_value": null,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-11"
+      "unsorted_date": "2021-05-11",
+      "usherTree": "EPI_ISL_2375247"
     },
     {
       "age": 53,
@@ -538,7 +580,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-06-10"
+      "unsorted_date": "2021-06-10",
+      "usherTree": "EPI_ISL_2375490"
     },
     {
       "age": 58,
@@ -550,7 +593,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-06-01"
+      "unsorted_date": "2021-06-01",
+      "usherTree": "EPI_ISL_2379651"
     },
     {
       "age": 52,
@@ -562,7 +606,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-04-28"
+      "unsorted_date": "2021-04-28",
+      "usherTree": "EPI_ISL_2405276"
     },
     {
       "age": 59,
@@ -574,7 +619,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-03-02"
+      "unsorted_date": "2021-03-02",
+      "usherTree": "EPI_ISL_2408472"
     },
     {
       "age": 56,
@@ -586,7 +632,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-12"
+      "unsorted_date": "2021-05-12",
+      "usherTree": "EPI_ISL_2544226"
     },
     {
       "age": 51,
@@ -598,7 +645,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-05-13"
+      "unsorted_date": "2021-05-13",
+      "usherTree": "EPI_ISL_2544332"
     },
     {
       "age": 50,
@@ -610,7 +658,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-24"
+      "unsorted_date": "2021-05-24",
+      "usherTree": "EPI_ISL_2544452"
     },
     {
       "age": 55,
@@ -622,7 +671,8 @@
       "qc_value": 0.91,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-05"
+      "unsorted_date": "2021-05-05",
+      "usherTree": "EPI_ISL_2574088"
     },
     {
       "age": null,
@@ -634,7 +684,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-01-16"
+      "unsorted_date": "2021-01-16",
+      "usherTree": "EPI_ISL_3016465"
     }
   ]
 }

--- a/endToEndTests/test/queries/OffsetLimitOverlap.json
+++ b/endToEndTests/test/queries/OffsetLimitOverlap.json
@@ -22,7 +22,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-03-15"
+      "unsorted_date": "2021-03-15",
+      "usherTree": "EPI_ISL_721941"
     },
     {
       "age": 53,
@@ -34,7 +35,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-14"
+      "unsorted_date": "2021-05-14",
+      "usherTree": "EPI_ISL_737604"
     },
     {
       "age": 56,
@@ -46,7 +48,8 @@
       "qc_value": 0.89,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-05-16"
+      "unsorted_date": "2021-05-16",
+      "usherTree": "EPI_ISL_737715"
     },
     {
       "age": 56,
@@ -58,7 +61,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-04-28"
+      "unsorted_date": "2021-04-28",
+      "usherTree": "EPI_ISL_737860"
     },
     {
       "age": 56,
@@ -70,7 +74,8 @@
       "qc_value": 0.98,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2020-03-16"
+      "unsorted_date": "2020-03-16",
+      "usherTree": "EPI_ISL_768148"
     },
     {
       "age": 50,
@@ -82,7 +87,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-03-03"
+      "unsorted_date": "2021-03-03",
+      "usherTree": "EPI_ISL_830864"
     },
     {
       "age": 59,
@@ -94,7 +100,8 @@
       "qc_value": 0.96,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-07-14"
+      "unsorted_date": "2021-07-14",
+      "usherTree": "EPI_ISL_899725"
     },
     {
       "age": 58,
@@ -106,7 +113,8 @@
       "qc_value": 0.97,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-07-19"
+      "unsorted_date": "2021-07-19",
+      "usherTree": "EPI_ISL_899762"
     },
     {
       "age": 50,
@@ -118,7 +126,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-05-10"
+      "unsorted_date": "2021-05-10",
+      "usherTree": "EPI_ISL_931031"
     },
     {
       "age": 50,
@@ -130,7 +139,8 @@
       "qc_value": 0.96,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-05-11"
+      "unsorted_date": "2021-05-11",
+      "usherTree": "EPI_ISL_931279"
     }
   ]
 }

--- a/endToEndTests/test/queries/PhyloDescendantOf.json
+++ b/endToEndTests/test/queries/PhyloDescendantOf.json
@@ -3,28 +3,28 @@
   "query": {
     "action": {
       "type": "Aggregated",
-      "groupByFields": ["gisaid_epi_isl"],
+      "groupByFields": ["usherTree"],
       "orderByFields": [
         {
-          "field": "gisaid_epi_isl",
+          "field": "usherTree",
           "order": "ascending"
         }
       ]
     },
     "filterExpression": {
       "type": "PhyloDescendantOf",
-      "column": "gisaid_epi_isl",
+      "column": "usherTree",
       "internalNode": "NODE_0000072"
     }
   },
   "expectedQueryResult": [
     {
       "count": 1,
-      "gisaid_epi_isl": "EPI_ISL_1003849"
+      "usherTree": "EPI_ISL_1003849"
     },
     {
       "count": 1,
-      "gisaid_epi_isl": "EPI_ISL_1260480"
+      "usherTree": "EPI_ISL_1260480"
     }
   ]
 }

--- a/endToEndTests/test/queries/Subtree_onlyMissingNodes.json
+++ b/endToEndTests/test/queries/Subtree_onlyMissingNodes.json
@@ -12,13 +12,18 @@
       "children": [
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_1001493"
         },
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_1747752"
+        },
+        {
+          "type": "StringEquals",
+          "column": "gisaid_epi_isl",
+          "value": "EPI_ISL_1408408"
         }
       ]
     }
@@ -26,7 +31,7 @@
   "expectedQueryResult": [
     {
       "subtreeNewick": "",
-      "missingNodeCount": 2,
+      "missingNodeCount": 3,
       "missingFromTree": "EPI_ISL_1001493,EPI_ISL_1747752"
     }
   ]

--- a/endToEndTests/test/queries/Subtree_onlyMissingNodes.json
+++ b/endToEndTests/test/queries/Subtree_onlyMissingNodes.json
@@ -3,7 +3,7 @@
   "query": {
     "action": {
       "type": "PhyloSubtree",
-      "columnName": "gisaid_epi_isl",
+      "columnName": "usherTree",
       "orderByFields": ["subtreeNewick"],
       "printNodesNotInTree": true
     },
@@ -12,12 +12,12 @@
       "children": [
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1001493"
         },
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1747752"
         }
       ]
@@ -26,7 +26,7 @@
   "expectedQueryResult": [
     {
       "subtreeNewick": "",
-      "missingNodeCount": 2,
+      "missingNodeCount": 3,
       "missingFromTree": "EPI_ISL_1001493,EPI_ISL_1747752"
     }
   ]

--- a/endToEndTests/test/queries/Subtree_onlyMissingNodes.json
+++ b/endToEndTests/test/queries/Subtree_onlyMissingNodes.json
@@ -26,7 +26,7 @@
   "expectedQueryResult": [
     {
       "subtreeNewick": "",
-      "missingNodeCount": 3,
+      "missingNodeCount": 2,
       "missingFromTree": "EPI_ISL_1001493,EPI_ISL_1747752"
     }
   ]

--- a/endToEndTests/test/queries/Subtree_simpleQuery.json
+++ b/endToEndTests/test/queries/Subtree_simpleQuery.json
@@ -3,7 +3,7 @@
   "query": {
     "action": {
       "type": "PhyloSubtree",
-      "columnName": "gisaid_epi_isl",
+      "columnName": "usherTree",
       "orderByFields": ["subtreeNewick"],
       "contractUnaryNodes": false
     },
@@ -12,12 +12,12 @@
       "children": [
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_3247294"
         },
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_3465732"
         }
       ]

--- a/endToEndTests/test/queries/Subtree_simpleQuery.json
+++ b/endToEndTests/test/queries/Subtree_simpleQuery.json
@@ -12,12 +12,12 @@
       "children": [
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_3247294"
         },
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_3465732"
         }
       ]

--- a/endToEndTests/test/queries/Subtree_simple_query_without_unary_nodes.json
+++ b/endToEndTests/test/queries/Subtree_simple_query_without_unary_nodes.json
@@ -3,7 +3,7 @@
   "query": {
     "action": {
       "type": "PhyloSubtree",
-      "columnName": "gisaid_epi_isl",
+      "columnName": "usherTree",
       "orderByFields": ["subtreeNewick"],
       "contractUnaryNodes": true
     },
@@ -12,12 +12,12 @@
       "children": [
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_3247294"
         },
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_3465732"
         }
       ]

--- a/endToEndTests/test/queries/Subtree_simple_query_without_unary_nodes.json
+++ b/endToEndTests/test/queries/Subtree_simple_query_without_unary_nodes.json
@@ -12,12 +12,12 @@
       "children": [
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_3247294"
         },
         {
           "type": "StringEquals",
-          "column": "usherTree",
+          "column": "gisaid_epi_isl",
           "value": "EPI_ISL_3465732"
         }
       ]

--- a/endToEndTests/test/queries/Subtree_withMissingNode.json
+++ b/endToEndTests/test/queries/Subtree_withMissingNode.json
@@ -3,7 +3,7 @@
   "query": {
     "action": {
       "type": "PhyloSubtree",
-      "columnName": "gisaid_epi_isl",
+      "columnName": "usherTree",
       "orderByFields": ["subtreeNewick"],
       "printNodesNotInTree": true
     },
@@ -12,22 +12,22 @@
       "children": [
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1001493"
         },
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1004495"
         },
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1003373"
         },
         {
           "type": "StringEquals",
-          "column": "gisaid_epi_isl",
+          "column": "usherTree",
           "value": "EPI_ISL_1747752"
         }
       ]
@@ -36,7 +36,7 @@
   "expectedQueryResult": [
     {
       "subtreeNewick": "(EPI_ISL_1003373:0.00010761,EPI_ISL_1004495:0.00013378)NODE_0000096;",
-      "missingNodeCount": 2,
+      "missingNodeCount": 3,
       "missingFromTree": "EPI_ISL_1001493,EPI_ISL_1747752"
     }
   ]

--- a/endToEndTests/test/queries/Subtree_withMissingNode.json
+++ b/endToEndTests/test/queries/Subtree_withMissingNode.json
@@ -36,7 +36,7 @@
   "expectedQueryResult": [
     {
       "subtreeNewick": "(EPI_ISL_1003373:0.00010761,EPI_ISL_1004495:0.00013378)NODE_0000096;",
-      "missingNodeCount": 3,
+      "missingNodeCount": 2,
       "missingFromTree": "EPI_ISL_1001493,EPI_ISL_1747752"
     }
   ]

--- a/endToEndTests/test/queries/nOf_2of3_details.json
+++ b/endToEndTests/test/queries/nOf_2of3_details.json
@@ -41,7 +41,8 @@
       "qc_value": 0.9,
       "region": "Europe",
       "test_boolean_column": false,
-      "unsorted_date": "2021-01-22"
+      "unsorted_date": "2021-01-22",
+      "usherTree": "EPI_ISL_2019235"
     },
     {
       "age": 50,
@@ -53,7 +54,8 @@
       "qc_value": 0.95,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2021-07-04"
+      "unsorted_date": "2021-07-04",
+      "usherTree": "EPI_ISL_1195052"
     },
     {
       "age": 54,
@@ -65,7 +67,8 @@
       "qc_value": 0.94,
       "region": "Europe",
       "test_boolean_column": true,
-      "unsorted_date": "2021-02-10"
+      "unsorted_date": "2021-02-10",
+      "usherTree": "EPI_ISL_1597932"
     },
     {
       "age": 50,
@@ -77,7 +80,8 @@
       "qc_value": 0.92,
       "region": "Europe",
       "test_boolean_column": null,
-      "unsorted_date": "2020-12-17"
+      "unsorted_date": "2020-12-17",
+      "usherTree": "EPI_ISL_1005148"
     }
   ]
 }

--- a/src/silo/query_engine/actions/most_recent_common_ancestor.h
+++ b/src/silo/query_engine/actions/most_recent_common_ancestor.h
@@ -19,7 +19,7 @@ class MostRecentCommonAncestor : public TreeAction {
    MostRecentCommonAncestor(std::string column_name, bool print_nodes_not_in_tree);
 
    arrow::Status addResponseToBuilder(
-      std::unordered_set<std::string>& all_node_ids,
+      NodeValuesResponse& all_node_ids,
       std::unordered_map<std::string_view, exec_node::JsonValueTypeArrayBuilder>& output_builder,
       const common::PhyloTree& phylo_tree,
       bool print_nodes_not_in_tree

--- a/src/silo/query_engine/actions/phylo_subtree.h
+++ b/src/silo/query_engine/actions/phylo_subtree.h
@@ -20,7 +20,7 @@ class PhyloSubtree : public TreeAction {
    PhyloSubtree(std::string column_name, bool print_nodes_not_in_tree, bool contract_unary_nodes);
 
    arrow::Status addResponseToBuilder(
-      std::unordered_set<std::string>& all_node_ids,
+      NodeValuesResponse& all_node_ids,
       std::unordered_map<std::string_view, exec_node::JsonValueTypeArrayBuilder>& output_builder,
       const common::PhyloTree& phylo_tree,
       bool print_nodes_not_in_tree

--- a/src/silo/query_engine/actions/tree_action.cpp
+++ b/src/silo/query_engine/actions/tree_action.cpp
@@ -58,7 +58,7 @@ NodeValuesResponse TreeAction::getNodeValues(
       num_rows += filter->cardinality();
    }
    std::unordered_set<std::string> all_tree_node_ids;
-   int num_empty = 0;
+   uint32_t num_empty = 0;
    all_tree_node_ids.reserve(num_rows);
    for (size_t i = 0; i < table->getNumberOfPartitions(); ++i) {
       const storage::TablePartition& table_partition = table->getPartition(i);

--- a/src/silo/query_engine/actions/tree_action.cpp
+++ b/src/silo/query_engine/actions/tree_action.cpp
@@ -48,7 +48,7 @@ void TreeAction::validateOrderByFields(const schema::TableSchema& schema) const 
    }
 }
 
-std::unordered_set<std::string> TreeAction::getNodeValues(
+NodeValuesResponse TreeAction::getNodeValues(
    std::shared_ptr<const storage::Table> table,
    const std::string& column_name,
    std::vector<CopyOnWriteBitmap>& bitmap_filter
@@ -58,6 +58,7 @@ std::unordered_set<std::string> TreeAction::getNodeValues(
       num_rows += filter->cardinality();
    }
    std::unordered_set<std::string> all_tree_node_ids;
+   int num_empty = 0;
    all_tree_node_ids.reserve(num_rows);
    for (size_t i = 0; i < table->getNumberOfPartitions(); ++i) {
       const storage::TablePartition& table_partition = table->getPartition(i);
@@ -73,10 +74,12 @@ std::unordered_set<std::string> TreeAction::getNodeValues(
             string_column.lookupValue(string_column.getValues().at(row_in_table_partition));
          if (!value.empty()) {
             all_tree_node_ids.insert(value);
+         } else {
+            ++num_empty;
          }
       }
    }
-   return all_tree_node_ids;
+   return NodeValuesResponse{std::move(all_tree_node_ids), num_empty};
 }
 
 arrow::Result<QueryPlan> TreeAction::toQueryPlanImpl(
@@ -136,11 +139,11 @@ arrow::Result<QueryPlan> TreeAction::toQueryPlanImpl(
          );
       }
 
-      auto all_node_ids =
+      auto node_values =
          this->getNodeValues(table, column_name_to_evaluate, evaluated_partition_filters);
 
       ARROW_RETURN_NOT_OK(
-         this->addResponseToBuilder(all_node_ids, output_builder, phylo_tree, print_missing_nodes)
+         this->addResponseToBuilder(node_values, output_builder, phylo_tree, print_missing_nodes)
       );
 
       // Order of result_columns is relevant as it needs to be consistent with vector in schema

--- a/src/silo/query_engine/actions/tree_action.h
+++ b/src/silo/query_engine/actions/tree_action.h
@@ -22,7 +22,7 @@ namespace silo::query_engine::actions {
 class NodeValuesResponse {
   public:
    std::unordered_set<std::string> node_values;
-   int32_t missing_node_count = 0;
+   uint32_t missing_node_count = 0;
 };
 
 class TreeAction : public Action {

--- a/src/silo/query_engine/actions/tree_action.h
+++ b/src/silo/query_engine/actions/tree_action.h
@@ -19,6 +19,12 @@
 
 namespace silo::query_engine::actions {
 
+class NodeValuesResponse {
+  public:
+   std::unordered_set<std::string> node_values;
+   int32_t missing_node_count = 0;
+};
+
 class TreeAction : public Action {
   private:
    std::string column_name;
@@ -41,14 +47,14 @@ class TreeAction : public Action {
   public:
    TreeAction(std::string column_name, bool print_nodes_not_in_tree);
 
-   std::unordered_set<std::string> getNodeValues(
+   NodeValuesResponse getNodeValues(
       std::shared_ptr<const storage::Table> table,
       const std::string& column_name,
       std::vector<CopyOnWriteBitmap>& bitmap_filter
    ) const;
 
    virtual arrow::Status addResponseToBuilder(
-      std::unordered_set<std::string>& all_node_ids,
+      NodeValuesResponse& all_node_ids,
       std::unordered_map<std::string_view, exec_node::JsonValueTypeArrayBuilder>& output_builder,
       const common::PhyloTree& phylo_tree,
       bool print_nodes_not_in_tree

--- a/testBaseData/exampleDataset/README.md
+++ b/testBaseData/exampleDataset/README.md
@@ -1,0 +1,26 @@
+## Phylogenetic Tree
+
+The phylogenetic tree was created from the `input_file.ndjson` entries. First a new metadata field was created called `usherTree` that was a copy of the `gisaid_epi_isl` field.
+
+```bash
+jq -c '.metadata.usherTree = .metadata.gisaid_epi_isl' input_file.ndjson > output.ndjson
+```
+
+Then the sequences in the ndjson file were extracted into a fasta file where the `usherTree` column was used as the fasta entry header. Then a tree was generated using [`augur tree`](https://github.com/nextstrain/augur), additionally to label the internal nodes `augur refine` was run.
+
+```bash
+jq -r '
+  # for each JSON object (.),
+  # grab the ID and sequence, then format as FASTA
+  . as $obj
+  | ">" + ($obj.metadata.usherTree) 
+    + "\n" 
+    + ($obj.alignedNucleotideSequences.main)
+' input_file.ndjson > output.fasta
+
+augur tree --alignment output.fasta --output initial.tree
+
+augur refine  --tree initial.tree --alignment output.fasta --output-tree output.tree
+```
+
+Later `EPI_ISL_1001493` and `EPI_ISL_1747752` were removed from the tree and the node `EPI_ISL_1408408` was set to null in the metadata. This ensures that the missing node count should always be 3.

--- a/testBaseData/exampleDataset/database_config.yaml
+++ b/testBaseData/exampleDataset/database_config.yaml
@@ -3,6 +3,8 @@ schema:
   metadata:
     - name: gisaid_epi_isl
       type: string
+    - name: usherTree
+      type: string
       isPhyloTreeField: true
     - name: date
       type: date


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves https://github.com/GenSpectrum/LAPIS-SILO/issues/926

### Summary
1. Adds docs on how the phylogenetic trees were created for the e2e tests.
2. Changes the e2e configuration by adding a new field `usherTree` which should be used as the `phyloTreeField` instead of the primaryKey - the tests had to be modified to now include this new field in the expected result.
3. @chaoran-chen discovered that in the case where there were NULL values in the phyloTree column these are not included in the missing Node count - I have now added these - however, we offer the option to print missing nodes - we print the name of the nodes in the `usherTree` field - thus for NULL values these are not added to the list. Is this intended behavior? Should we create a new field for NULL values instead of adding this to the missing node count?

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
