### PR TITLE
build: always export compile commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_BINARY_DIR}/generators/")
 # (looking for the <lib>-config.cmake files of transitive dependencies of modules, e.g. spdlog->fmt)
 set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "${CMAKE_BINARY_DIR}/generators/")
 
+# Export compile commands for configuring language servers or debugging the build
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Export compile commands for configuring language servers or debugging the build.

It does have non noticable over-head on project setup