### PR TITLE
feat: increase default concurrent connections to 256 and number of worker threads to 8

### DIFF
--- a/src/silo/config/runtime_config.cpp
+++ b/src/silo/config/runtime_config.cpp
@@ -82,12 +82,12 @@ ConfigSpecification RuntimeConfig::getConfigSpecification() {
             ),
             ConfigAttributeSpecification::createWithDefault(
                apiMaxConnectionsOptionKey(),
-               ConfigValue::fromInt32(64),
+               ConfigValue::fromInt32(256),
                "The maximum number of concurrent connections accepted at any time."
             ),
             ConfigAttributeSpecification::createWithDefault(
                apiParallelThreadsOptionKey(),
-               ConfigValue::fromInt32(4),
+               ConfigValue::fromInt32(8),
                "The number of worker threads."
             ),
             ConfigAttributeSpecification::createWithoutDefault(


### PR DESCRIPTION
### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

As a follow-up to #952

Such that default LAPIS and default SILO configurations are always compatible