### PR TITLE
feat: default to using number of threads equal to processors

### DIFF
--- a/src/silo/config/runtime_config.cpp
+++ b/src/silo/config/runtime_config.cpp
@@ -87,8 +87,9 @@ ConfigSpecification RuntimeConfig::getConfigSpecification() {
             ),
             ConfigAttributeSpecification::createWithDefault(
                apiParallelThreadsOptionKey(),
-               ConfigValue::fromInt32(8),
-               "The number of worker threads."
+               ConfigValue::fromInt32(0),
+               "The number of worker threads. If set to 0 it will be set to the number of "
+               "processors."
             ),
             ConfigAttributeSpecification::createWithoutDefault(
                apiEstimatedStartupTimeOptionKey(),


### PR DESCRIPTION
We ran into another annoying situation when comparing benchmarking results and noticed that we did not set the thread count appropriately. This will fix the problem