### PR TITLE
benchmarking: preprocessing sc2open

### DIFF
--- a/src/silo/append/database_inserter.cpp
+++ b/src/silo/append/database_inserter.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include "evobench/evobench.hpp"
 #include "silo/common/error.h"
 #include "silo/schema/duplicate_primary_key_exception.h"
 
@@ -164,7 +165,7 @@ std::expected<void, std::string> TablePartitionInserter::insert(
    simdjson::ondemand::document_reference ndjson_line,
    const std::vector<TablePartitionInserter::SniffedField>& field_order_hint
 ) const {
-   EVOBENCH_SCOPE("TablePartitionInserter", "insert");
+   EVOBENCH_SCOPE_EVERY(20, "TablePartitionInserter", "insert");
    ASSIGN_OR_RAISE(auto object, iterateToObject(ndjson_line));
    for (auto sniffed_field : field_order_hint) {
       ASSIGN_OR_RAISE(auto column_value, findFieldWithFallbacks(object, sniffed_field));

--- a/src/silo/append/ndjson_line_reader.h
+++ b/src/silo/append/ndjson_line_reader.h
@@ -48,7 +48,7 @@ class NdjsonLineReader {
       }
 
       iterator& operator++() {
-         EVOBENCH_SCOPE("NdjsonLineReader::Iterator", "operator++");
+         EVOBENCH_SCOPE_EVERY(21, "NdjsonLineReader::Iterator", "operator++");
          if (stream->error) {
             at_end = true;
          }

--- a/src/silo/storage/column_group.cpp
+++ b/src/silo/storage/column_group.cpp
@@ -323,7 +323,7 @@ std::expected<void, std::string> ColumnPartitionGroup::addJsonValueToColumn(
    const schema::ColumnIdentifier& column,
    simdjson::ondemand::value& value
 ) {
-   EVOBENCH_SCOPE("ColumnPartitionGroup", "addJsonValueToColumn");
+   EVOBENCH_SCOPE_EVERY(200, "ColumnPartitionGroup", "addJsonValueToColumn");
    return column::visit(column.type, ColumnValueInserter{}, *this, column, value);
 }
 

--- a/src/silo/storage/column_group.cpp
+++ b/src/silo/storage/column_group.cpp
@@ -323,7 +323,7 @@ std::expected<void, std::string> ColumnPartitionGroup::addJsonValueToColumn(
    const schema::ColumnIdentifier& column,
    simdjson::ondemand::value& value
 ) {
-   EVOBENCH_SCOPE_EVERY(200, "ColumnPartitionGroup", "addJsonValueToColumn");
+   EVOBENCH_SCOPE_EVERY(1000, "ColumnPartitionGroup", "addJsonValueToColumn");
    return column::visit(column.type, ColumnValueInserter{}, *this, column, value);
 }
 


### PR DESCRIPTION
### Summary

Benchmarking of SCov2 was impossible with the existing probes because it generated too much data (so much so that it filled the /dev/shm tmpfs).

Change the hot probes to statistical ones so that benchmarking of preprocessing of SCov2 works.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted or there is an issue to do so.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
