### PR TITLE
Suggestion for reduced chance of stall, better cleanup, better logging

### DIFF
--- a/src/silo/query_engine/query_plan.cpp
+++ b/src/silo/query_engine/query_plan.cpp
@@ -28,19 +28,28 @@ arrow::Status QueryPlan::executeAndWriteImpl(
    std::ostream* output_stream,
    uint64_t timeout_in_seconds
 ) {
+   constexpr double kGraceShutdownSeconds = 5.0;  // avoid hanging on teardown
    EVOBENCH_SCOPE("QueryPlan", "execute");
    SPDLOG_TRACE("{}", arrow_plan->ToString());
    arrow_plan->StartProducing();
    SPDLOG_TRACE("Plan started producing, will now read the resulting batches.");
+
+   // Ensure plan is stopped on any exit path (timeout/error/exception).
+   struct PlanStopGuard {
+      std::shared_ptr<arrow::acero::ExecPlan> plan;
+      ~PlanStopGuard() { if (plan) plan->StopProducing(); }
+   } guard{arrow_plan};
+
    while (true) {
       arrow::Future<std::optional<arrow::ExecBatch>> future_batch = results_generator();
       SPDLOG_TRACE("await the next batch");
-      bool finished_batch_in_time = future_batch.Wait(timeout_in_seconds);
+      bool finished_batch_in_time = future_batch.Wait(static_cast<double>(timeout_in_seconds));
       if (!finished_batch_in_time) {
-         return arrow::Status::ExecutionError(fmt::format(
-            "Request timed out, could not detect any progress within {} seconds.",
-            timeout_in_seconds
-         ));
+         SPDLOG_WARN("Batch wait timed out after {} s — stopping plan.", timeout_in_seconds);
+         arrow_plan->StopProducing();  // best-effort cancel
+         (void)arrow_plan->finished().Wait(kGraceShutdownSeconds);  // bounded drain
+         return arrow::Status::ExecutionError(
+            fmt::format("Request timed out, no batch within {} seconds.", timeout_in_seconds));
       }
       ARROW_ASSIGN_OR_RAISE(std::optional<arrow::ExecBatch> optional_batch, future_batch.result());
       SPDLOG_TRACE("Batch received");
@@ -48,7 +57,7 @@ arrow::Status QueryPlan::executeAndWriteImpl(
       if (!optional_batch.has_value()) {
          break;  // end of input
       }
-      SPDLOG_TRACE("Batch contains data with {} values.", optional_batch.value().length);
+      SPDLOG_TRACE("Batch contains {} rows.", optional_batch->length);
 
       // TODO(#764) make output format configurable
       ARROW_RETURN_NOT_OK(
@@ -57,20 +66,17 @@ arrow::Status QueryPlan::executeAndWriteImpl(
    };
    SPDLOG_TRACE("Finished reading all batches.");
    auto future = arrow_plan->finished();
-   if (future.state() == arrow::FutureState::PENDING) {
-      SPDLOG_DEBUG(
-         "Plan still pending, but no more results in the future? Not a problem in itself as it "
-         "could be a race condition so the next await will clear this, but be a hint in case we "
-         "detect some weird behavior."
-      );
-   }
-   future.Wait();
-   if (future.status().ok()) {
-      SPDLOG_DEBUG("All results successfully produced. Clearing ExecPlan.");
+   // Bounded wait for teardown; don't block forever on buggy operators.
+   const bool drained = future.Wait(kGraceShutdownSeconds);
+   if (drained) {
+      if (future.status().ok()) {
+         SPDLOG_DEBUG("All results successfully produced. Clearing ExecPlan.");
+      } else {
+         return future.status();
+      }
    } else {
-      return future.status();
+      SPDLOG_WARN("ExecPlan cleanup exceeded {} s grace; continuing.", kGraceShutdownSeconds);
    }
-   arrow_plan->StopProducing();
    return arrow::Status::OK();
 }
 


### PR DESCRIPTION
I don't know much Cpp nor Arrow but some reading of docs and interaction with ChatGPT makes me think that there is scope of improvement here.

E.g. it seems you still don't always have timeouts when you wait? The debug log mentions a race condition - what guarantees that this race condition won't cause a deadlock?

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [ ] The implemented feature is covered by an appropriate test.
