### PR TITLE
refactor(benchmarking): do not configure the API via hard-coded parameters

### DIFF
--- a/benchmarking/Makefile_api
+++ b/benchmarking/Makefile_api
@@ -51,9 +51,6 @@ dependencies: $(API_QUERY)
 
 # ---- Running silo -----------------------------------------------------------
 
-API_OPTIONS=--api-threads-for-http-connections 16
-export API_OPTIONS
-
 .silo.pid: $(PREPROCESSING_STAMP)
 	rm -f .silo.stopped
 	bin/start-silo

--- a/benchmarking/bin/run-silo
+++ b/benchmarking/bin/run-silo
@@ -1,8 +1,5 @@
 #!/bin/bash
 set -meuo pipefail
-IFS=' '
 
 echo "$$" > .silo.pid
-exec "$SILO" api --data-directory "$OUTPUT_DIR" $API_OPTIONS
-
-
+exec "$SILO" api --data-directory "$OUTPUT_DIR"


### PR DESCRIPTION


### Summary

@Taepper's change to use all hardware threads #960 was not taking effect because we passed it a configuration flag to set it explicitly. Now the default is to let #960 take its effect (use all hardware threads), but it can be overridden via the `SILO_API_THREADS_FOR_HTTP_CONNECTIONS` env var which is now also configured in the 'ci' (https://github.com/GenSpectrum/silo-benchmark-ci/commit/5780178ea2e2cf33dda0391f6a7450b494ee9c00).


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted or there is an issue to do so.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
