### PR TITLE
refactor: change the default port for e2e testing using the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,14 @@ output: ${SILO_EXECUTABLE}
 
 ${RUNNING_SILO_FLAG}: ${SILO_EXECUTABLE} output
 	@{ \
-		if lsof -i :8081 > /dev/null 2>&1; then \
-			echo "Error: Port 8081 is already in use. Another SILO instance might already be running."; \
+``		if lsof -i :8093 > /dev/null 2>&1; then \
+			echo "Error: Port 8093 is already in use. Another SILO instance might already be running."; \
 			exit 1; \
 		fi; \
-		${SILO_EXECUTABLE} api & \
+		${SILO_EXECUTABLE} api --api-port 8093 & \
 		pid=$$!; \
 		echo "Waiting for silo (PID $$pid) to be ready..."; \
-		until curl -s -o /dev/null -w "%{http_code}" http://localhost:8081/info | grep -q "200"; do \
+		until curl -s -o /dev/null -w "%{http_code}" http://localhost:8093/info | grep -q "200"; do \
 			sleep 0.2; \
 		done; \
 		echo $$pid > ${RUNNING_SILO_FLAG}; \
@@ -38,7 +38,7 @@ ${RUNNING_SILO_FLAG}: ${SILO_EXECUTABLE} output
 
 e2e: ${RUNNING_SILO_FLAG}
 	trap 'make clean-api' EXIT; \
-	(cd endToEndTests && SILO_URL=localhost:8081 npm run test)
+	(cd endToEndTests && SILO_URL=localhost:8093 npm run test)
 
 test: ${SILO_EXECUTABLE}
 	build/Debug/silo_test --gtest_filter=* --gtest_color=no


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This is handy because the port 8081 is used by many deployments of ours. Therefore it can happy often that it will be in use when running the unit tests on e.g. the dev server.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
