### PR TITLE
feat(silo): fix clang-tidy configs (no comment allowed in checks), error on warnings in CMake clang-tidy option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 WarningsAsErrors: "*"
-Checks: >
+Checks: >-
   -*,
   abseil-*,
   bugprone-*,
@@ -12,7 +12,6 @@ Checks: >
   readability-*,
   performance-*,
   readability-magic-numbers,
-# clang-analyzer-cplusplus.NewDeleteLeaks TODO(#632) readd
   -misc-non-private-member-variables-in-classes,
   -misc-include-cleaner,
   -google-readability-avoid-underscore-in-googletest-name,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ if (NOT CMAKE_BUILD_TYPE STREQUAL Release AND BUILD_WITH_CLANG_TIDY)
     else ()
         message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
         message(STATUS "run clang tidy with: ${CLANG_TIDY_EXE}")
-        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE};--warnings-as-errors=*")
     endif ()
 endif ()
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [ ] The implemented feature is covered by an appropriate test.
