### PR TITLE
fix(e2e): remove obsolete version tag in docker compose files leading to warning

### DIFF
--- a/docker-compose-for-tests-api.yml
+++ b/docker-compose-for-tests-api.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   silo:
     image: ${SILO_IMAGE}

--- a/docker-compose-for-tests-preprocessing-from-ndjson.yml
+++ b/docker-compose-for-tests-preprocessing-from-ndjson.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   silo:
     image: ${SILO_IMAGE}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves a misleading warning that is printed in our CI on every PR
