### PR TITLE
refactor(silo): change CopyOnWriteBitmap interface to better differentiate owning and non-owning bitmaps

### DIFF
--- a/src/silo/api/query_handler.cpp
+++ b/src/silo/api/query_handler.cpp
@@ -36,6 +36,8 @@ void QueryHandler::post(
    Poco::Net::HTTPServerResponse& response
 ) {
    EVOBENCH_SCOPE("QueryHandler", "post");
+
+   // This fixes the database to outlive the execution of the query
    const auto database = database_handle->getActiveDatabase();
 
    const auto request_id = response.get("X-Request-Id");

--- a/src/silo/common/phylo_tree.cpp
+++ b/src/silo/common/phylo_tree.cpp
@@ -21,7 +21,6 @@
 
 #include "evobench/evobench.hpp"
 #include "silo/preprocessing/preprocessing_exception.h"
-#include "silo/query_engine/bad_request.h"
 
 namespace silo::common {
 using silo::common::TreeNodeId;

--- a/src/silo/query_engine/batched_bitmap_reader.test.cpp
+++ b/src/silo/query_engine/batched_bitmap_reader.test.cpp
@@ -55,7 +55,7 @@ TEST(BatchedBitmapReader, batchesCorrectlyHundredsOfValues) {
    initial_bitmap.add(1002);
    initial_bitmap.add(1004);
 
-   CopyOnWriteBitmap bitmap{initial_bitmap};
+   CopyOnWriteBitmap bitmap{&initial_bitmap};
    BatchedBitmapReader under_test{bitmap, batch_size - 1};
 
    size_t expected_batches = (initial_bitmap.cardinality() + batch_size - 1) / batch_size;

--- a/src/silo/query_engine/copy_on_write_bitmap.cpp
+++ b/src/silo/query_engine/copy_on_write_bitmap.cpp
@@ -10,9 +10,9 @@ CopyOnWriteBitmap::CopyOnWriteBitmap()
     : mutable_bitmap(std::make_shared<roaring::Roaring>()),
       immutable_bitmap(nullptr) {}
 
-CopyOnWriteBitmap::CopyOnWriteBitmap(const roaring::Roaring& bitmap)
+CopyOnWriteBitmap::CopyOnWriteBitmap(const roaring::Roaring* bitmap)
     : mutable_bitmap(nullptr),
-      immutable_bitmap(&bitmap) {}
+      immutable_bitmap(bitmap) {}
 
 CopyOnWriteBitmap::CopyOnWriteBitmap(roaring::Roaring&& bitmap)
     : mutable_bitmap(std::make_shared<roaring::Roaring>(std::move(bitmap))),

--- a/src/silo/query_engine/copy_on_write_bitmap.h
+++ b/src/silo/query_engine/copy_on_write_bitmap.h
@@ -15,7 +15,11 @@ class CopyOnWriteBitmap {
 
   public:
    CopyOnWriteBitmap();
-   explicit CopyOnWriteBitmap(const roaring::Roaring& bitmap);
+
+   // A CopyOnWriteBitmap pointing into an immutable bitmap should only be constructed
+   // when the CopyOnWriteBitmap's lifetime is contained by bitmap
+   explicit CopyOnWriteBitmap(const roaring::Roaring* bitmap);
+
    explicit CopyOnWriteBitmap(roaring::Roaring&& bitmap);
 
    roaring::Roaring& operator*();

--- a/src/silo/query_engine/filter/expressions/bool_equals.cpp
+++ b/src/silo/query_engine/filter/expressions/bool_equals.cpp
@@ -43,16 +43,16 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> BoolEquals::com
 
    if (value == std::nullopt) {
       return std::make_unique<operators::IndexScan>(
-         &bool_column.null_bitmap, table_partition.sequence_count
+         CopyOnWriteBitmap{&bool_column.null_bitmap}, table_partition.sequence_count
       );
    }
    if (value.value()) {
       return std::make_unique<operators::IndexScan>(
-         &bool_column.true_bitmap, table_partition.sequence_count
+         CopyOnWriteBitmap{&bool_column.true_bitmap}, table_partition.sequence_count
       );
    } else {
       return std::make_unique<operators::IndexScan>(
-         &bool_column.false_bitmap, table_partition.sequence_count
+         CopyOnWriteBitmap{&bool_column.false_bitmap}, table_partition.sequence_count
       );
    }
    SILO_UNREACHABLE();

--- a/src/silo/query_engine/filter/expressions/float_between.cpp
+++ b/src/silo/query_engine/filter/expressions/float_between.cpp
@@ -69,7 +69,7 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> FloatBetween::c
    if (predicates.empty()) {
       return std::make_unique<operators::Complement>(
          std::make_unique<operators::IndexScan>(
-            &float_column.null_bitmap, table_partition.sequence_count
+            CopyOnWriteBitmap{&float_column.null_bitmap}, table_partition.sequence_count
          ),
          table_partition.sequence_count
       );

--- a/src/silo/query_engine/filter/expressions/float_equals.cpp
+++ b/src/silo/query_engine/filter/expressions/float_equals.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> FloatEquals::co
       );
    }
    return std::make_unique<operators::IndexScan>(
-      &float_column.null_bitmap, table_partition.sequence_count
+      CopyOnWriteBitmap{&float_column.null_bitmap}, table_partition.sequence_count
    );
 }
 

--- a/src/silo/query_engine/filter/expressions/int_between.cpp
+++ b/src/silo/query_engine/filter/expressions/int_between.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> IntBetween::com
    if (predicates.empty()) {
       return std::make_unique<operators::Complement>(
          std::make_unique<operators::IndexScan>(
-            &int_column.null_bitmap, table_partition.sequence_count
+            CopyOnWriteBitmap{&int_column.null_bitmap}, table_partition.sequence_count
          ),
          table_partition.sequence_count
       );

--- a/src/silo/query_engine/filter/expressions/int_equals.cpp
+++ b/src/silo/query_engine/filter/expressions/int_equals.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> IntEquals::comp
       );
    }
    return std::make_unique<operators::IndexScan>(
-      &int_column.null_bitmap, table_partition.sequence_count
+      CopyOnWriteBitmap{&int_column.null_bitmap}, table_partition.sequence_count
    );
 }
 

--- a/src/silo/query_engine/filter/expressions/lineage_filter.cpp
+++ b/src/silo/query_engine/filter/expressions/lineage_filter.cpp
@@ -87,7 +87,9 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> LineageFilter::
    if (bitmap == std::nullopt) {
       return std::make_unique<operators::Empty>(table_partition.sequence_count);
    }
-   return std::make_unique<operators::IndexScan>(bitmap.value(), table_partition.sequence_count);
+   return std::make_unique<operators::IndexScan>(
+      CopyOnWriteBitmap{bitmap.value()}, table_partition.sequence_count
+   );
 }
 
 namespace {

--- a/src/silo/query_engine/filter/expressions/string_equals.cpp
+++ b/src/silo/query_engine/filter/expressions/string_equals.cpp
@@ -51,7 +51,9 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> StringEquals::c
       if (bitmap == std::nullopt || bitmap.value()->isEmpty()) {
          return std::make_unique<operators::Empty>(table_partition.sequence_count);
       }
-      return std::make_unique<operators::IndexScan>(bitmap.value(), table_partition.sequence_count);
+      return std::make_unique<operators::IndexScan>(
+         CopyOnWriteBitmap{bitmap.value()}, table_partition.sequence_count
+      );
    }
    SILO_ASSERT(table_partition.columns.string_columns.contains(column_name));
    const auto& string_column = table_partition.columns.string_columns.at(column_name);
@@ -64,7 +66,7 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> StringEquals::c
       );
    }
    return std::make_unique<operators::IndexScan>(
-      &string_column.null_bitmap, table_partition.sequence_count
+      CopyOnWriteBitmap{&string_column.null_bitmap}, table_partition.sequence_count
    );
 }
 

--- a/src/silo/query_engine/filter/expressions/symbol_equals.cpp
+++ b/src/silo/query_engine/filter/expressions/symbol_equals.cpp
@@ -140,7 +140,7 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> SymbolEquals<Sy
       return std::make_unique<operators::Complement>(
          std::make_unique<operators::IndexScan>(
             std::move(logical_equivalent_of_nested_index_scan),
-            seq_store_partition.getBitmap(position_idx, symbol),
+            CopyOnWriteBitmap{seq_store_partition.getBitmap(position_idx, symbol)},
             table_partition.sequence_count
          ),
          table_partition.sequence_count
@@ -175,7 +175,7 @@ std::unique_ptr<silo::query_engine::filter::operators::Operator> SymbolEquals<Sy
       std::make_unique<SymbolEquals>(valid_sequence_name, position_idx, symbol);
    return std::make_unique<operators::IndexScan>(
       std::move(logical_equivalent),
-      seq_store_partition.getBitmap(position_idx, symbol),
+      CopyOnWriteBitmap{seq_store_partition.getBitmap(position_idx, symbol)},
       table_partition.sequence_count
    );
 }

--- a/src/silo/query_engine/filter/operators/bitmap_producer.test.cpp
+++ b/src/silo/query_engine/filter/operators/bitmap_producer.test.cpp
@@ -12,7 +12,7 @@ TEST(OperatorBitmapProducer, evaluateShouldReturnCorrectValues) {
    const roaring::Roaring test_bitmap({1, 2, 3});
    const uint32_t row_count = 5;
 
-   const BitmapProducer under_test([&]() { return CopyOnWriteBitmap(test_bitmap); }, row_count);
+   const BitmapProducer under_test([&]() { return CopyOnWriteBitmap(&test_bitmap); }, row_count);
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({1, 2, 3}));
 }
 
@@ -20,8 +20,9 @@ TEST(OperatorBitmapProducer, evaluateShouldReturnCorrectValuesWhenNegated) {
    const roaring::Roaring test_bitmap({1, 2, 3});
    const uint32_t row_count = 5;
 
-   auto under_test =
-      std::make_unique<BitmapProducer>([&]() { return CopyOnWriteBitmap(test_bitmap); }, row_count);
+   auto under_test = std::make_unique<BitmapProducer>(
+      [&]() { return CopyOnWriteBitmap(&test_bitmap); }, row_count
+   );
    const auto negated = BitmapProducer::negate(std::move(under_test));
 
    ASSERT_EQ(*negated->evaluate(), roaring::Roaring({0, 4}));
@@ -31,7 +32,7 @@ TEST(OperatorBitmapProducer, correctTypeInfo) {
    const roaring::Roaring test_bitmap({1, 2, 3});
    const uint32_t row_count = 5;
 
-   const BitmapProducer under_test([&]() { return CopyOnWriteBitmap(test_bitmap); }, row_count);
+   const BitmapProducer under_test([&]() { return CopyOnWriteBitmap(&test_bitmap); }, row_count);
    ASSERT_EQ(under_test.type(), silo::query_engine::filter::operators::BITMAP_PRODUCER);
 }
 
@@ -39,6 +40,6 @@ TEST(OperatorBitmapProducer, correctToString) {
    const roaring::Roaring test_bitmap({1, 2, 3});
    const uint32_t row_count = 5;
 
-   const BitmapProducer under_test([&]() { return CopyOnWriteBitmap(test_bitmap); }, row_count);
+   const BitmapProducer under_test([&]() { return CopyOnWriteBitmap(&test_bitmap); }, row_count);
    ASSERT_EQ(under_test.toString(), "BitmapProducer");
 }

--- a/src/silo/query_engine/filter/operators/complement.test.cpp
+++ b/src/silo/query_engine/filter/operators/complement.test.cpp
@@ -5,6 +5,7 @@
 
 #include "silo/query_engine/filter/operators/index_scan.h"
 
+using silo::query_engine::CopyOnWriteBitmap;
 using silo::query_engine::filter::operators::Complement;
 using silo::query_engine::filter::operators::IndexScan;
 
@@ -12,7 +13,9 @@ TEST(OperatorComplement, evaluateShouldReturnCorrectValues) {
    const roaring::Roaring test_bitmap(roaring::Roaring({1, 2, 3}));
    const uint32_t row_count = 5;
 
-   const Complement under_test(std::make_unique<IndexScan>(&test_bitmap, row_count), row_count);
+   const Complement under_test(
+      std::make_unique<IndexScan>(CopyOnWriteBitmap{&test_bitmap}, row_count), row_count
+   );
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({0, 4}));
 }
 
@@ -20,7 +23,9 @@ TEST(OperatorComplement, evaluateShouldReturnCorrectValuesWhenEmptyInput) {
    const roaring::Roaring test_bitmap(roaring::Roaring({}));
    const uint32_t row_count = 3;
 
-   const Complement under_test(std::make_unique<IndexScan>(&test_bitmap, row_count), row_count);
+   const Complement under_test(
+      std::make_unique<IndexScan>(CopyOnWriteBitmap{&test_bitmap}, row_count), row_count
+   );
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({0, 1, 2}));
 }
 
@@ -28,7 +33,9 @@ TEST(OperatorComplement, evaluateShouldReturnCorrectValuesWhenEmptyDatabase) {
    const roaring::Roaring test_bitmap(roaring::Roaring({}));
    const uint32_t row_count = 0;
 
-   const Complement under_test(std::make_unique<IndexScan>(&test_bitmap, row_count), row_count);
+   const Complement under_test(
+      std::make_unique<IndexScan>(CopyOnWriteBitmap{&test_bitmap}, row_count), row_count
+   );
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({}));
 }
 
@@ -36,7 +43,9 @@ TEST(OperatorComplement, evaluateShouldReturnCorrectValuesWhenFullInput) {
    const roaring::Roaring test_bitmap(roaring::Roaring({0, 1, 2, 3}));
    const uint32_t row_count = 4;
 
-   const Complement under_test(std::make_unique<IndexScan>(&test_bitmap, row_count), row_count);
+   const Complement under_test(
+      std::make_unique<IndexScan>(CopyOnWriteBitmap{&test_bitmap}, row_count), row_count
+   );
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({}));
 }
 
@@ -44,7 +53,9 @@ TEST(OperatorComplement, evaluateShouldReturnCorrectValuesWhenSingleInput) {
    const roaring::Roaring test_bitmap(roaring::Roaring({1}));
    const uint32_t row_count = 5;
 
-   const Complement under_test(std::make_unique<IndexScan>(&test_bitmap, row_count), row_count);
+   const Complement under_test(
+      std::make_unique<IndexScan>(CopyOnWriteBitmap{&test_bitmap}, row_count), row_count
+   );
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({0, 2, 3, 4}));
 }
 
@@ -52,7 +63,9 @@ TEST(OperatorComplement, correctTypeInfo) {
    const roaring::Roaring test_bitmap({1, 2, 3});
    const uint32_t row_count = 5;
 
-   const Complement under_test(std::make_unique<IndexScan>(&test_bitmap, row_count), row_count);
+   const Complement under_test(
+      std::make_unique<IndexScan>(CopyOnWriteBitmap{&test_bitmap}, row_count), row_count
+   );
 
    ASSERT_EQ(under_test.type(), silo::query_engine::filter::operators::COMPLEMENT);
 }

--- a/src/silo/query_engine/filter/operators/index_scan.cpp
+++ b/src/silo/query_engine/filter/operators/index_scan.cpp
@@ -13,17 +13,17 @@
 
 namespace silo::query_engine::filter::operators {
 
-IndexScan::IndexScan(const roaring::Roaring* bitmap, uint32_t row_count)
-    : bitmap(bitmap),
+IndexScan::IndexScan(CopyOnWriteBitmap bitmap, uint32_t row_count)
+    : bitmap(std::move(bitmap)),
       row_count(row_count) {}
 
 IndexScan::IndexScan(
    std::unique_ptr<query_engine::filter::expressions::Expression>&& logical_equivalent,
-   const roaring::Roaring* bitmap,
+   CopyOnWriteBitmap bitmap,
    uint32_t row_count
 )
     : logical_equivalent(std::move(logical_equivalent)),
-      bitmap(bitmap),
+      bitmap(std::move(bitmap)),
       row_count(row_count) {}
 
 IndexScan::~IndexScan() noexcept = default;
@@ -42,7 +42,7 @@ Type IndexScan::type() const {
 
 CopyOnWriteBitmap IndexScan::evaluate() const {
    EVOBENCH_SCOPE("IndexScan", "evaluate");
-   return CopyOnWriteBitmap(*bitmap);
+   return bitmap;
 }
 std::unique_ptr<Operator> IndexScan::negate(std::unique_ptr<IndexScan>&& index_scan) {
    const uint32_t row_count = index_scan->row_count;

--- a/src/silo/query_engine/filter/operators/index_scan.h
+++ b/src/silo/query_engine/filter/operators/index_scan.h
@@ -21,15 +21,15 @@ class IndexScan : public Operator {
 
   private:
    std::optional<std::unique_ptr<query_engine::filter::expressions::Expression>> logical_equivalent;
-   const roaring::Roaring* bitmap;
+   CopyOnWriteBitmap bitmap;
    uint32_t row_count;
 
   public:
-   explicit IndexScan(const roaring::Roaring* bitmap, uint32_t row_count);
+   explicit IndexScan(CopyOnWriteBitmap bitmap, uint32_t row_count);
 
    explicit IndexScan(
       std::unique_ptr<query_engine::filter::expressions::Expression>&& logical_equivalent,
-      const roaring::Roaring* bitmap,
+      CopyOnWriteBitmap bitmap,
       uint32_t row_count
    );
 

--- a/src/silo/query_engine/filter/operators/index_scan.test.cpp
+++ b/src/silo/query_engine/filter/operators/index_scan.test.cpp
@@ -6,32 +6,33 @@
 #include "silo/query_engine/filter/expressions/false.h"
 #include "silo/query_engine/filter/expressions/true.h"
 
+using silo::query_engine::CopyOnWriteBitmap;
 using silo::query_engine::filter::expressions::False;
 using silo::query_engine::filter::expressions::True;
 using silo::query_engine::filter::operators::IndexScan;
 
 TEST(OperatorIndexScan, evaluateShouldReturnCorrectValues) {
    const roaring::Roaring test_bitmap(roaring::Roaring({1, 3}));
-   const IndexScan under_test(&test_bitmap, 5);
+   const IndexScan under_test(CopyOnWriteBitmap{&test_bitmap}, 5);
    ASSERT_EQ(*under_test.evaluate(), roaring::Roaring({1, 3}));
 }
 
 TEST(OperatorIndexScan, correctTypeInfo) {
    const roaring::Roaring test_bitmap({1, 2, 3});
 
-   const IndexScan under_test(&test_bitmap, 5);
+   const IndexScan under_test(CopyOnWriteBitmap{&test_bitmap}, 5);
 
    ASSERT_EQ(under_test.type(), silo::query_engine::filter::operators::INDEX_SCAN);
 }
 
 TEST(OperatorIndexScan, correctLogicalEquivalent) {
    const roaring::Roaring test_bitmap({1, 2, 3, 4, 5});
-   const IndexScan under_test(std::make_unique<True>(), &test_bitmap, 5);
+   const IndexScan under_test(std::make_unique<True>(), CopyOnWriteBitmap{&test_bitmap}, 5);
 
    ASSERT_EQ(under_test.toString(), "IndexScan(Logical Equivalent: True, Cardinality: 5)");
 
    const roaring::Roaring test_bitmap2({});
-   const IndexScan under_test2(std::make_unique<False>(), &test_bitmap, 5);
+   const IndexScan under_test2(std::make_unique<False>(), CopyOnWriteBitmap{&test_bitmap}, 5);
 
    ASSERT_EQ(under_test2.toString(), "IndexScan(Logical Equivalent: False, Cardinality: 5)");
 }

--- a/src/silo/query_engine/filter/operators/intersection.test.cpp
+++ b/src/silo/query_engine/filter/operators/intersection.test.cpp
@@ -6,6 +6,7 @@
 #include "silo/query_engine/filter/operators/index_scan.h"
 #include "silo/query_engine/query_compilation_exception.h"
 
+using silo::query_engine::CopyOnWriteBitmap;
 using silo::query_engine::filter::operators::IndexScan;
 using silo::query_engine::filter::operators::Intersection;
 using silo::query_engine::filter::operators::Operator;
@@ -16,7 +17,7 @@ OperatorVector generateTestInput(const std::vector<roaring::Roaring>& bitmaps, u
    OperatorVector result;
 
    std::ranges::transform(bitmaps, std::back_inserter(result), [&](const auto& bitmap) {
-      return std::make_unique<IndexScan>(&bitmap, row_count);
+      return std::make_unique<IndexScan>(CopyOnWriteBitmap{&bitmap}, row_count);
    });
    return result;
 }

--- a/src/silo/query_engine/filter/operators/threshold.test.cpp
+++ b/src/silo/query_engine/filter/operators/threshold.test.cpp
@@ -6,6 +6,7 @@
 #include "silo/query_engine/filter/operators/index_scan.h"
 #include "silo/query_engine/query_compilation_exception.h"
 
+using silo::query_engine::CopyOnWriteBitmap;
 using silo::query_engine::filter::operators::IndexScan;
 using silo::query_engine::filter::operators::Operator;
 using silo::query_engine::filter::operators::Threshold;
@@ -19,7 +20,7 @@ OperatorVector generateTestInput(
 ) {
    OperatorVector result;
    std::ranges::transform(bitmaps, std::back_inserter(result), [&](const auto& bitmap) {
-      return std::make_unique<IndexScan>(&bitmap, row_count);
+      return std::make_unique<IndexScan>(CopyOnWriteBitmap{&bitmap}, row_count);
    });
    return result;
 }

--- a/src/silo/query_engine/filter/operators/union.test.cpp
+++ b/src/silo/query_engine/filter/operators/union.test.cpp
@@ -6,6 +6,7 @@
 #include "silo/query_engine/filter/operators/index_scan.h"
 #include "silo/query_engine/query_compilation_exception.h"
 
+using silo::query_engine::CopyOnWriteBitmap;
 using silo::query_engine::filter::operators::IndexScan;
 using silo::query_engine::filter::operators::Operator;
 using silo::query_engine::filter::operators::Union;
@@ -16,7 +17,7 @@ namespace {
 OperatorVector generateTestInput(const std::vector<roaring::Roaring>& bitmaps, uint32_t row_count) {
    OperatorVector result;
    std::ranges::transform(bitmaps, std::back_inserter(result), [&](const auto& bitmap) {
-      return std::make_unique<IndexScan>(&bitmap, row_count);
+      return std::make_unique<IndexScan>(CopyOnWriteBitmap{&bitmap}, row_count);
    });
    return result;
 }


### PR DESCRIPTION
### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This is a partial PR for #965 for better reviewability

`IndexScan` now expects `CopyOnWriteBitmap` instead of `const roaring::Roaring*`

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
