### PR TITLE
feat(benchmarking): support versioned datasets

### DIFF
--- a/benchmarking/Makefile
+++ b/benchmarking/Makefile
@@ -13,10 +13,25 @@ endif
 # Our custom parameters (the shared ones, there can be more checks in
 # the `Makefile_*` files):
 
-# The name of a subfolder of `~/silo-benchmark-datasets/` where the
-# dataset is stored
+# The name of a subfolder of the setting in
+# `versioned_datasets_base_dir`, where the versioned datasets are
+# stored; in spite of `DATASET_DIR` below having the full path, we
+# still also use this dataset name, thus require it to be set
+# (guaranteed when running via evobench-run, but not when running
+# manually).
 ifeq ($(DATASET),)
 $(error "DATASET must be a subfolder name, got '$(DATASET)'")
+endif
+
+# Set by `evobench-run run`--chosen according to the optional
+# `versioned_datasets_base_dir` setting in `evobench-run.ron`, the
+# value of the `DATASET` custom variable, the current commit id, and
+# the names of the subdirectories of `DATASET_DIR` representing git
+# revision names. See documentation in the `evobench-run.ron` file,
+# and [Offer dataset versioning
+# #32](https://github.com/GenSpectrum/evobench/issues/32).
+ifeq ($(DATASET_DIR),)
+$(error "DATASET_DIR must be the path to the appropriate dataset folder")
 endif
 
 # Should sorted input be used?
@@ -35,9 +50,6 @@ export OUTPUT_DIR
 
 
 # ---- General -----------------------------------------------------------------
-
-DATASET_DIR=$(HOME)/silo-benchmark-datasets/$(DATASET)
-export DATASET_DIR
 
 SILO_PREPROCESSING_CONFIG=$(DATASET_DIR)/preprocessing_config.yaml
 export SILO_PREPROCESSING_CONFIG

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -36,10 +36,7 @@ a server on
     `evobench-run config-formats` to see which, and `evobench-run
     config-save` to recode an already-placed file.)
 
- 1. Make sure that you have a folder
-    `~/silo-benchmark-datasets/$DATASET` (where `$DATASET` is the
-    value of the `DATASET` setting in the `~/.evobench-run.ron` file
-    that you use, with these files (or symlinks to them):
+ 1. Make sure that you have dataset folders as configured in the evobench config file (`evobench-run.ron`); see [Offer dataset versioning #32](https://github.com/GenSpectrum/evobench/issues/32) for the required folder structure. Each versioned dataset folder needs these files (or symlinks to them):
 
         database_config.yaml
         input_file.ndjson.zst
@@ -48,10 +45,6 @@ a server on
         silo_queries.ndjson
 
         possibly: lineage_definitions.yaml
-
-    Currently, get these files from gs-staging-1, or when running
-    there, use the folder `~christian/silo-benchmark-datasets` (it is
-    planned to fetch these via S3 in the future).
 
  1. Run an instance of a daemon, `evobench-run --verbose run daemon`
     (the `--verbose` allows you to see what's going on, feel free to


### PR DESCRIPTION
Closes #1018

### Summary

Use the new `DATASET_DIR` env variable from evobench, to make use of the dataset versioning.

## PR Checklist

- [X] All necessary documentation has been adapted or there is an issue to do so.
- ~~[ ] The implemented feature is covered by an appropriate test.~~
