### PR TITLE
refactor(silo): remove unused (and incorrect) GermanString::dataAsHexString debug function

### DIFF
--- a/src/silo/common/german_string.h
+++ b/src/silo/common/german_string.h
@@ -66,13 +66,6 @@ class GermanString {
       std::memcpy(data.data() + PREFIX_START, short_string.data(), short_string_length);
    }
 
-   std::string dataAsHexString() const {
-      std::stringstream sstream;
-      sstream << "0x" << std::setfill('0') << std::setw(static_cast<int>(data.size() * 2))
-              << std::hex << data.data();
-      return sstream.str();
-   }
-
    inline length_type length() const { return *reinterpret_cast<const length_type*>(data.data()); }
 
    inline bool isInPlace() const { return length() <= I; }


### PR DESCRIPTION
Removal of a small debug printing function that was never used and is incorrect. Noticed in https://github.com/GenSpectrum/LAPIS-SILO/pull/1025
