### PR TITLE
fix(silo): reduce peak memory load by changing default allocator and tuning mimalloc options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,23 @@ set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "${CMAKE_BINARY_DIR}/generators/")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # ---------------------------------------------------------------------------
+# Allocator
+# ---------------------------------------------------------------------------
+
+option(USE_MIMALLOC "Use mimalloc allocator" ON)
+
+# Only use mimalloc in Release mode, because of conflicts with ASAN
+if(USE_MIMALLOC AND ${CMAKE_BUILD_TYPE} STREQUAL "Release")
+    message("Using mimalloc as allocator")
+    find_package(mimalloc REQUIRED)
+    add_compile_definitions(SILO_USE_MIMALLOC=1)
+    set(MIMALLOC_LIB mimalloc-static)
+else()
+    set(MIMALLOC_LIB "")
+endif()
+
+
+# ---------------------------------------------------------------------------
 # Compile definitions
 # ---------------------------------------------------------------------------
 
@@ -113,6 +130,7 @@ add_library(silolib OBJECT ${SRC_SILO_WITHOUT_MAIN})
 target_link_libraries(
         silolib
         PUBLIC
+        ${MIMALLOC_LIB} # this should be first
         Arrow::arrow_static
         ArrowAcero::arrow_acero_static
         ${Boost_LIBRARIES}

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,9 +8,10 @@ class SiloRecipe(ConanFile):
     requires = [
         "arrow/22.0.0",
         "boost/1.85.0",
-        "poco/1.13.3",
-        "nlohmann_json/3.12.0",
         "gtest/1.16.0",
+        "mimalloc/2.2.4",
+        "nlohmann_json/3.12.0",
+        "poco/1.13.3",
         "re2/20240702",
         "roaring/4.2.1",
         "simdjson/3.12.3",
@@ -22,6 +23,7 @@ class SiloRecipe(ConanFile):
     default_options = {
         "abseil/*:shared": False,
 
+        "arrow/*:with_mimalloc": False,
         "arrow/*:compute": True,
         "arrow/*:acero": True,
 
@@ -64,6 +66,8 @@ class SiloRecipe(ConanFile):
         "gtest/*:no_main": True,
 
         "hwloc/*:shared": False,
+
+        "mimalloc/*:override": True,
 
         "poco/*:shared": False,
         "poco/*:enable_json": True,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,17 +1,16 @@
+#ifdef SILO_USE_MIMALLOC
+#include <mimalloc.h>
+#endif
+
 #include <filesystem>
 
-#include <spdlog/spdlog.h>
-
 #include <arrow/compute/api.h>
+#include <spdlog/spdlog.h>
 
 #include "evobench/evobench.hpp"
 #include "silo/api/api.h"
 #include "silo/api/logging.h"
 #include "silo/append/append.h"
-#include "silo/append/database_inserter.h"
-#include "silo/append/ndjson_line_reader.h"
-#include "silo/common/input_stream_wrapper.h"
-#include "silo/common/overloaded.h"
 #include "silo/common/panic.h"
 #include "silo/common/version.h"
 #include "silo/config/append_config.h"
@@ -171,6 +170,12 @@ int mainWhichMayThrowExceptions(int argc, char** argv) {
 }  // namespace
 
 int main(int argc, char** argv) {
+#ifdef SILO_USE_MIMALLOC
+   // If this option is not set, memory remains very high even when no requests are sent
+   // Also reduces peak memory usage under concurrency
+   mi_option_set(mi_option_purge_delay, 0);
+#endif
+
    try {
       return mainWhichMayThrowExceptions(argc, argv);
    } catch (const std::exception& error) {

--- a/src/silo/api/memory_monitor.cpp
+++ b/src/silo/api/memory_monitor.cpp
@@ -2,7 +2,9 @@
 
 #if defined(__linux__)
 
-#include <malloc.h>
+#ifdef SILO_USE_MIMALLOC
+#include <mimalloc.h>
+#endif
 
 #include <fstream>
 #include <optional>
@@ -72,8 +74,11 @@ void MemoryMonitor::checkRssAndLimit(Poco::Timer& /*timer*/) {
       SPDLOG_INFO("Current memory consumption: {} KB", rss.value());
 
       if (soft_memory_limit_in_kb.has_value() && rss.value() > soft_memory_limit_in_kb.value()) {
-         SPDLOG_INFO("Manually invoking malloc_trim() to give back memory to OS.");
-         malloc_trim(0);
+#ifdef SILO_USE_MIMALLOC
+         SPDLOG_INFO("Manually invoking mi_collect(true) to give back memory to OS.");
+         mi_collect(true);
+         mi_collect(true);  // This should be invoked twice
+#endif
       }
    }
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
reduces impact of #1034 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

We were already using `mimalloc` indirectly with Arrow (e.g. through Arrow `RecordBatch` creating). Now we are using `mimalloc` for all allocations in SILO.

I tested this by starting an instance with loculus data and stress testing the sequence download:

Before:
```
alexander@dev-1:~/LAPIS-SILO$ monitor_rss
Monitoring RSS of process 177715...
Timestamp, PID, RSS (KB)
2025-10-30 11:07:48, 177715, 61696
2025-10-30 11:07:49, 177715, 61696
2025-10-30 11:07:50, 177715, 437364
2025-10-30 11:07:51, 177715, 517664
2025-10-30 11:07:52, 177715, 467140
2025-10-30 11:07:53, 177715, 513908
2025-10-30 11:07:54, 177715, 468708
2025-10-30 11:07:55, 177715, 468708
2025-10-30 11:07:56, 177715, 468708
2025-10-30 11:07:57, 177715, 465888
2025-10-30 11:07:58, 177715, 440084
2025-10-30 11:07:59, 177715, 425920
2025-10-30 11:08:00, 177715, 460664
2025-10-30 11:08:01, 177715, 463024
2025-10-30 11:08:02, 177715, 483336
2025-10-30 11:08:03, 177715, 433832
2025-10-30 11:08:05, 177715, 491012
2025-10-30 11:08:06, 177715, 471748
```

After:

```
alexander@dev-1:~/LAPIS-SILO$ monitor_rss
Monitoring RSS of process 236049...
Timestamp, PID, RSS (KB)
2025-10-30 11:15:55, 236049, 61824
2025-10-30 11:15:56, 236049, 61824
2025-10-30 11:15:57, 236049, 254328
2025-10-30 11:15:58, 236049, 243360
2025-10-30 11:15:59, 236049, 315176
2025-10-30 11:16:00, 236049, 259712
2025-10-30 11:16:01, 236049, 269188
2025-10-30 11:16:02, 236049, 259024
2025-10-30 11:16:03, 236049, 223536
```

I let the stress tests running for >10 minutes and the memory did not increase above the peak anymore