### PR TITLE
feat(build): tag images with branch name again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,8 @@ jobs:
           images: ${{ env.DOCKER_IMAGE_NAME }}
           tags: |
             type=ref,event=pr
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=${{ github.head_ref || github.ref_name }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}            
             type=raw,value=commit-${{ env.HEAD_SHA }}
             type=semver,value=${{ env.SILO_VERSION }},enable=${{ env.SILO_VERSION != '' }},pattern={{version}}
             type=semver,value=${{ env.SILO_VERSION }},enable=${{ env.SILO_VERSION != '' }},pattern={{major}}.{{minor}}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1021 

This line is important:
`type=raw,value=${{ github.head_ref || github.ref_name }}`

On pull requests, `github.head_ref` will contain the branch name, on the release trigger:
```
  workflow_run:
    workflows: [Release SILO]
    types: [completed]
    branches: [main]
```
the correct branch name is given by `github.ref_name`
