### PR TITLE
fix(build): correctly fix the cppstd for installing the arrow dependency

### DIFF
--- a/build_with_conan.py
+++ b/build_with_conan.py
@@ -37,7 +37,7 @@ def main(args):
         conan_options.append("--output-folder=build/Debug/generators")
 
     # TODO(#986) remove this when arrow is fixed
-    conan_options.append("--settings 'arrow:compiler.cppstd=20'")
+    conan_options.append("--settings 'arrow/*:compiler.cppstd=20'")
 
     if args.clean:
         print("----------------------------------")


### PR DESCRIPTION
The valid name for the dependency is not `arrow`, but `arrow/22.0.0`. Therefore, the version we  fixed was never actually applied. I did not notice this, because I had a local change to `conanprofile` to fix the cppstd for all dependencies to 20.

Now, @pflanze ran into the same problem when trying to install our dependencies on Debian, which failed, as arrow is not fully cppstd 23 compatible yet.

This correctly fixes the cppstd for installing arrow to 20, by specifying a version wildcard `arrow/*`