### PR TITLE
feat(build): add Makefile rule to generate conanprofile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ DEPENDENCIES_FLAG=dependencies
 
 ci: format all-tests
 
+conanprofile:
+	conan profile detect && conan profile show --context build > conanprofile
+
 ${DEPENDENCIES_FLAG}: conanfile.py conanprofile
 	conan install . --update --build=missing --profile ./conanprofile --profile:build ./conanprofile \
 	  --settings '&:build_type=Debug' --output-folder=build/Debug/generators && \


### PR DESCRIPTION
Developer QoL change, on new checkout `make test` is now working if conan, cmake, .. is installed