### PR TITLE
chore(silo): fix compilation on staging

### DIFF
--- a/src/silo/query_engine/filter/operators/index_scan.h
+++ b/src/silo/query_engine/filter/operators/index_scan.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <roaring/roaring.hh>

--- a/src/silo/query_engine/filter/operators/is_in_covered_region.cpp
+++ b/src/silo/query_engine/filter/operators/is_in_covered_region.cpp
@@ -1,6 +1,7 @@
 #include "silo/query_engine/filter/operators/is_in_covered_region.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <fmt/format.h>

--- a/src/silo/storage/column/vertical_sequence_index.h
+++ b/src/silo/storage/column/vertical_sequence_index.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <vector>
 
 #include <boost/serialization/access.hpp>


### PR DESCRIPTION
This fixes an issue where missing includes lead to compilation errors on old gcc versions