### PR TITLE
refactor(silo): do not overly rely on std::ostream when writing to http buffer

### DIFF
--- a/src/silo/query_engine/exec_node/ndjson_sink.h
+++ b/src/silo/query_engine/exec_node/ndjson_sink.h
@@ -6,12 +6,10 @@
 #include <arrow/util/async_generator_fwd.h>
 #include <spdlog/spdlog.h>
 
-#include "silo/common/panic.h"
-
 namespace silo::query_engine::exec_node {
 
 arrow::Status writeBatchAsNdjson(
-   arrow::compute::ExecBatch batch,
+   const arrow::compute::ExecBatch& batch,
    const std::shared_ptr<arrow::Schema>& schema,
    std::ostream* output_stream
 );


### PR DESCRIPTION
This changes the way we write to an std::ostream, to guarantee that we do not write to it in too big chunks of data