### PR TITLE
feat(benchmarking): optionally store the produced binaries

### DIFF
--- a/benchmarking/Makefile
+++ b/benchmarking/Makefile
@@ -60,24 +60,39 @@ export BUILD
 
 SILO=../build/$(BUILD)/silo_$(COMMIT_ID)
 export SILO
+
+ifeq ($(SILOBENCHMARKING_KEPT_BINARIES_BASEDIR),0)
+KEPT_SILO=.kept_silo
+else
+KEPT_SILO=$(SILOBENCHMARKING_KEPT_BINARIES_BASEDIR)/silo-$(COMMIT_TAGS)
+endif
+KEPT_SILO_GZ=$(KEPT_SILO).gz
+export KEPT_SILO
+export KEPT_SILO_GZ
+
 PREPROCESSING_STAMP = $(OUTPUT_DIR)/.done
 export PREPROCESSING_STAMP
 
+
 $(SILO):
 	bin/build-silo
+
+$(KEPT_SILO_GZ): $(SILO)
+	bin/keep-silo
+
 
 # ---- Benchmarking targets ----------------------------------------------------
 
 # Want data on the preprocessing, hence remove the stamp and let it
 # re-run. Do not also run the api since it would clobber the log file
 # from the preprocessing.
-preprocessing: $(SILO)
+preprocessing: $(SILO) $(KEPT_SILO_GZ)
 	rm -f $(PREPROCESSING_STAMP)
 	make -f Makefile_preprocessing
 
 # Want data on the api; still run the preprocessing if needed but
 # without logging
-api: $(SILO)
+api: $(SILO) $(KEPT_SILO_GZ)
 	( unset EVOBENCH_LOG; make -f Makefile_preprocessing )
 	make -f Makefile_api
 

--- a/benchmarking/bin/keep-silo
+++ b/benchmarking/bin/keep-silo
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -meuo pipefail
+IFS=
+
+# Check if KEPT_SILO=.kept_silo -- if so, just touch that file if not
+# exists, and let make short-cut. Otherwise, see if we need to keep
+# it.
+
+# Is keeping actually asked for?
+if [ -n "${SILOBENCHMARKING_KEPT_BINARIES_BASEDIR-}" ] && [ -n "$COMMIT_TAGS" ]; then
+    if [ ! -e "$KEPT_SILO_GZ" ]; then
+        rm -f "$KEPT_SILO"
+        cp "$SILO" "$KEPT_SILO"
+        gzip "$KEPT_SILO"
+
+        symlink="$SILOBENCHMARKING_KEPT_BINARIES_BASEDIR/silo-current.gz"
+        rm -f "$symlink"
+        ln -s "$(basename "$KEPT_SILO_GZ")" "$symlink"
+
+        commit_tags="$SILOBENCHMARKING_KEPT_BINARIES_BASEDIR/_current_commit_tags.txt"
+        commit_tags_tmp="$commit_tags".tmp
+        rm -f "$commit_tags_tmp"
+        printf '%s\n' "$COMMIT_TAGS" > "$commit_tags_tmp"
+        mv "$commit_tags_tmp" "$commit_tags"
+    fi
+
+else
+    # Make alternative stamp to satisfy make. Only touch once, to
+    # avoid spurious rebuilds.
+    if [ ! -e "$KEPT_SILO_GZ" ]; then
+        touch "$KEPT_SILO_GZ"
+    fi
+fi


### PR DESCRIPTION
Closes #1087

### Summary

As discussed, to allow to put built silo binaries into a publishing directory, as temporary stopgap solution.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [ ] The implemented feature is covered by an appropriate test.
