### PR TITLE
refactor(silo): better handling of BadRequest errors in queries

### DIFF
--- a/src/silo/api/bad_request.h
+++ b/src/silo/api/bad_request.h
@@ -1,19 +1,11 @@
 #pragma once
 
-#include <stdexcept>
-#include <string>
+#include <exception>
+#include <typeinfo>
 
 #include <fmt/format.h>
 
-#define CHECK_SILO_QUERY(condition, ...)      \
-   do {                                       \
-      bool condition_bool = condition;        \
-      if (!(condition_bool)) {                \
-         throw silo::BadRequest(__VA_ARGS__); \
-      }                                       \
-   } while (0);
-
-namespace silo {
+namespace silo::api {
 
 class [[maybe_unused]] BadRequest : public std::runtime_error {
   public:
@@ -25,4 +17,4 @@ class [[maybe_unused]] BadRequest : public std::runtime_error {
        : std::runtime_error(fmt::format(fmt_str, std::forward<Args>(args)...)) {}
 };
 
-}  // namespace silo
+}  // namespace silo::api

--- a/src/silo/api/error_request_handler.cpp
+++ b/src/silo/api/error_request_handler.cpp
@@ -11,6 +11,7 @@
 #include <nlohmann/json.hpp>
 
 #include "silo/api/active_database.h"
+#include "silo/api/bad_request.h"
 
 namespace silo::api {
 ErrorRequestHandler::ErrorRequestHandler(
@@ -40,6 +41,13 @@ void ErrorRequestHandler::handleRequest(
       std::ostream& out_stream = response.send();
       out_stream << nlohmann::json(
          ErrorResponse{.error = "Service Temporarily Unavailable", .message = message}
+      );
+   } catch (const api::BadRequest& exception) {
+      response.setContentType("application/json");
+      response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+      std::ostream& out_stream = response.send();
+      out_stream << nlohmann::json(
+         ErrorResponse{.error = "Bad request", .message = exception.what()}
       );
    } catch (const std::exception& exception) {
       SPDLOG_ERROR("Caught exception: {}", exception.what());

--- a/src/silo/database.cpp
+++ b/src/silo/database.cpp
@@ -18,7 +18,7 @@
 #include "silo/common/version.h"
 #include "silo/database_info.h"
 #include "silo/persistence/exception.h"
-#include "silo/query_engine/bad_request.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/schema/database_schema.h"
 #include "silo/storage/table_partition.h"
 

--- a/src/silo/query_engine/actions/action.cpp
+++ b/src/silo/query_engine/actions/action.cpp
@@ -23,11 +23,11 @@
 #include "silo/query_engine/actions/most_recent_common_ancestor.h"
 #include "silo/query_engine/actions/mutations.h"
 #include "silo/query_engine/actions/phylo_subtree.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/exec_node/arrow_util.h"
 #include "silo/query_engine/exec_node/throttled_batch_reslicer.h"
 #include "silo/query_engine/exec_node/zstd_decompress_expression.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/column/column_type_visitor.h"
 
 namespace silo::query_engine::actions {
@@ -182,7 +182,7 @@ void from_json(const nlohmann::json& json, std::unique_ptr<Action>& action) {
    } else if (expression_type == "AminoAcidInsertions") {
       action = json.get<std::unique_ptr<InsertionAggregation<AminoAcid>>>();
    } else {
-      throw BadRequest(expression_type + " is not a valid action");
+      throw query_engine::IllegalQueryException("{} is not a valid action", expression_type);
    }
 
    std::vector<OrderByField> order_by_fields;

--- a/src/silo/query_engine/actions/aggregated.cpp
+++ b/src/silo/query_engine/actions/aggregated.cpp
@@ -11,9 +11,9 @@
 
 #include "evobench/evobench.hpp"
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/exec_node/table_scan.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table.h"
 
 using silo::query_engine::CopyOnWriteBitmap;

--- a/src/silo/query_engine/actions/details.cpp
+++ b/src/silo/query_engine/actions/details.cpp
@@ -3,7 +3,7 @@
 #include <utility>
 
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/bad_request.h"
+#include "silo/query_engine/illegal_query_exception.h"
 
 namespace silo::query_engine::actions {
 Details::Details(std::vector<std::string> fields)

--- a/src/silo/query_engine/actions/fasta.cpp
+++ b/src/silo/query_engine/actions/fasta.cpp
@@ -7,7 +7,7 @@
 #include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/bad_request.h"
+#include "silo/query_engine/illegal_query_exception.h"
 
 namespace silo::query_engine::actions {
 

--- a/src/silo/query_engine/actions/fasta_aligned.cpp
+++ b/src/silo/query_engine/actions/fasta_aligned.cpp
@@ -8,7 +8,7 @@
 #include <nlohmann/json.hpp>
 
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/bad_request.h"
+#include "silo/query_engine/illegal_query_exception.h"
 
 namespace silo::query_engine::actions {
 

--- a/src/silo/query_engine/actions/insertions.cpp
+++ b/src/silo/query_engine/actions/insertions.cpp
@@ -17,9 +17,9 @@
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/exec_node/arrow_util.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/column/insertion_index.h"
 #include "silo/storage/table_partition.h"
 

--- a/src/silo/query_engine/actions/most_recent_common_ancestor.cpp
+++ b/src/silo/query_engine/actions/most_recent_common_ancestor.cpp
@@ -11,8 +11,8 @@
 #include <nlohmann/json.hpp>
 
 #include "silo/common/phylo_tree.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/exec_node/json_value_type_array_builder.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/schema/database_schema.h"
 
 namespace silo::query_engine::actions {

--- a/src/silo/query_engine/actions/mutations.cpp
+++ b/src/silo/query_engine/actions/mutations.cpp
@@ -21,10 +21,10 @@
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/common/symbol_map.h"
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/exec_node/arrow_util.h"
 #include "silo/query_engine/exec_node/json_value_type_array_builder.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/column/sequence_column.h"
 #include "silo/storage/table_partition.h"
 
@@ -623,7 +623,7 @@ void from_json(const nlohmann::json& json, std::unique_ptr<Mutations<SymbolType>
    );
    const double min_proportion = json[MIN_PROPORTION_FIELD_NAME].get<double>();
    if (min_proportion < 0 || min_proportion > 1) {
-      throw BadRequest(
+      throw IllegalQueryException(
          "Invalid proportion: " + MIN_PROPORTION_FIELD_NAME + " must be in interval [0.0, 1.0]"
       );
    }

--- a/src/silo/query_engine/actions/phylo_subtree.cpp
+++ b/src/silo/query_engine/actions/phylo_subtree.cpp
@@ -11,8 +11,8 @@
 #include <nlohmann/json.hpp>
 
 #include "silo/common/phylo_tree.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/exec_node/json_value_type_array_builder.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/schema/database_schema.h"
 
 namespace silo::query_engine::actions {

--- a/src/silo/query_engine/actions/simple_select_action.cpp
+++ b/src/silo/query_engine/actions/simple_select_action.cpp
@@ -8,8 +8,8 @@
 #include <fmt/ranges.h>
 
 #include "evobench/evobench.hpp"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/exec_node/table_scan.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/schema/database_schema.h"
 
 namespace silo::query_engine::actions {

--- a/src/silo/query_engine/actions/tree_action.cpp
+++ b/src/silo/query_engine/actions/tree_action.cpp
@@ -12,9 +12,9 @@
 
 #include "evobench/evobench.hpp"
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/exec_node/arrow_util.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/schema/database_schema.h"
 #include "silo/storage/column_group.h"
 #include "silo/storage/table.h"

--- a/src/silo/query_engine/filter/expressions/and.cpp
+++ b/src/silo/query_engine/filter/expressions/and.cpp
@@ -11,7 +11,6 @@
 #include <boost/algorithm/string/join.hpp>
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/complement.h"
 #include "silo/query_engine/filter/operators/empty.h"
@@ -20,6 +19,7 @@
 #include "silo/query_engine/filter/operators/operator.h"
 #include "silo/query_engine/filter/operators/selection.h"
 #include "silo/query_engine/filter/operators/union.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table_partition.h"
 
 namespace silo::query_engine::filter::expressions {

--- a/src/silo/query_engine/filter/expressions/bool_equals.cpp
+++ b/src/silo/query_engine/filter/expressions/bool_equals.cpp
@@ -5,10 +5,10 @@
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/index_scan.h"
 #include "silo/query_engine/filter/operators/operator.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table_partition.h"
 
 namespace silo::query_engine::filter::expressions {

--- a/src/silo/query_engine/filter/expressions/date_between.cpp
+++ b/src/silo/query_engine/filter/expressions/date_between.cpp
@@ -8,9 +8,9 @@
 #include <nlohmann/json.hpp>
 
 #include "silo/common/date.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/operators/range_selection.h"
 #include "silo/query_engine/filter/operators/selection.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/column/date_column.h"
 #include "silo/storage/table_partition.h"
 

--- a/src/silo/query_engine/filter/expressions/exact.cpp
+++ b/src/silo/query_engine/filter/expressions/exact.cpp
@@ -7,9 +7,9 @@
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/operator.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/query_engine/query_compilation_exception.h"
 #include "silo/storage/table_partition.h"
 

--- a/src/silo/query_engine/filter/expressions/expression.cpp
+++ b/src/silo/query_engine/filter/expressions/expression.cpp
@@ -6,7 +6,6 @@
 
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/and.h"
 #include "silo/query_engine/filter/expressions/bool_equals.h"
 #include "silo/query_engine/filter/expressions/date_between.h"
@@ -28,6 +27,7 @@
 #include "silo/query_engine/filter/expressions/string_search.h"
 #include "silo/query_engine/filter/expressions/symbol_equals.h"
 #include "silo/query_engine/filter/expressions/true.h"
+#include "silo/query_engine/illegal_query_exception.h"
 
 namespace silo::query_engine::filter::expressions {
 
@@ -101,7 +101,9 @@ void from_json(const nlohmann::json& json, std::unique_ptr<Expression>& filter) 
    } else if (expression_type == "AminoAcidInsertionContains") {
       filter = json.get<std::unique_ptr<InsertionContains<AminoAcid>>>();
    } else {
-      throw BadRequest("Unknown object filter type '" + expression_type + "'");
+      throw query_engine::IllegalQueryException(
+         "Unknown object filter type '" + expression_type + "'"
+      );
    }
 }
 

--- a/src/silo/query_engine/filter/expressions/float_between.cpp
+++ b/src/silo/query_engine/filter/expressions/float_between.cpp
@@ -6,11 +6,11 @@
 
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/complement.h"
 #include "silo/query_engine/filter/operators/index_scan.h"
 #include "silo/query_engine/filter/operators/selection.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table_partition.h"
 
 using silo::storage::column::FloatColumnPartition;

--- a/src/silo/query_engine/filter/expressions/float_equals.cpp
+++ b/src/silo/query_engine/filter/expressions/float_equals.cpp
@@ -7,11 +7,11 @@
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/index_scan.h"
 #include "silo/query_engine/filter/operators/operator.h"
 #include "silo/query_engine/filter/operators/selection.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table_partition.h"
 
 using silo::storage::column::FloatColumnPartition;

--- a/src/silo/query_engine/filter/expressions/has_mutation.cpp
+++ b/src/silo/query_engine/filter/expressions/has_mutation.cpp
@@ -7,10 +7,10 @@
 #include <nlohmann/json.hpp>
 
 #include "silo/common/nucleotide_symbols.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/expressions/symbol_in_set.h"
 #include "silo/query_engine/filter/operators/operator.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/query_engine/query_compilation_exception.h"
 #include "silo/query_engine/query_parse_sequence_name.h"
 #include "silo/storage/table.h"

--- a/src/silo/query_engine/filter/expressions/insertion_contains.cpp
+++ b/src/silo/query_engine/filter/expressions/insertion_contains.cpp
@@ -8,11 +8,11 @@
 
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/bitmap_producer.h"
 #include "silo/query_engine/filter/operators/operator.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/query_engine/query_parse_sequence_name.h"
 #include "silo/storage/column/insertion_index.h"
 #include "silo/storage/column/sequence_column.h"
@@ -78,7 +78,7 @@ std::unique_ptr<operators::Operator> InsertionContains<SymbolType>::compile(
             auto search_result = sequence_store.insertion_index.search(position_idx, value);
             return CopyOnWriteBitmap(std::move(*search_result));
          } catch (const silo::storage::InsertionFormatException& exception) {
-            throw silo::BadRequest(
+            throw silo::query_engine::IllegalQueryException(
                "The field 'value' in the InsertionContains expression does not contain a valid "
                "regex "
                "pattern: \"{}\". It must only consist of {} symbols and the regex symbol '.*'. "

--- a/src/silo/query_engine/filter/expressions/int_between.cpp
+++ b/src/silo/query_engine/filter/expressions/int_between.cpp
@@ -7,12 +7,12 @@
 #include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/complement.h"
 #include "silo/query_engine/filter/operators/index_scan.h"
 #include "silo/query_engine/filter/operators/operator.h"
 #include "silo/query_engine/filter/operators/selection.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table_partition.h"
 
 using silo::storage::column::IntColumnPartition;

--- a/src/silo/query_engine/filter/expressions/int_equals.cpp
+++ b/src/silo/query_engine/filter/expressions/int_equals.cpp
@@ -5,11 +5,11 @@
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/index_scan.h"
 #include "silo/query_engine/filter/operators/operator.h"
 #include "silo/query_engine/filter/operators/selection.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table_partition.h"
 
 using silo::storage::column::IntColumnPartition;

--- a/src/silo/query_engine/filter/expressions/lineage_filter.cpp
+++ b/src/silo/query_engine/filter/expressions/lineage_filter.cpp
@@ -9,10 +9,10 @@
 #include <fmt/ranges.h>
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/operators/empty.h"
 #include "silo/query_engine/filter/operators/index_scan.h"
 #include "silo/query_engine/filter/operators/operator.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table_partition.h"
 
 namespace silo::query_engine::filter::expressions {

--- a/src/silo/query_engine/filter/expressions/maybe.cpp
+++ b/src/silo/query_engine/filter/expressions/maybe.cpp
@@ -6,9 +6,9 @@
 
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/operator.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/query_engine/query_compilation_exception.h"
 #include "silo/storage/table_partition.h"
 

--- a/src/silo/query_engine/filter/expressions/negation.cpp
+++ b/src/silo/query_engine/filter/expressions/negation.cpp
@@ -6,9 +6,9 @@
 
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/operator.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table_partition.h"
 
 namespace silo::query_engine::filter::expressions {

--- a/src/silo/query_engine/filter/expressions/nof.cpp
+++ b/src/silo/query_engine/filter/expressions/nof.cpp
@@ -6,7 +6,6 @@
 
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/and.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/expressions/negation.h"
@@ -17,6 +16,7 @@
 #include "silo/query_engine/filter/operators/operator.h"
 #include "silo/query_engine/filter/operators/threshold.h"
 #include "silo/query_engine/filter/operators/union.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table_partition.h"
 
 namespace {

--- a/src/silo/query_engine/filter/expressions/or.cpp
+++ b/src/silo/query_engine/filter/expressions/or.cpp
@@ -7,13 +7,13 @@
 #include <boost/algorithm/string/join.hpp>
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/complement.h"
 #include "silo/query_engine/filter/operators/empty.h"
 #include "silo/query_engine/filter/operators/full.h"
 #include "silo/query_engine/filter/operators/operator.h"
 #include "silo/query_engine/filter/operators/union.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table_partition.h"
 #include "symbol_in_set.h"
 

--- a/src/silo/query_engine/filter/expressions/phylo_child_filter.cpp
+++ b/src/silo/query_engine/filter/expressions/phylo_child_filter.cpp
@@ -7,10 +7,10 @@
 #include <nlohmann/json.hpp>
 
 #include "silo/common/panic.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/bitmap_producer.h"
 #include "silo/query_engine/filter/operators/operator.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table_partition.h"
 
 namespace silo::query_engine::filter::expressions {

--- a/src/silo/query_engine/filter/expressions/string_equals.cpp
+++ b/src/silo/query_engine/filter/expressions/string_equals.cpp
@@ -7,12 +7,12 @@
 #include <nlohmann/json.hpp>
 
 #include "silo/common/panic.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/empty.h"
 #include "silo/query_engine/filter/operators/index_scan.h"
 #include "silo/query_engine/filter/operators/operator.h"
 #include "silo/query_engine/filter/operators/selection.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table_partition.h"
 
 namespace silo::query_engine::filter::expressions {

--- a/src/silo/query_engine/filter/expressions/string_search.cpp
+++ b/src/silo/query_engine/filter/expressions/string_search.cpp
@@ -6,10 +6,10 @@
 #include <nlohmann/json.hpp>
 
 #include "silo/common/panic.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/operators/bitmap_producer.h"
 #include "silo/query_engine/filter/operators/operator.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/storage/table_partition.h"
 
 namespace silo::query_engine::filter::expressions {

--- a/src/silo/query_engine/filter/expressions/symbol_equals.cpp
+++ b/src/silo/query_engine/filter/expressions/symbol_equals.cpp
@@ -8,11 +8,11 @@
 
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
 #include "silo/query_engine/filter/expressions/symbol_in_set.h"
 #include "silo/query_engine/filter/operators/index_scan.h"
 #include "silo/query_engine/filter/operators/operator.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/query_engine/query_compilation_exception.h"
 #include "silo/query_engine/query_parse_sequence_name.h"
 #include "silo/storage/table_partition.h"

--- a/src/silo/query_engine/filter/expressions/symbol_in_set.cpp
+++ b/src/silo/query_engine/filter/expressions/symbol_in_set.cpp
@@ -8,7 +8,6 @@
 
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/operators/complement.h"
 #include "silo/query_engine/filter/operators/index_scan.h"
 #include "silo/query_engine/filter/operators/intersection.h"
@@ -16,6 +15,7 @@
 #include "silo/query_engine/filter/operators/operator.h"
 #include "silo/query_engine/filter/operators/selection.h"
 #include "silo/query_engine/filter/operators/union.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/query_engine/query_compilation_exception.h"
 #include "silo/query_engine/query_parse_sequence_name.h"
 

--- a/src/silo/query_engine/illegal_query_exception.h
+++ b/src/silo/query_engine/illegal_query_exception.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#include <fmt/format.h>
+
+#define CHECK_SILO_QUERY(condition, ...)                               \
+   do {                                                                \
+      bool condition_bool = condition;                                 \
+      if (!(condition_bool)) {                                         \
+         throw silo::query_engine::IllegalQueryException(__VA_ARGS__); \
+      }                                                                \
+   } while (0);
+
+namespace silo::query_engine {
+
+class [[maybe_unused]] IllegalQueryException : public std::runtime_error {
+  public:
+   explicit IllegalQueryException(const std::string& error_message)
+       : std::runtime_error(error_message) {}
+
+   template <typename... Args>
+   explicit IllegalQueryException(fmt::format_string<Args...> fmt_str, Args&&... args)
+       : std::runtime_error(fmt::format(fmt_str, std::forward<Args>(args)...)) {}
+};
+
+}  // namespace silo::query_engine

--- a/src/silo/query_engine/query.cpp
+++ b/src/silo/query_engine/query.cpp
@@ -6,8 +6,8 @@
 #include <nlohmann/json.hpp>
 
 #include "silo/query_engine/actions/action.h"
-#include "silo/query_engine/bad_request.h"
 #include "silo/query_engine/filter/expressions/expression.h"
+#include "silo/query_engine/illegal_query_exception.h"
 
 using silo::query_engine::actions::Action;
 using silo::query_engine::filter::expressions::Expression;
@@ -19,15 +19,15 @@ std::shared_ptr<Query> Query::parseQuery(const std::string& query_string) {
       nlohmann::json json = nlohmann::json::parse(query_string);
       if (!json.contains("filterExpression") || !json["filterExpression"].is_object() ||
           !json.contains("action") || !json["action"].is_object()) {
-         throw BadRequest("Query json must contain filterExpression and action.");
+         throw IllegalQueryException("Query json must contain filterExpression and action.");
       }
       auto filter = json["filterExpression"].get<std::unique_ptr<Expression>>();
       auto action = json["action"].get<std::unique_ptr<Action>>();
       return std::make_shared<Query>(std::move(filter), std::move(action));
    } catch (const nlohmann::json::parse_error& ex) {
-      throw BadRequest("The query was not a valid JSON: " + std::string(ex.what()));
+      throw IllegalQueryException("The query was not a valid JSON: " + std::string(ex.what()));
    } catch (const nlohmann::json::exception& ex) {
-      throw BadRequest("The query was not a valid JSON: " + std::string(ex.what()));
+      throw IllegalQueryException("The query was not a valid JSON: " + std::string(ex.what()));
    }
 }
 


### PR DESCRIPTION
This improves the way we deal with a `BadRequest` in our api, properly having a centralized logic for sending error responses while keeping the separation of `silo::api` and `silo::query_engine`