### PR TITLE
fix(legacyNdjsonTransformer): correctly parse floats with serde_json

### DIFF
--- a/tools/legacyNdjsonTransformer/Cargo.toml
+++ b/tools/legacyNdjsonTransformer/Cargo.toml
@@ -13,4 +13,4 @@ path = "main.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }

--- a/tools/legacyNdjsonTransformer/main.rs
+++ b/tools/legacyNdjsonTransformer/main.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize};
+use serde::Deserialize;
 use serde_json::{Map, Value};
 use std::io::{self, BufRead, BufReader};
 
@@ -30,7 +30,8 @@ fn transform_data(input: InputData) -> Map<String, Value> {
         if sequence_value.is_null() {
             result.insert(segment_key.clone(), Value::Null);
         } else {
-            let insertions = input.nucleotide_insertions
+            let insertions = input
+                .nucleotide_insertions
                 .get(&segment_key)
                 .cloned()
                 .unwrap_or(Value::Array(vec![]));
@@ -48,7 +49,8 @@ fn transform_data(input: InputData) -> Map<String, Value> {
         if sequence_value.is_null() {
             result.insert(gene_key.clone(), Value::Null);
         } else {
-            let insertions = input.amino_acid_insertions
+            let insertions = input
+                .amino_acid_insertions
                 .get(&gene_key)
                 .cloned()
                 .unwrap_or(Value::Array(vec![]));
@@ -97,6 +99,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_transform_floats_correctly() {
+        let input = r#"{
+            "metadata": {"key": "id1", "col":0.9994409243384271},
+            "alignedNucleotideSequences": {"segment1": null},
+            "unalignedNucleotideSequences": {"segment1": null},
+            "alignedAminoAcidSequences": {"gene1": null},
+            "nucleotideInsertions": {"segment1": []},
+            "aminoAcidInsertions": {"gene1": []}
+        }"#;
+
+        let input_data: InputData = serde_json::from_str(input).unwrap();
+        let result = transform_data(input_data);
+
+        assert_eq!(result.get("key"), Some(&json!("id1")));
+        assert_eq!(
+            serde_json::to_string(result.get("col").unwrap()).unwrap(),
+            "0.9994409243384271"
+        );
+    }
 
     #[test]
     fn test_transform_null_values() {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1098

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->
correctly parse floats with serde_json by setting the feature flag `float_roundtrip`

According to https://github.com/serde-rs/json/issues/707 this feature flag comes at an approximately 2x performance hit for parsing floats, but as most time is spend on parsing the long genomic sequences, this should not be noticeable.


A test is added that confirms the correct round-trip. `cargo test` with the fix passes the test, whereas without the fix the new test-case fails

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] The implemented feature is covered by an appropriate test.
