### PR TITLE
feat(build): change builder base image to debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ list(REMOVE_ITEM SRC_SILO_WITHOUT_MAIN "${CMAKE_SOURCE_DIR}/src/main.cpp")
 
 option(BUILD_WITH_CLANG_TIDY "Build process clang-tidy")
 if (NOT CMAKE_BUILD_TYPE STREQUAL Release AND BUILD_WITH_CLANG_TIDY)
-    find_program(CLANG_TIDY_EXE NAMES clang-tidy-20)
+    find_program(CLANG_TIDY_EXE NAMES clang-tidy-19 clang-tidy-20)
     if (NOT CLANG_TIDY_EXE)
         message(SEND_ERROR "clang-tidy not found, aborting. You can run the build with '-D BUILD_WITH_CLANG_TIDY=OFF' to disable clang-tidy.")
     else ()

--- a/Dockerfile_dependencies
+++ b/Dockerfile_dependencies
@@ -1,13 +1,10 @@
-FROM ubuntu:24.04
+FROM debian:oldstable
 
 ARG TARGETPLATFORM
 
-RUN apt update && apt dist-upgrade -y \
-    && apt install -y \
-    build-essential cmake python3 pipx software-properties-common wget gnupg lsb-release jq curl \
-    && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
-    && add-apt-repository 'deb http://apt.llvm.org/jammy/  llvm-toolchain-jammy-20 main' \
-    && apt install -y clang-tidy-20
+RUN apt-get update && apt-get dist-upgrade -y \
+    && apt-get install -y \
+    build-essential cmake python3 python3-pip python3-venv pipx software-properties-common wget gnupg lsb-release jq curl patchelf  clang-tidy-19
 
 # ensurepath adds a line to .profile
 # which puts the pipx install directory ~/.local/bin into the PATH variable


### PR DESCRIPTION
partial progress on #575 

We want to build the final binaries with a glibc version that is equal to debian's `oldstable` glibc version. Therefore, we should already use this as the image for building the binaries that also go into our docker images