### PR TITLE
fix(silo): do not spawn an excessive number of threads to avoid arrow bugs

### DIFF
--- a/src/silo/query_engine/actions/action.cpp
+++ b/src/silo/query_engine/actions/action.cpp
@@ -221,12 +221,13 @@ QueryPlan Action::toQueryPlan(
    std::string_view request_id
 ) {
    validateOrderByFields(table->schema);
-   auto query_plan =
+   auto query_plan_or_error =
       toQueryPlanImpl(std::move(table), std::move(partition_filters), query_options, request_id);
-   if (!query_plan.status().ok()) {
-      SILO_PANIC("Arrow error: {}", query_plan.status().ToString());
+   if (!query_plan_or_error.status().ok()) {
+      SILO_PANIC("Arrow error: {}", query_plan_or_error.status().ToString());
    };
-   return query_plan.ValueUnsafe();
+   auto query_plan = std::move(query_plan_or_error).ValueUnsafe();
+   return query_plan;
 }
 
 arrow::Result<arrow::acero::ExecNode*> Action::addSortNode(


### PR DESCRIPTION
This PR removes code that was introduced to avoid arrow bugs.

The spawning of a thread for every query that is send, just to add some indirection should be avoided. Instead, I now introduce a guard that avoids that the source nodes in the arrow plan start generating batches, before the query plan execution is fully started (i.e. `arrow_plan.StartProducing()` returns)

This could avoid the situation where SILO sometimes crashes in the benchmarking, where a very high load of queries are send per second (more than curl could ever send). #1035