### PR TITLE
refactor(silo): rewrite boolean expression in macro to avoid compiler warning

### DIFF
--- a/src/silo/common/panic.h
+++ b/src/silo/common/panic.h
@@ -55,7 +55,8 @@ namespace silo::common {
 /// performance overrides safety, use `SILO_DEBUG_ASSERT` instead.
 #define SILO_ASSERT(e)                                        \
    do {                                                       \
-      if (!(e)) {                                             \
+      bool condition = (e);                                   \
+      if (!condition) {                                       \
          silo::common::assertFailure(#e, __FILE__, __LINE__); \
       }                                                       \
    } while (0)


### PR DESCRIPTION
Minor change to silence a compiler warning