### PR TITLE
feat: add compiled binaries for linux to GitHub releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
             PLATFORM="linux/$arch"
             echo "Extracting from $IMAGE ($PLATFORM)"
 
-            binary="./silo-linux-$arch"
+            binary="silo-linux-$arch"
 
             docker create --platform $PLATFORM --name extract-$arch $IMAGE
             docker cp extract-$arch:/app/silo "./$binary"


### PR DESCRIPTION
resolves #575


### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

I forked the repo to have a playground on which I can test creating releases: https://github.com/fengelniederhammer/LAPIS-SILO. If you want to test this, I can add you as a collaborator there.

It would actually be great if someone could test whether the arm binary works.

Since we already use Debian's `oldstable` as base images to build the binary for the containers, we can simply extract it from there and add it to the already existing GitHub release that Release Please created earlier.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
