### PR TITLE
fix(test): fix flaky test that has non-deterministic result order

### DIFF
--- a/src/silo/query_engine/actions/fasta_aligned.test.cpp
+++ b/src/silo/query_engine/actions/fasta_aligned.test.cpp
@@ -414,7 +414,7 @@ const QueryTestScenario FASTA_ALIGNED_WITH_LIMIT_UNSORTED = {
 {"primaryKey":"id_1","segment1":"ATGCN"},
 {"primaryKey":"id_2","segment1":"NNNNN"}])"
    ),
-   .query_options = silo::config::QueryOptions{.materialization_cutoff = 1}
+   .query_options = silo::config::QueryOptions{.materialization_cutoff = 3}
 };
 
 const QueryTestScenario FASTA_ALIGNED_WITH_OFFSET_AND_LIMIT = {


### PR DESCRIPTION
the test was intended to test that a limit without an order-by returns the first three elements of a table (insertion-order). However, this sometimes failed, as the output after the three elements are selected is not required to be deterministic. Because our arrow batch size was 2 (which is less than 3), these batches could be returned in any order, leading to the result `[2,0,1]` instead of the expected `[0,1,2]`. While this again depends on an implementation detail, this should make the test deterministic for now