### PR TITLE
feat(silo): add a arrow query interface to the python bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,3 +346,39 @@ jobs:
             -w /workspace \
             ${{ env.DOCKER_IMAGE }} \
             bash -login -c "mv /src/conanprofile . && make test"
+
+  pythonTests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate dependency files hash
+        run: |
+          DIR_HASH=$(echo -n ${{ hashFiles('conanfile.py', 'conanprofile.docker', './Dockerfile_dependencies') }})
+          echo "DIR_HASH=$DIR_HASH" >> $GITHUB_ENV
+
+      - name: Choose docker image for executing Python tests
+        run: |
+          DEPENDENCY_TAG="filehash-${{ env.DIR_HASH }}-amd64"
+
+          DEPENDENCY_IMAGE="${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:${DEPENDENCY_TAG}"
+          LATEST_IMAGE="${{ env.DOCKER_DEPENDENCY_IMAGE_NAME }}:latest"
+
+          if docker manifest inspect ${DEPENDENCY_IMAGE} > /dev/null 2>&1; then
+            echo "Using image: ${DEPENDENCY_IMAGE}"
+            DOCKER_IMAGE=${DEPENDENCY_IMAGE}
+          else
+            echo "Image not found, falling back to :latest"
+            DOCKER_IMAGE=${LATEST_IMAGE}
+          fi
+
+          echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> $GITHUB_ENV
+
+      - name: Run Python tests in Docker
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            ${{ env.DOCKER_IMAGE }} \
+            bash -login -c "mv /src/conanprofile . && mv /src/build . && pipx install uv && make python-tests"

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,11 @@ e2e: ${RUNNING_SILO_FLAG}
 test: ${SILO_EXECUTABLE}
 	build/Debug/silo_test --gtest_filter='*' --gtest_color=no
 
-python-tests:
-	pip install -q pytest
-	pip install -q .
-	pytest python/tests -v
+python-tests: ${DEPENDENCIES_FLAG}
+	uv venv --allow-existing .venv
+	uv pip install -q setuptools wheel 'Cython>=3.0.0'
+	uv pip install -q --no-build-isolation ".[test]"
+	.venv/bin/pytest python/tests -v
 
 all-tests: test e2e python-tests
 

--- a/performance/many_string_equals.cpp
+++ b/performance/many_string_equals.cpp
@@ -11,6 +11,7 @@
 #include "silo/append/ndjson_line_reader.h"
 #include "silo/initialize/initializer.h"
 #include "silo/query_engine/actions/aggregated.h"
+#include "silo/query_engine/exec_node/ndjson_sink.h"
 #include "silo/query_engine/filter/expressions/or.h"
 #include "silo/query_engine/filter/expressions/string_equals.h"
 #include "silo/query_engine/filter/expressions/string_in_set.h"
@@ -125,7 +126,8 @@ std::unique_ptr<Expression> buildStringInSet(
 void executeAggregatedQuery(const std::shared_ptr<Database>& database, Query& query) {
    auto query_plan = database->createQueryPlan(query, {}, "benchmark_query");
    std::stringstream result;
-   query_plan.executeAndWrite(&result, /*timeout_in_seconds=*/60);
+   silo::query_engine::exec_node::NdjsonSink sink{&result, query_plan.results_schema};
+   query_plan.executeAndWrite(sink, /*timeout_in_seconds=*/60);
 }
 
 struct BenchmarkResult {

--- a/performance/mutation_benchmark.cpp
+++ b/performance/mutation_benchmark.cpp
@@ -4,9 +4,10 @@
 #include "silo/append/ndjson_line_reader.h"
 #include "silo/initialize/initializer.h"
 #include "silo/query_engine/actions/mutations.h"
-#include "silo/query_engine/filter/expressions/true.h"
+#include "silo/query_engine/exec_node/ndjson_sink.h"
 #include "silo/query_engine/filter/expressions/negation.h"
 #include "silo/query_engine/filter/expressions/string_equals.h"
+#include "silo/query_engine/filter/expressions/true.h"
 #include "silo/query_engine/query.h"
 
 namespace {
@@ -115,7 +116,8 @@ void executeMutationsAllQuery(std::shared_ptr<Database> database){
 
    auto query_plan = database->createQueryPlan(query, {}, "test_query");
    std::stringstream result;
-   query_plan.executeAndWrite(&result, /*timeout_in_seconds=*/3);
+   silo::query_engine::exec_node::NdjsonSink sink{&result, query_plan.results_schema};
+   query_plan.executeAndWrite(sink, /*timeout_in_seconds=*/3);
    printClipped(result.str());
 }
 
@@ -126,7 +128,8 @@ void executeMutationsAlmostAllQuery(std::shared_ptr<Database> database){
 
    auto query_plan = database->createQueryPlan(query, {}, "test_query");
    std::stringstream result;
-   query_plan.executeAndWrite(&result, /*timeout_in_seconds=*/3);
+   silo::query_engine::exec_node::NdjsonSink sink{&result, query_plan.results_schema};
+   query_plan.executeAndWrite(sink, /*timeout_in_seconds=*/3);
    printClipped(result.str());
 }
 }  // namespace

--- a/python/pysilo/database.pxd
+++ b/python/pysilo/database.pxd
@@ -4,6 +4,9 @@ from libcpp.pair cimport pair
 from libcpp.optional cimport optional
 from libc.stdint cimport uint64_t, uint32_t
 
+cdef extern from "exception_handler.h":
+    void handle_silo_exception()
+
 cdef extern from "roaring/roaring.hh" namespace "roaring":
     cdef cppclass Roaring:
         Roaring() except +
@@ -21,10 +24,12 @@ cdef extern from "silo/database.h" namespace "silo":
         void printAllData(string table_name) except +
         string getNucleotideReferenceSequence(string table_name, string sequence_name) except +
         string getAminoAcidReferenceSequence(string table_name, string sequence_name) except +
-        vector[pair[uint64_t, string]] getPrevalentNucMutations(string table_name, string sequence_name, double prevalence_threshold, string filter) except +
-        vector[pair[uint64_t, string]] getPrevalentAminoAcidMutations(string table_name, string sequence_name, double prevalence_threshold, string filter) except +
-        Roaring getFilteredBitmap(string table_name, string filter) except +
+        vector[pair[uint64_t, string]] getPrevalentNucMutations(string table_name, string sequence_name, double prevalence_threshold, string filter) except +handle_silo_exception
+        vector[pair[uint64_t, string]] getPrevalentAminoAcidMutations(string table_name, string sequence_name, double prevalence_threshold, string filter) except +handle_silo_exception
+        Roaring getFilteredBitmap(string table_name, string filter) except +handle_silo_exception
         void saveDatabaseState(string save_directory) except +
+        string executeQueryAsArrowIpc(string table_name, string query_json) except +handle_silo_exception
+        string getTablesAsArrowIpc() except +
 
         @staticmethod
         optional[Database] loadDatabaseStateFromPath(string save_directory) except +

--- a/python/pysilo/exception_handler.h
+++ b/python/pysilo/exception_handler.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <Python.h>
+#include <stdexcept>
+#include "silo/query_engine/illegal_query_exception.h"
+
+inline void handle_silo_exception() {
+    try {
+        throw;  // re-throw current exception
+    } catch (const silo::query_engine::IllegalQueryException& e) {
+        PyErr_SetString(PyExc_ValueError, e.what());
+    } catch (const std::runtime_error& e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+    } catch (const std::exception& e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+    } catch (...) {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown C++ exception");
+    }
+}

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import tempfile
 import shutil
+import os
 
 
 @pytest.fixture

--- a/src/silo/database.h
+++ b/src/silo/database.h
@@ -107,6 +107,16 @@ class Database {
       const config::QueryOptions& query_options,
       std::string_view request_id
    ) const;
+
+   [[nodiscard]] std::string executeQueryAsArrowIpc(
+      const std::string& table_name,
+      const std::string& query_json
+   ) const;
+
+   [[nodiscard]] std::string getTablesAsArrowIpc() const;
+
+  private:
+   [[nodiscard]] arrow::Result<std::string> getTablesAsArrowIpcImpl() const;
 };
 
 }  // namespace silo

--- a/src/silo/database.test.cpp
+++ b/src/silo/database.test.cpp
@@ -125,6 +125,7 @@ TEST(DatabaseTest, shouldReturnCorrectDatabaseInfoAfterAppendingNewSequences) {
 using silo::Nucleotide;
 using silo::query_engine::Query;
 using silo::query_engine::actions::Aggregated;
+using silo::query_engine::exec_node::NdjsonSink;
 using silo::query_engine::filter::expressions::True;
 using silo::schema::ColumnIdentifier;
 using silo::schema::ColumnType;
@@ -162,7 +163,8 @@ TEST(DatabaseTest, canCreateMultipleTablesAndAddData) {
    auto query_plan_1 =
       database.createQueryPlan(aggregated_all_query, silo::config::QueryOptions{}, "test_query_1");
    std::stringstream result;
-   query_plan_1.executeAndWrite(&result, 100);
+   NdjsonSink output_sink_1{&result, query_plan_1.results_schema};
+   query_plan_1.executeAndWrite(output_sink_1, 100);
    ASSERT_EQ(result.str(), "{\"count\":20}\n");
 
    silo::schema::TableName second_table_name{"second"};
@@ -177,6 +179,7 @@ TEST(DatabaseTest, canCreateMultipleTablesAndAddData) {
    auto query_plan_2 =
       database.createQueryPlan(aggregated_all_query, silo::config::QueryOptions{}, "test_query_2");
    std::stringstream result_2;
-   query_plan_2.executeAndWrite(&result_2, 100);
+   NdjsonSink output_sink_2{&result_2, query_plan_2.results_schema};
+   query_plan_2.executeAndWrite(output_sink_2, 100);
    ASSERT_EQ(result_2.str(), "{\"count\":1}\n");
 }

--- a/src/silo/preprocessing/preprocessing.test.cpp
+++ b/src/silo/preprocessing/preprocessing.test.cpp
@@ -12,6 +12,7 @@
 #include "silo/database.h"
 #include "silo/database_info.h"
 #include "silo/preprocessing/preprocessing_exception.h"
+#include "silo/query_engine/exec_node/ndjson_sink.h"
 #include "silo/query_engine/query.h"
 #include "silo/query_engine/query_plan.h"
 
@@ -882,6 +883,8 @@ const auto TEST_CASES = ::testing::Values(
 
 INSTANTIATE_TEST_SUITE_P(PreprocessorTest, PreprocessorTestFixture, TEST_CASES, printTestName<Success>);
 
+using silo::query_engine::exec_node::NdjsonSink;
+
 TEST_P(PreprocessorTestFixture, shouldProcessData) {
    const auto& scenario = GetParam();
 
@@ -899,7 +902,8 @@ TEST_P(PreprocessorTestFixture, shouldProcessData) {
       *query, silo::config::RuntimeConfig::withDefaults().query_options, "some_id"
    );
    std::stringstream actual_result_stream;
-   query_plan.executeAndWrite(&actual_result_stream, /*timeout_in_seconds=*/3);
+   NdjsonSink output_sink{&actual_result_stream, query_plan.results_schema};
+   query_plan.executeAndWrite(output_sink, /*timeout_in_seconds=*/3);
    nlohmann::json actual_ndjson_result_as_array = nlohmann::json::array();
    std::string line;
    while (std::getline(actual_result_stream, line)) {

--- a/src/silo/query_engine/exec_node/arrow_batch_sink.h
+++ b/src/silo/query_engine/exec_node/arrow_batch_sink.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <ostream>
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/io/interfaces.h>
+
+namespace silo::query_engine::exec_node {
+
+class ArrowBatchSink {
+  public:
+   virtual ~ArrowBatchSink() = default;
+
+   virtual arrow::Status writeBatch(const arrow::compute::ExecBatch& batch) = 0;
+   virtual arrow::Status finish() = 0;
+};
+
+}  // namespace silo::query_engine::exec_node

--- a/src/silo/query_engine/exec_node/arrow_ipc_sink.cpp
+++ b/src/silo/query_engine/exec_node/arrow_ipc_sink.cpp
@@ -1,0 +1,68 @@
+#include "silo/query_engine/exec_node/arrow_ipc_sink.h"
+
+#include <spdlog/spdlog.h>
+
+#include "evobench/evobench.hpp"
+
+namespace silo::query_engine::exec_node {
+
+OstreamWrapper::OstreamWrapper(std::ostream* output_stream)
+    : output_stream(output_stream) {}
+
+arrow::Status OstreamWrapper::Close() {
+   is_closed_ = true;
+   output_stream->flush();
+   if (!*output_stream) {
+      return arrow::Status::IOError("Failed to flush output stream on close");
+   }
+   return arrow::Status::OK();
+}
+
+bool OstreamWrapper::closed() const {
+   return is_closed_;
+}
+
+arrow::Result<int64_t> OstreamWrapper::Tell() const {
+   return position_;
+}
+
+arrow::Status OstreamWrapper::Write(const void* data, int64_t nbytes) {
+   output_stream->write(static_cast<const char*>(data), static_cast<std::streamsize>(nbytes));
+   if (!*output_stream) {
+      return arrow::Status::IOError("Failed to write to output stream");
+   }
+   position_ += nbytes;
+   return arrow::Status::OK();
+}
+
+arrow::Status OstreamWrapper::Flush() {
+   output_stream->flush();
+   if (!*output_stream) {
+      return arrow::Status::IOError("Failed to flush output stream");
+   }
+   return arrow::Status::OK();
+}
+
+arrow::Result<ArrowIpcSink> ArrowIpcSink::Make(
+   std::ostream* output_stream,
+   std::shared_ptr<arrow::Schema> schema
+) {
+   auto output_wrapper = std::make_shared<OstreamWrapper>(output_stream);
+   ARROW_ASSIGN_OR_RAISE(auto writer, arrow::ipc::MakeStreamWriter(output_wrapper, schema));
+   return ArrowIpcSink(output_wrapper, writer, schema);
+}
+
+arrow::Status ArrowIpcSink::writeBatch(const arrow::compute::ExecBatch& batch) {
+   EVOBENCH_SCOPE("QueryPlan", "writeBatchAsArrowIpc");
+
+   ARROW_ASSIGN_OR_RAISE(auto record_batch, batch.ToRecordBatch(schema));
+   ARROW_RETURN_NOT_OK(writer->WriteRecordBatch(*record_batch));
+
+   return arrow::Status::OK();
+}
+
+arrow::Status ArrowIpcSink::finish() {
+   return writer->Close();
+}
+
+}  // namespace silo::query_engine::exec_node

--- a/src/silo/query_engine/exec_node/arrow_ipc_sink.h
+++ b/src/silo/query_engine/exec_node/arrow_ipc_sink.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <ostream>
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/io/interfaces.h>
+#include <arrow/ipc/writer.h>
+
+#include "silo/query_engine/exec_node/arrow_batch_sink.h"
+
+namespace silo::query_engine::exec_node {
+
+/// Adapter that wraps a std::ostream as an Arrow OutputStream for IPC writing
+/// This is required by the arrow::ipc::RecordBatchWriter
+class OstreamWrapper : public arrow::io::OutputStream {
+   std::ostream* output_stream;
+   int64_t position_ = 0;
+   bool is_closed_ = false;
+
+  public:
+   explicit OstreamWrapper(std::ostream* output_stream);
+
+   arrow::Status Close() override;
+   bool closed() const override;
+   arrow::Result<int64_t> Tell() const override;
+   arrow::Status Write(const void* data, int64_t nbytes) override;
+   arrow::Status Flush() override;
+};
+
+/// Writer for streaming Arrow IPC format to an ostream.
+/// Usage:
+///   auto writer = ArrowIpcSink::Make(output_stream, schema);
+///   for each batch:
+///     writer.writeBatch(batch);
+///   writer.finish();
+class ArrowIpcSink : public ArrowBatchSink {
+   std::shared_ptr<OstreamWrapper> output_wrapper;
+   std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;
+   std::shared_ptr<arrow::Schema> schema;
+
+   ArrowIpcSink(
+      std::shared_ptr<OstreamWrapper> output_wrapper,
+      std::shared_ptr<arrow::ipc::RecordBatchWriter> writer,
+      std::shared_ptr<arrow::Schema> schema
+   )
+       : output_wrapper(output_wrapper),
+         writer(writer),
+         schema(schema) {}
+
+  public:
+   static arrow::Result<ArrowIpcSink> Make(
+      std::ostream* output_stream,
+      std::shared_ptr<arrow::Schema> schema
+   );
+   arrow::Status writeBatch(const arrow::compute::ExecBatch& batch) override;
+   arrow::Status finish() override;
+};
+
+}  // namespace silo::query_engine::exec_node

--- a/src/silo/query_engine/exec_node/ndjson_sink.cpp
+++ b/src/silo/query_engine/exec_node/ndjson_sink.cpp
@@ -165,11 +165,7 @@ void sendJsonLinesInBatches(
 
 }  // namespace
 
-arrow::Status writeBatchAsNdjson(
-   const arrow::compute::ExecBatch& batch,
-   const std::shared_ptr<arrow::Schema>& schema,
-   std::ostream* output_stream
-) {
+arrow::Status NdjsonSink::writeBatch(const arrow::compute::ExecBatch& batch) {
    EVOBENCH_SCOPE("QueryPlan", "writeBatchAsNdjson");
    size_t row_count = batch.length;
    std::vector<std::shared_ptr<arrow::Array>> column_arrays;
@@ -198,6 +194,11 @@ arrow::Status writeBatchAsNdjson(
    if (!*output_stream) {
       return arrow::Status::IOError("Could not write to network stream");
    }
+   return arrow::Status::OK();
+}
+
+arrow::Status NdjsonSink::finish() {
+   // TODO(#480) mark that the download is complete
    return arrow::Status::OK();
 }
 

--- a/src/silo/query_engine/exec_node/ndjson_sink.h
+++ b/src/silo/query_engine/exec_node/ndjson_sink.h
@@ -6,12 +6,21 @@
 #include <arrow/util/async_generator_fwd.h>
 #include <spdlog/spdlog.h>
 
+#include "silo/query_engine/exec_node/arrow_batch_sink.h"
+
 namespace silo::query_engine::exec_node {
 
-arrow::Status writeBatchAsNdjson(
-   const arrow::compute::ExecBatch& batch,
-   const std::shared_ptr<arrow::Schema>& schema,
-   std::ostream* output_stream
-);
+class NdjsonSink : public ArrowBatchSink {
+   std::ostream* output_stream;
+   std::shared_ptr<arrow::Schema> schema;
+
+  public:
+   NdjsonSink(std::ostream* output_stream_, std::shared_ptr<arrow::Schema> schema_)
+       : output_stream(output_stream_),
+         schema(schema_) {}
+
+   arrow::Status writeBatch(const arrow::compute::ExecBatch& batch) override;
+   arrow::Status finish() override;
+};
 
 }  // namespace silo::query_engine::exec_node

--- a/src/silo/query_engine/filter/expressions/or.cpp
+++ b/src/silo/query_engine/filter/expressions/or.cpp
@@ -112,6 +112,9 @@ ExpressionVector Or::rewriteSymbolInSetExpressions(ExpressionVector children) {
    return new_children;
 }
 
+template ExpressionVector Or::rewriteSymbolInSetExpressions<AminoAcid>(ExpressionVector children);
+template ExpressionVector Or::rewriteSymbolInSetExpressions<Nucleotide>(ExpressionVector children);
+
 ExpressionVector Or::mergeStringInSetExpressions(ExpressionVector children) {
    ExpressionVector new_children;
    using Column = std::string;

--- a/src/silo/query_engine/query_plan.h
+++ b/src/silo/query_engine/query_plan.h
@@ -8,6 +8,8 @@
 #include <arrow/acero/options.h>
 #include <arrow/util/async_generator_fwd.h>
 
+#include "silo/query_engine/exec_node/arrow_batch_sink.h"
+
 namespace silo::query_engine {
 
 class QueryPlan {
@@ -25,7 +27,7 @@ class QueryPlan {
       std::string_view request_id
    );
 
-   void executeAndWrite(std::ostream* output_stream, uint64_t timeout_in_seconds);
+   void executeAndWrite(exec_node::ArrowBatchSink& output_sink, uint64_t timeout_in_seconds);
 
   private:
    QueryPlan(
@@ -39,7 +41,10 @@ class QueryPlan {
          backpressure_monitor(backpressure_monitor),
          request_id(request_id) {}
 
-   arrow::Status executeAndWriteImpl(std::ostream* output_stream, uint64_t timeout_in_seconds);
+   arrow::Status executeAndWriteImpl(
+      exec_node::ArrowBatchSink& output_sink,
+      uint64_t timeout_in_seconds
+   );
 
    static arrow::Result<arrow::acero::BackpressureMonitor*> createGenerator(
       arrow::acero::ExecPlan* plan,

--- a/src/silo/query_engine/query_plan.test.cpp
+++ b/src/silo/query_engine/query_plan.test.cpp
@@ -8,7 +8,10 @@
 #include "arrow/acero/options.h"
 #include "arrow/builder.h"
 
+#include "silo/query_engine/exec_node/ndjson_sink.h"
+
 using silo::query_engine::QueryPlan;
+using silo::query_engine::exec_node::NdjsonSink;
 
 namespace {
 
@@ -52,10 +55,11 @@ TEST(QueryPlan, timesOutWhenAnInvalidPlanDoesNotFinish) {
          auto under_test = QueryPlan::makeQueryPlan(arrow_plan, node, "some_id").ValueOrDie();
 
          std::stringstream dummy_output{};
+         NdjsonSink output_sink{&dummy_output, under_test.results_schema};
          // Set time-out to zero, so it immediately cancels execution (only works with pipeline
          // breakers like aggregate, because otherwise the StartProducing call might already do all
          // the work)
-         under_test.executeAndWrite(&dummy_output, 0);
+         under_test.executeAndWrite(output_sink, 0);
       }),
       ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
          "Internal server error. Please notify developers. SILO likely constructed an invalid "


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1141 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This adds SILO queries to the python interface. Crucially, this directly makes them available to interact with in python through pyarrow, instead of going through ndjson as we do in the http interface

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
