### PR TITLE
refactor(silo): replace boost::join with fmt::join

### DIFF
--- a/src/config/config_key_path.cpp
+++ b/src/config/config_key_path.cpp
@@ -1,7 +1,8 @@
 #include "config/config_key_path.h"
 
+#include <algorithm>
+
 #include <fmt/format.h>
-#include <boost/algorithm/string/join.hpp>
 
 namespace {
 bool isLowerCaseOrNumeric(char character) {

--- a/src/config/source/command_line_arguments.cpp
+++ b/src/config/source/command_line_arguments.cpp
@@ -1,8 +1,8 @@
 #include "config/source/command_line_arguments.h"
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>
 
 #include "config/config_exception.h"
@@ -16,7 +16,7 @@ std::string CommandLineArguments::configKeyPathToString(const ConfigKeyPath& key
          result.push_back(current_string);
       }
    }
-   return "--" + boost::join(result, "-");
+   return fmt::format("--{}", fmt::join(result, "-"));
 }
 
 AmbiguousConfigKeyPath CommandLineArguments::stringToConfigKeyPath(const std::string& option) {
@@ -140,7 +140,7 @@ VerifiedCommandLineArguments CommandLineArguments::verify(
          "in {}: unknown {} {}",
          debugContext(),
          keys_or_options,
-         boost::join(invalid_config_keys, ", ")
+         fmt::join(invalid_config_keys, ", ")
       ));
    }
 

--- a/src/config/source/environment_variables.cpp
+++ b/src/config/source/environment_variables.cpp
@@ -2,9 +2,10 @@
 
 #include <cstddef>
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <spdlog/spdlog.h>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>
 
 constexpr std::string_view ENV_VAR_PREFIX = "SILO_";
@@ -57,7 +58,7 @@ EnvironmentVariables EnvironmentVariables::newWithAllowListAndEnv(
          result.push_back(current_string_all_uppercase);
       }
    }
-   return fmt::format("{}{}", ENV_VAR_PREFIX, boost::join(result, "_"));
+   return fmt::format("{}{}", ENV_VAR_PREFIX, fmt::join(result, "_"));
 }
 
 AmbiguousConfigKeyPath EnvironmentVariables::stringToConfigKeyPath(
@@ -125,7 +126,7 @@ AmbiguousConfigKeyPath EnvironmentVariables::stringToConfigKeyPath(
          "in {}: unknown {} {} for '{}'",
          debugContext(),
          keys_or_options,
-         boost::join(invalid_config_keys, ", "),
+         fmt::join(invalid_config_keys, ", "),
          config_specification.program_name
       ));
    }

--- a/src/config/source/yaml_file.cpp
+++ b/src/config/source/yaml_file.cpp
@@ -4,9 +4,9 @@
 #include <fstream>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <spdlog/spdlog.h>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>
 
 #include "config/config_exception.h"
@@ -115,7 +115,7 @@ void yamlToPaths(
          auto debug_string_parents = ({
             std::vector<std::string> result;
             std::ranges::transform(parents_vector, std::back_inserter(result), joinCamelCase);
-            boost::join(result, ".");
+            fmt::format("{}", fmt::join(result, "."));
          });
          throw silo::config::ConfigException(
             fmt::format("{}: found invalid key: {}", debug_context, debug_string_parents)
@@ -142,7 +142,7 @@ std::string YamlFile::configKeyPathToString(const ConfigKeyPath& config_key_path
    for (const auto& list : config_key_path.getPath()) {
       camel_case_strings.emplace_back(joinCamelCase(list));
    }
-   return boost::join(camel_case_strings, ".");
+   return fmt::format("{}", fmt::join(camel_case_strings, "."));
 }
 
 ConfigKeyPath YamlFile::stringToConfigKeyPath(const std::string& key_path_string) {
@@ -251,7 +251,7 @@ VerifiedConfigAttributes YamlFile::verify(const ConfigSpecification& config_spec
          "in {}: unknown {} {}",
          debugContext(),
          keys_or_options,
-         boost::join(invalid_config_keys, ", ")
+         fmt::join(invalid_config_keys, ", ")
       ));
    }
 

--- a/src/silo/common/lineage_tree.cpp
+++ b/src/silo/common/lineage_tree.cpp
@@ -7,7 +7,6 @@
 
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
-#include <boost/algorithm/string/join.hpp>
 
 #include "evobench/evobench.hpp"
 #include "silo/common/panic.h"

--- a/src/silo/common/string_utils.cpp
+++ b/src/silo/common/string_utils.cpp
@@ -3,7 +3,7 @@
 #include <stdexcept>
 
 #include <fmt/format.h>
-#include <boost/algorithm/string/join.hpp>
+#include <fmt/ranges.h>
 #include "silo/common/panic.h"
 
 namespace silo {
@@ -81,7 +81,7 @@ std::string tieAsString(
    const std::vector<std::string>& elements2,
    std::string_view suffix
 ) {
-   return boost::join(tie(prefix, elements1, delimiter, elements2, suffix), "");
+   return fmt::format("{}", fmt::join(tie(prefix, elements1, delimiter, elements2, suffix), ""));
 }
 
 }  // namespace silo

--- a/src/silo/config/runtime_config.cpp
+++ b/src/silo/config/runtime_config.cpp
@@ -3,7 +3,6 @@
 #include <string>
 
 #include <spdlog/spdlog.h>
-#include <boost/algorithm/string/join.hpp>
 #include <nlohmann/json.hpp>
 
 #include "config/config_interface.h"

--- a/src/silo/initialize/initializer.cpp
+++ b/src/silo/initialize/initializer.cpp
@@ -2,7 +2,6 @@
 
 #include <fmt/ranges.h>
 #include <spdlog/spdlog.h>
-#include <boost/algorithm/string/join.hpp>
 
 #include "evobench/evobench.hpp"
 #include "silo/common/aa_symbols.h"

--- a/src/silo/query_engine/actions/mutations.cpp
+++ b/src/silo/query_engine/actions/mutations.cpp
@@ -13,7 +13,6 @@
 #include <arrow/util/future.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
-#include <boost/algorithm/string/join.hpp>
 #include <nlohmann/json.hpp>
 
 #include "evobench/evobench.hpp"
@@ -648,13 +647,7 @@ void from_json(const nlohmann::json& json, std::unique_ptr<Mutations<SymbolType>
             iter != Mutations<SymbolType>::VALID_FIELDS.end(),
             "The attribute 'fields' contains an invalid field '{}'. Valid fields are {}.",
             field,
-            boost::join(
-               std::vector<std::string>{
-                  Mutations<SymbolType>::VALID_FIELDS.begin(),
-                  Mutations<SymbolType>::VALID_FIELDS.end()
-               },
-               ", "
-            )
+            fmt::join(Mutations<SymbolType>::VALID_FIELDS, ", ")
          );
          fields.push_back(*iter);
       }

--- a/src/silo/query_engine/filter/expressions/and.cpp
+++ b/src/silo/query_engine/filter/expressions/and.cpp
@@ -8,7 +8,6 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <spdlog/spdlog.h>
-#include <boost/algorithm/string/join.hpp>
 #include <nlohmann/json.hpp>
 
 #include "silo/query_engine/filter/expressions/expression.h"
@@ -37,7 +36,7 @@ std::string And::toString() const {
       std::back_inserter(child_strings),
       [&](const std::unique_ptr<Expression>& child) { return child->toString(); }
    );
-   return "And(" + boost::algorithm::join(child_strings, " & ") + ")";
+   return fmt::format("And({})", fmt::join(child_strings, " & "));
 }
 
 namespace {

--- a/src/silo/query_engine/filter/expressions/insertion_contains.cpp
+++ b/src/silo/query_engine/filter/expressions/insertion_contains.cpp
@@ -3,7 +3,6 @@
 #include <utility>
 
 #include <spdlog/spdlog.h>
-#include <boost/algorithm/string/join.hpp>
 #include <nlohmann/json.hpp>
 
 #include "silo/common/aa_symbols.h"

--- a/src/silo/query_engine/filter/expressions/or.cpp
+++ b/src/silo/query_engine/filter/expressions/or.cpp
@@ -4,7 +4,8 @@
 #include <string>
 #include <utility>
 
-#include <boost/algorithm/string/join.hpp>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <nlohmann/json.hpp>
 
 #include "silo/query_engine/filter/expressions/expression.h"
@@ -34,7 +35,7 @@ std::string Or::toString() const {
       std::back_inserter(child_strings),
       [&](const std::unique_ptr<Expression>& child) { return child->toString(); }
    );
-   return "Or(" + boost::algorithm::join(child_strings, " | ") + ")";
+   return fmt::format("Or({})", fmt::join(child_strings, " | "));
 }
 
 std::vector<const Expression*> Or::collectChildren(const ExpressionVector& children) {

--- a/src/silo/query_engine/filter/operators/range_selection.cpp
+++ b/src/silo/query_engine/filter/operators/range_selection.cpp
@@ -5,7 +5,8 @@
 #include <utility>
 #include <vector>
 
-#include <boost/algorithm/string/join.hpp>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "evobench/evobench.hpp"
 #include "silo/query_engine/copy_on_write_bitmap.h"
@@ -33,7 +34,7 @@ std::string RangeSelection::toString() const {
          return std::to_string(range.start) + "-" + std::to_string(range.end);
       }
    );
-   return "RangeSelection(" + boost::algorithm::join(range_strings, ", ") + ")";
+   return fmt::format("RangeSelection({})", fmt::join(range_strings, ", "));
 }
 
 Type RangeSelection::type() const {

--- a/src/silo/query_engine/filter/operators/selection.cpp
+++ b/src/silo/query_engine/filter/operators/selection.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <boost/algorithm/string/join.hpp>
+#include <fmt/ranges.h>
 #include <roaring/roaring.hh>
 
 #include "evobench/evobench.hpp"
@@ -77,8 +77,7 @@ std::string Selection::toString() const {
    if (child_operator.has_value()) {
       child_operator_string = child_operator.value()->toString();
    }
-   return "Select[" + boost::algorithm::join(predicate_strings, ",") + "](" +
-          child_operator_string + ")";
+   return fmt::format("Select[{}]({})", fmt::join(predicate_strings, ","), child_operator_string);
 }
 
 Type Selection::type() const {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #999

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This replace `boost::join` with `fmt::join`. This makes us less reliant on boost and fmt has a nicer/more modern api as well

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
