### PR TITLE
feat(silo): add verbosity argument to CLI interface

### DIFF
--- a/src/config/config_interface.h
+++ b/src/config/config_interface.h
@@ -74,6 +74,11 @@ std::variant<C, int32_t> getConfig(
    try {
       VerifiedCommandLineArguments cmd_source =
          CommandLineArguments{cmd}.verify(config_specification);
+      if (cmd_source.verbose_count == 1) {
+         spdlog::set_level(spdlog::level::debug);
+      } else if (cmd_source.verbose_count >= 2) {
+         spdlog::set_level(spdlog::level::trace);
+      }
       if (cmd_source.asks_for_help) {
          std::cout << config_specification.helpText() << "\n" << std::flush;
          return 0;

--- a/src/config/config_specification.cpp
+++ b/src/config/config_specification.cpp
@@ -66,7 +66,11 @@ std::string ConfigSpecification::helpText() const {
              << "\n"
              << "  -h | --help\n"
              << "\n"
-             << "    Show help.\n";
+             << "    Show help.\n"
+             << "\n"
+             << "  -v | --verbose\n"
+             << "\n"
+             << "    Increase log verbosity. Pass once for debug level, twice for trace level.\n";
    auto addln = [&help_text](const std::string& line) { help_text << line << "\n"; };
 
    for (const auto& field_spec : attribute_specifications) {

--- a/src/config/source/command_line_arguments.test.cpp
+++ b/src/config/source/command_line_arguments.test.cpp
@@ -158,3 +158,34 @@ TEST(CommandLineArguments, testPositionalArgumentsStartingWithMinus) {
       ASSERT_EQ(verified.positional_arguments.at(0), "-positional_argument_with_minus");
    }
 }
+
+TEST(CommandLineArguments, verboseFlagShortForm) {
+   std::vector<std::string> arguments{"-v"};
+   const auto verified = CommandLineArguments{{arguments.begin(), arguments.end()}}.verify({});
+   ASSERT_EQ(verified.verbose_count, 1U);
+   ASSERT_TRUE(verified.positional_arguments.empty());
+}
+
+TEST(CommandLineArguments, verboseFlagLongForm) {
+   std::vector<std::string> arguments{"--verbose"};
+   const auto verified = CommandLineArguments{{arguments.begin(), arguments.end()}}.verify({});
+   ASSERT_EQ(verified.verbose_count, 1U);
+}
+
+TEST(CommandLineArguments, verboseFlagRepeated) {
+   std::vector<std::string> arguments{"-v", "--verbose", "-v"};
+   const auto verified = CommandLineArguments{{arguments.begin(), arguments.end()}}.verify({});
+   ASSERT_EQ(verified.verbose_count, 3U);
+}
+
+TEST(CommandLineArguments, verboseFlagCluster) {
+   std::vector<std::string> arguments{"-vvv"};
+   const auto verified = CommandLineArguments{{arguments.begin(), arguments.end()}}.verify({});
+   ASSERT_EQ(verified.verbose_count, 3U);
+}
+
+TEST(CommandLineArguments, verboseFlagDoesNotCountAsUnknownOption) {
+   std::vector<std::string> arguments{"-v"};
+   // Even with an empty specification (no known options), -v should not throw.
+   ASSERT_NO_THROW(((void)CommandLineArguments{{arguments.begin(), arguments.end()}}.verify({})));
+}

--- a/src/config/verified_config_attributes.cpp
+++ b/src/config/verified_config_attributes.cpp
@@ -97,17 +97,20 @@ std::optional<std::vector<std::string>> VerifiedConfigAttributes::getList(
 VerifiedCommandLineArguments VerifiedCommandLineArguments::askingForHelp() {
    VerifiedCommandLineArguments result;
    result.asks_for_help = true;
+   result.verbose_count = 0;
    return result;
 }
 
 VerifiedCommandLineArguments VerifiedCommandLineArguments::fromConfigValuesAndPositionalArguments(
    std::unordered_map<ConfigKeyPath, ConfigValue> config_values,
-   std::vector<std::string> positional_arguments
+   std::vector<std::string> positional_arguments,
+   uint32_t verbose_count
 ) {
    VerifiedCommandLineArguments result;
    result.config_values = std::move(config_values);
    result.positional_arguments = std::move(positional_arguments);
    result.asks_for_help = false;
+   result.verbose_count = verbose_count;
    return result;
 }
 

--- a/src/config/verified_config_attributes.h
+++ b/src/config/verified_config_attributes.h
@@ -15,8 +15,8 @@ namespace silo::config {
 /// The accessors return an option since even though invalid options are
 /// not present in this, the given option may also not be present.
 ///
-/// `positional_arguments` and `asks_for_help` are only used by the command
-/// line argument backend, other backends leave them empty/false.
+/// `positional_arguments`, `asks_for_help`, and `verbose_count` are only used
+/// by the command line argument backend, other backends leave them empty/false/0.
 class VerifiedConfigAttributes {
   public:
    std::unordered_map<ConfigKeyPath, ConfigValue> config_values;
@@ -43,12 +43,16 @@ class VerifiedCommandLineArguments : public VerifiedConfigAttributes {
   public:
    std::vector<std::string> positional_arguments;
    bool asks_for_help;
+   /// Number of times -v / --verbose was passed on the command line.
+   /// 1 → debug level, 2+ → trace level.
+   uint32_t verbose_count;
 
    static VerifiedCommandLineArguments askingForHelp();
 
    static VerifiedCommandLineArguments fromConfigValuesAndPositionalArguments(
       std::unordered_map<ConfigKeyPath, ConfigValue> config_values,
-      std::vector<std::string> positional_arguments
+      std::vector<std::string> positional_arguments,
+      uint32_t verbose_count
    );
 };
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #565 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

`-v` / `--verbose` can be passed once for debug-level logging and twice for trace-level logging

`-vv..` is also supported

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so. (`--help` message)
- [X] The implemented feature is covered by an appropriate test.
