### PR TITLE
feat(silo): allow sequence-column inputs to be zstd-compressed in base64 format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ find_package(re2 REQUIRED)
 find_package(roaring REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(simdjson REQUIRED)
+find_package(simdutf REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(zstd REQUIRED)
 
@@ -141,6 +142,7 @@ target_link_libraries(
         ${roaring_LIBRARIES}
         ${spdlog_LIBRARIES}
         ${simdjson_LIBRARIES}
+        ${simdutf_LIBRARIES}
         ${yaml-cpp_LIBRARIES}
         zstd::libzstd_static
         Poco::Net

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,6 +15,7 @@ class SiloRecipe(ConanFile):
         "re2/20240702",
         "roaring/4.2.1",
         "simdjson/3.12.3",
+        "simdutf/8.0.0",
         "spdlog/1.15.1",
         "yaml-cpp/0.8.0",
         "zstd/1.5.7",
@@ -96,6 +97,8 @@ class SiloRecipe(ConanFile):
 
         "simdjson/*:shared": False,
 
+        "simdutf/*:shared": False,
+
         "spdlog/*:shared": False,
 
         "yaml-cpp/*:shared": False,
@@ -117,6 +120,7 @@ class SiloRecipe(ConanFile):
         deps.set_property("roaring", "cmake_find_mode", "both")
         deps.set_property("spdlog", "cmake_find_mode", "both")
         deps.set_property("simdjson", "cmake_find_mode", "both")
+        deps.set_property("simdutf", "cmake_find_mode", "both")
         deps.set_property("yaml-cpp", "cmake_find_mode", "both")
         deps.set_property("zstd", "cmake_find_mode", "both")
         deps.generate()

--- a/documentation/input_format.md
+++ b/documentation/input_format.md
@@ -18,6 +18,7 @@ SILO expects input data in **NDJSON format** (Newline Delimited JSON), where eac
 ```json
 {"primaryKey":"seq_001","date":"2021-03-18","country":"Switzerland","age":54,"main":{"sequence":"ACGT","insertions":[]}}
 {"primaryKey":"seq_002","date":"2021-04-13","country":"Germany","age":null,"main":{"sequence":"AAGN","insertions":["2:AC"]}}
+{"primaryKey":"seq_003","date":"2021-05-01","country":"France","age":30,"main":{"sequenceCompressed":"<base64-zstd>","insertions":[]}}
 ```
 
 ## Configuration Files
@@ -201,6 +202,7 @@ DNA/RNA sequence data with optional insertions.
 
 **Fields**:
 - `sequence`: The nucleotide sequence string
+- `sequenceCompressed` (alternative to `sequence`): A base64-encoded, ZSTD-compressed nucleotide sequence. The ZSTD compression must use the column's reference genome string as a dictionary. When present, `sequenceCompressed` takes precedence over `sequence`.
 - `insertions`: Array of insertions in format `position:sequence`. `sequence` is inserted _after_ `position`. `position` 0 inserts _before the first symbol_. Valid positions are therefore in the range `[0, n]` where `n` is the length of the reference sequence.
 - `offset` (optional): Integer offset into reference genome (default: 0)
 
@@ -249,6 +251,12 @@ Protein sequence data with optional insertions.
   }
 }
 ```
+
+**Fields**:
+- `sequence`: The amino acid sequence string
+- `sequenceCompressed` (alternative to `sequence`): A base64-encoded, ZSTD-compressed amino acid sequence. The ZSTD compression must use the column's reference sequence string as a dictionary. When present, `sequenceCompressed` takes precedence over `sequence`.
+- `insertions`: Array of insertions in format `position:sequence`
+- `offset` (optional): Integer offset into reference sequence (default: 0)
 
 **Valid Amino Acid Characters**:
 
@@ -300,5 +308,7 @@ defaultNucleotideSequence: main
 | Invalid date format | Date string not in YYYY-MM-DD format | Error with details |
 | Invalid sequence character | Unknown nucleotide/amino acid | Error with position |
 | Invalid insertion format | Malformed insertion string | Error with details |
+| Invalid base64 in `sequenceCompressed` | Illegal characters or wrong padding | Error with details |
+| Invalid ZSTD data in `sequenceCompressed` | Wrong dictionary or corrupt bytes | Error with details |
 | Duplicate primary key | Same primary key appears twice | Error at validation |
 | Unknown field | Field in JSON not in schema | Warning, ignored |

--- a/src/silo/common/base64.cpp
+++ b/src/silo/common/base64.cpp
@@ -1,0 +1,43 @@
+#include "silo/common/base64.h"
+
+#include <expected>
+#include <string>
+#include <string_view>
+
+#include <simdutf.h>
+
+namespace silo {
+
+std::expected<std::string, std::string> decodeBase64(std::string_view encoded) {
+   const size_t max_size =
+      simdutf::maximal_binary_length_from_base64(encoded.data(), encoded.size());
+   std::string result(max_size, '\0');
+   const auto decode_result =
+      simdutf::base64_to_binary(encoded.data(), encoded.size(), result.data());
+   if (decode_result.error != simdutf::error_code::SUCCESS) {
+      switch (decode_result.error) {
+         case simdutf::SUCCESS:
+            break;
+         case simdutf::INVALID_BASE64_CHARACTER:
+            return std::unexpected{"the encoded string contained an invalid base64 character"};
+         case simdutf::BASE64_INPUT_REMAINDER:
+            return std::unexpected{"invalid padding of base64 input"};
+         case simdutf::BASE64_EXTRA_BITS:
+            return std::unexpected{"the base64 input terminates with non-zero padding bits"};
+         case simdutf::OUTPUT_BUFFER_TOO_SMALL:
+            return std::unexpected{"the provided buffer is too small, please notify developers"};
+         case simdutf::HEADER_BITS:
+         case simdutf::OVERLONG:
+         case simdutf::SURROGATE:
+         case simdutf::TOO_SHORT:
+         case simdutf::TOO_LONG:
+         case simdutf::TOO_LARGE:
+         case simdutf::OTHER:
+            return std::unexpected{"an unexpected error occurred when decoding base64 string"};
+      }
+   }
+   result.resize(decode_result.count);
+   return result;
+}
+
+}  // namespace silo

--- a/src/silo/common/base64.h
+++ b/src/silo/common/base64.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <expected>
+#include <string>
+#include <string_view>
+
+namespace silo {
+
+/// Decodes a standard base64-encoded string to binary data.
+/// Returns a user-legible error string if the input cannot be decoded
+std::expected<std::string, std::string> decodeBase64(std::string_view encoded);
+
+}  // namespace silo

--- a/src/silo/common/base64.test.cpp
+++ b/src/silo/common/base64.test.cpp
@@ -1,0 +1,26 @@
+#include "silo/common/base64.h"
+
+#include <string>
+#include <string_view>
+
+#include <gtest/gtest.h>
+#include <simdutf.h>
+
+TEST(Base64, givenInvalidCharacterReturnsSensibleError) {
+   // '!' is not a valid base64 character
+   // simdutf reports INVALID_BASE64_CHARACTER which we turn into an error message
+   const std::string_view invalid = "!!!!";
+
+   const auto result = silo::decodeBase64(invalid);
+   ASSERT_FALSE(result.has_value());
+   EXPECT_EQ(result.error(), "the encoded string contained an invalid base64 character");
+}
+
+TEST(Base64, givenInvalidLengthReturnsSensibleError) {
+   // the length must be a multiple of two
+   const std::string_view invalid = "aaaAA";
+
+   const auto result = silo::decodeBase64(invalid);
+   ASSERT_FALSE(result.has_value());
+   EXPECT_EQ(result.error(), "invalid padding of base64 input");
+}

--- a/src/silo/storage/column/sequence_column.cpp
+++ b/src/silo/storage/column/sequence_column.cpp
@@ -91,7 +91,10 @@ SequenceColumnPartition<SymbolType>::SequenceColumnPartition(
     : metadata(metadata),
       genome_length(metadata->reference_sequence.size()),
       local_reference_sequence_string(SymbolType::sequenceToString(metadata->reference_sequence)),
-      horizontal_coverage_index() {
+      horizontal_coverage_index(),
+      compressed_input_decompressor(
+         std::make_shared<ZstdDDictionary>(local_reference_sequence_string)
+      ) {
    mutation_buffer.resize(genome_length);
    SILO_ASSERT_GT(genome_length, 0ULL);
 }

--- a/src/silo/storage/column/sequence_column.h
+++ b/src/silo/storage/column/sequence_column.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -17,6 +18,8 @@
 #include "silo/storage/column/horizontal_coverage_index.h"
 #include "silo/storage/column/insertion_index.h"
 #include "silo/storage/column/vertical_sequence_index.h"
+#include "silo/zstd/zstd_decompressor.h"
+#include "silo/zstd/zstd_dictionary.h"
 
 namespace silo::storage::column {
 
@@ -68,6 +71,11 @@ class SequenceColumnPartition {
       archive & sequence_count;
       archive & null_bitmap;
       // clang-format on
+      if constexpr (Archive::is_loading::value) {
+         compressed_input_decompressor = ZstdDecompressor{std::make_shared<ZstdDDictionary>(
+            SymbolType::sequenceToString(metadata->reference_sequence)
+         )};
+      }
    }
 
   public:
@@ -83,6 +91,8 @@ class SequenceColumnPartition {
    SequenceColumnInfo sequence_column_info;
    roaring::Roaring null_bitmap;
    uint32_t sequence_count = 0;
+
+   ZstdDecompressor compressed_input_decompressor;
 
    explicit SequenceColumnPartition(Metadata* metadata);
 

--- a/src/silo/storage/column_group.cpp
+++ b/src/silo/storage/column_group.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <expected>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include <fmt/format.h>
@@ -13,6 +14,7 @@
 
 #include "evobench/evobench.hpp"
 #include "silo/common/aa_symbols.h"
+#include "silo/common/base64.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/storage/column/column_type_visitor.h"
 
@@ -142,6 +144,61 @@ namespace {
       )};                                                                                   \
    }
 
+struct InputSequence {
+   std::variant<std::string_view, std::string> sequence;
+
+   [[nodiscard]] std::string_view getView() const {
+      if (std::holds_alternative<std::string_view>(sequence)) {
+         return std::get<std::string_view>(sequence);
+      }
+      return std::get<std::string>(sequence);
+   }
+};
+
+template <typename SymbolType>
+std::expected<InputSequence, std::string> getSequenceFromJsonLine(
+   simdjson::ondemand::value& value,
+   std::string_view column_name,
+   column::SequenceColumnPartition<SymbolType>& sequence_column
+) {
+   // Determine sequence: try 'sequenceCompressed' (base64-encoded zstd-compressed) first,
+   // then fall back to plain 'sequence'.
+   InputSequence input_sequence;
+   auto compressed_field = value["sequenceCompressed"];
+   if (!compressed_field.error()) {
+      std::string_view compressed_base64;
+      auto error = compressed_field.get(compressed_base64);
+      RAISE_STRING_ERROR_WITH_CONTEXT(
+         error, value, "error getting field 'sequenceCompressed' in object: {}"
+      );
+      auto decoded = decodeBase64(compressed_base64);
+      if (!decoded.has_value()) {
+         return std::unexpected{fmt::format(
+            "invalid base64 in 'sequenceCompressed' for column '{}': {}. base64 encoded data "
+            "length: {}",
+            column_name,
+            decoded.error(),
+            compressed_base64.size()
+         )};
+      }
+      try {
+         std::string buffer;
+         sequence_column.compressed_input_decompressor.decompress(*decoded, buffer);
+         input_sequence.sequence = std::move(buffer);
+      } catch (const std::runtime_error& ex) {
+         return std::unexpected{
+            fmt::format("failed to decompress 'sequenceCompressed': {}", ex.what())
+         };
+      }
+   } else {
+      std::string_view sequence_view;
+      auto error = value["sequence"].get(sequence_view);
+      RAISE_STRING_ERROR_WITH_CONTEXT(error, value, "error getting field 'sequence' in object: {}");
+      input_sequence.sequence = sequence_view;
+   }
+   return input_sequence;
+}
+
 template <typename SymbolType>
 std::expected<void, std::string> insertToSequenceColumn(
    ColumnPartitionGroup& columns,
@@ -157,9 +214,11 @@ std::expected<void, std::string> insertToSequenceColumn(
       sequence_column.appendNull();
       return {};
    }
-   std::string_view sequence;
-   error = value["sequence"].get(sequence);
-   RAISE_STRING_ERROR_WITH_CONTEXT(error, value, "error getting field 'sequence' in object: {}");
+   auto input_sequence = getSequenceFromJsonLine(value, column.name, sequence_column);
+   if (!input_sequence.has_value()) {
+      return std::unexpected{input_sequence.error()};
+   }
+   const std::string_view sequence = input_sequence.value().getView();
    uint32_t offset = 0;
    auto offset_in_file = value["offset"];
    if (!offset_in_file.error()) {
@@ -169,7 +228,7 @@ std::expected<void, std::string> insertToSequenceColumn(
    std::vector<std::string> insertions;
    error = value["insertions"].get(insertions);
    RAISE_STRING_ERROR_WITH_CONTEXT(error, value, "error getting field 'insertions' in object: {}");
-   sequence_column.append(std::move(sequence), offset, std::move(insertions));
+   sequence_column.append(sequence, offset, insertions);
    return {};
 }
 

--- a/src/silo/storage/column_group.test.cpp
+++ b/src/silo/storage/column_group.test.cpp
@@ -1,8 +1,14 @@
 #include "silo/storage/column_group.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 #include <simdjson.h>
+#include <simdutf.h>
 
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/schema/database_schema.h"
@@ -12,6 +18,8 @@
 #include "silo/storage/column/int_column.h"
 #include "silo/storage/column/sequence_column.h"
 #include "silo/storage/column/string_column.h"
+#include "silo/zstd/zstd_compressor.h"
+#include "silo/zstd/zstd_dictionary.h"
 
 using silo::Nucleotide;
 using silo::schema::ColumnIdentifier;
@@ -53,6 +61,40 @@ std::expected<void, std::string> setupColumnAndInsertJson(
    return partition_group.addJsonValueToColumn(
       ColumnIdentifier{column_name, ColumnType::TYPE}, val
    );
+}
+
+std::expected<void, std::string> setupNucleotideColumnAndInsertJson(
+   const std::string& column_name,
+   const std::vector<Nucleotide::Symbol>& reference,
+   const std::string& json_string
+) {
+   auto meta = std::make_unique<SequenceColumnMetadata<Nucleotide>>(
+      column_name, std::vector<Nucleotide::Symbol>{reference}
+   );
+   ColumnPartitionGroup partition_group;
+   partition_group.getColumns<SequenceColumnPartition<Nucleotide>>().emplace(
+      column_name, SequenceColumnPartition<Nucleotide>{meta.get()}
+   );
+
+   simdjson::ondemand::parser parser;
+   const simdjson::padded_string json(json_string);
+   auto doc = parser.iterate(json).value_unsafe();
+   simdjson::ondemand::value val = doc[column_name].value_unsafe();
+
+   return partition_group.addJsonValueToColumn(
+      ColumnIdentifier{.name = column_name, .type = SequenceColumnPartition<Nucleotide>::TYPE}, val
+   );
+}
+
+std::string compressAndBase64Encode(std::string_view sequence, const std::string& reference) {
+   auto cdict = std::make_shared<silo::ZstdCDictionary>(reference, 3);
+   silo::ZstdCompressor compressor(cdict);
+   const auto compressed = compressor.compress(sequence.data(), sequence.size());
+
+   const size_t base64_len = simdutf::base64_length_from_binary(compressed.size());
+   std::string encoded(base64_len, '\0');
+   simdutf::binary_to_base64(compressed.data(), compressed.size(), encoded.data());
+   return encoded;
 }
 
 }  // namespace
@@ -148,4 +190,100 @@ TEST(ColumnPartitionGroup, givenObjectMissingInsertionsField_returnsColumnInsert
          "error inserting into column 'nuc_col': error getting field 'insertions' in object:"
       )
    );
+}
+
+TEST(ColumnPartitionGroup, givenValidSequenceCompressed_succeeds) {
+   const std::vector<Nucleotide::Symbol> reference = {
+      Nucleotide::Symbol::A, Nucleotide::Symbol::C, Nucleotide::Symbol::G, Nucleotide::Symbol::T
+   };
+   const std::string reference_str = "ACGT";
+   const std::string encoded = compressAndBase64Encode("ACGT", reference_str);
+
+   const auto result = setupNucleotideColumnAndInsertJson(
+      "nuc_col",
+      reference,
+      fmt::format(R"({{"nuc_col": {{"sequenceCompressed": "{}", "insertions": []}}}})", encoded)
+   );
+
+   ASSERT_TRUE(result.has_value());
+}
+
+TEST(ColumnPartitionGroup, givenSequenceCompressedWithMutation_succeeds) {
+   const std::vector<Nucleotide::Symbol> reference = {
+      Nucleotide::Symbol::A, Nucleotide::Symbol::C, Nucleotide::Symbol::G, Nucleotide::Symbol::T
+   };
+   const std::string reference_str = "ACGT";
+   // Sequence differs from reference at position 1 (C → T)
+   const std::string encoded = compressAndBase64Encode("ATGT", reference_str);
+
+   const auto result = setupNucleotideColumnAndInsertJson(
+      "nuc_col",
+      reference,
+      fmt::format(R"({{"nuc_col": {{"sequenceCompressed": "{}", "insertions": []}}}})", encoded)
+   );
+
+   ASSERT_TRUE(result.has_value());
+}
+
+TEST(ColumnPartitionGroup, givenSequenceCompressedMultipleRows_succeeds) {
+   std::vector<Nucleotide::Symbol> reference = {
+      Nucleotide::Symbol::A, Nucleotide::Symbol::C, Nucleotide::Symbol::G, Nucleotide::Symbol::T
+   };
+   const std::string reference_str = "ACGT";
+
+   auto meta =
+      std::make_unique<SequenceColumnMetadata<Nucleotide>>("nuc_col", std::move(reference));
+   ColumnPartitionGroup partition_group;
+   partition_group.getColumns<SequenceColumnPartition<Nucleotide>>().emplace(
+      "nuc_col", SequenceColumnPartition<Nucleotide>{meta.get()}
+   );
+
+   for (const std::string_view sequence : {"ACGT", "ATGT", "ACGT"}) {
+      const std::string encoded = compressAndBase64Encode(sequence, reference_str);
+      const std::string json =
+         fmt::format(R"({{"nuc_col": {{"sequenceCompressed": "{}", "insertions": []}}}})", encoded);
+
+      simdjson::ondemand::parser parser;
+      const simdjson::padded_string padded(json);
+      auto doc = parser.iterate(padded).value_unsafe();
+      simdjson::ondemand::value val = doc["nuc_col"].value_unsafe();
+
+      const auto result = partition_group.addJsonValueToColumn(
+         ColumnIdentifier{.name = "nuc_col", .type = SequenceColumnPartition<Nucleotide>::TYPE}, val
+      );
+      ASSERT_TRUE(result.has_value());
+   }
+}
+
+TEST(ColumnPartitionGroup, givenSequenceCompressedWithInvalidBase64_returnsError) {
+   const std::vector<Nucleotide::Symbol> reference = {Nucleotide::Symbol::A};
+
+   const auto result = setupNucleotideColumnAndInsertJson(
+      "nuc_col",
+      reference,
+      R"({"nuc_col": {"sequenceCompressed": "not!valid@base64#", "insertions": []}})"
+   );
+
+   ASSERT_FALSE(result.has_value());
+   EXPECT_THAT(result.error(), testing::HasSubstr("invalid base64"));
+}
+
+TEST(ColumnPartitionGroup, givenSequenceCompressedWithInvalidZstdData_returnsError) {
+   const std::vector<Nucleotide::Symbol> reference = {
+      Nucleotide::Symbol::A, Nucleotide::Symbol::C, Nucleotide::Symbol::G, Nucleotide::Symbol::T
+   };
+   // Valid base64 but the decoded bytes are not valid zstd-compressed data
+   const std::string random_bytes = "\x01\x02\x03\x04\x05\x06\x07\x08";
+   const size_t base64_len = simdutf::base64_length_from_binary(random_bytes.size());
+   std::string encoded(base64_len, '\0');
+   simdutf::binary_to_base64(random_bytes.data(), random_bytes.size(), encoded.data());
+
+   const auto result = setupNucleotideColumnAndInsertJson(
+      "nuc_col",
+      reference,
+      fmt::format(R"({{"nuc_col": {{"sequenceCompressed": "{}", "insertions": []}}}})", encoded)
+   );
+
+   ASSERT_FALSE(result.has_value());
+   EXPECT_THAT(result.error(), testing::HasSubstr("failed to decompress"));
 }

--- a/src/silo/zstd/zstd_context.cpp
+++ b/src/silo/zstd/zstd_context.cpp
@@ -26,7 +26,7 @@ ZstdDContext::ZstdDContext() {
 }
 
 ZstdDContext::ZstdDContext(silo::ZstdDContext&& other) noexcept {
-   std::swap(value, other.value);
+   value = std::exchange(other.value, nullptr);
 }
 
 ZstdDContext& ZstdDContext::operator=(silo::ZstdDContext&& other) noexcept {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1186

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

Sometimes, users of SILO already have the sequences in zstd compressed format. Therefore, it can help processing times to avoid the decompression in the client software. This will also reduce input file-sizes by a lot in those cases

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
