### PR TITLE
fix(silo): let `N` (`X` for amino acids) also code for `-`

### DIFF
--- a/documentation/maybe_documentation.md
+++ b/documentation/maybe_documentation.md
@@ -14,3 +14,127 @@ for all `NucleotideEquals` or `AminoAcidEquals` expressions
 contained in this filters subtree, the expression would
 evaluate to true _for all_ possible non-ambiguous sequence
 symbols at the sequence position.
+
+## Ambiguity Symbol Graph
+
+Ambiguous symbols are IUPAC codes that represent multiple possible concrete symbols.
+Two maps define the ambiguity system:
+
+- **`CODES_FOR[S]`**: The set of concrete symbols that `S` codes for (the primary definition).
+- **`AMBIGUITY_SYMBOLS[S]`**: The set of all symbols `Y` such that `CODES_FOR[S] ⊆ CODES_FOR[Y]`. In other words, all symbols that are at least as general as `S`. This is derived from `CODES_FOR`.
+
+### Nucleotide CODES_FOR Graph
+
+```
+Symbol -> Codes for
+───────────────────────────────
+GAP    -> {GAP}
+A      -> {A}
+C      -> {C}
+G      -> {G}
+T      -> {T}
+R      -> {A, G}           (puRine)
+Y      -> {C, T}           (pYrimidine)
+S      -> {G, C}           (Strong)
+W      -> {A, T}           (Weak)
+K      -> {G, T}           (Keto)
+M      -> {A, C}           (aMino)
+B      -> {C, G, T}        (not A)
+D      -> {A, G, T}        (not C)
+H      -> {A, C, T}        (not G)
+V      -> {A, C, G}        (not T)
+N      -> {all symbols}    (aNy)
+```
+
+### Nucleotide AMBIGUITY_SYMBOLS (derived)
+
+```
+Symbol -> Matched by
+───────────────────────────────
+GAP    -> {GAP, N}
+A      -> {A, R, M, W, D, H, V, N}
+C      -> {C, Y, S, M, B, H, V, N}
+G      -> {G, R, K, S, B, D, V, N}
+T      -> {T, Y, K, W, B, D, H, N}
+R      -> {R, D, V, N}
+Y      -> {Y, B, H, N}
+S      -> {S, B, V, N}
+W      -> {W, D, H, N}
+K      -> {K, B, D, N}
+M      -> {M, H, V, N}
+B      -> {B, N}
+D      -> {D, N}
+H      -> {H, N}
+V      -> {V, N}
+N      -> {N}
+```
+
+### Amino Acid CODES_FOR Graph
+
+```
+Symbol -> Codes for
+───────────────────────────────
+GAP    -> {GAP}
+A      -> {A}              (Alanine)
+C      -> {C}              (Cysteine)
+D      -> {D}              (Aspartic Acid)
+E      -> {E}              (Glutamic Acid)
+F      -> {F}              (Phenylalanine)
+G      -> {G}              (Glycine)
+H      -> {H}              (Histidine)
+I      -> {I}              (Isoleucine)
+K      -> {K}              (Lysine)
+L      -> {L}              (Leucine)
+M      -> {M}              (Methionine)
+N      -> {N}              (Asparagine)
+O      -> {O}              (Pyrrolysine)
+P      -> {P}              (Proline)
+Q      -> {Q}              (Glutamine)
+R      -> {R}              (Arginine)
+S      -> {S}              (Serine)
+T      -> {T}              (Threonine)
+U      -> {U}              (Selenocysteine)
+V      -> {V}              (Valine)
+W      -> {W}              (Tryptophan)
+Y      -> {Y}              (Tyrosine)
+B      -> {D, N}           (Aspartic acid or Asparagine)
+J      -> {L, I}           (Leucine or Isoleucine)
+Z      -> {Q, E}           (Glutamine or Glutamic acid)
+STOP   -> {STOP}
+X      -> {all symbols}    (any amino acid)
+```
+
+### Amino Acid AMBIGUITY_SYMBOLS (derived)
+
+```
+Symbol -> Matched by
+───────────────────────────────
+GAP    -> {GAP, X}
+A      -> {A, X}
+C      -> {C, X}
+D      -> {D, B, X}
+E      -> {E, Z, X}
+F      -> {F, X}
+G      -> {G, X}
+H      -> {H, X}
+I      -> {I, J, X}
+K      -> {K, X}
+L      -> {L, J, X}
+M      -> {M, X}
+N      -> {N, B, X}
+O      -> {O, X}
+P      -> {P, X}
+Q      -> {Q, Z, X}
+R      -> {R, X}
+S      -> {S, X}
+T      -> {T, X}
+U      -> {U, X}
+V      -> {V, X}
+W      -> {W, X}
+Y      -> {Y, X}
+B      -> {B, X}
+J      -> {J, X}
+Z      -> {Z, X}
+STOP   -> {STOP, X}
+X      -> {X}
+```

--- a/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeGAP.json
+++ b/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeGAP.json
@@ -16,7 +16,7 @@
   },
   "expectedQueryResult": [
     {
-      "count": 1
+      "count": 6
     }
   ]
 }

--- a/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeR.json
+++ b/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeR.json
@@ -16,7 +16,7 @@
   },
   "expectedQueryResult": [
     {
-      "count": 2
+      "count": 7
     }
   ]
 }

--- a/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeY.json
+++ b/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeY.json
@@ -16,7 +16,7 @@
   },
   "expectedQueryResult": [
     {
-      "count": 1
+      "count": 6
     }
   ]
 }

--- a/src/silo/common/aa_symbols.cpp
+++ b/src/silo/common/aa_symbols.cpp
@@ -1,37 +1,74 @@
 #include "silo/common/aa_symbols.h"
 
+#include <algorithm>
+
 #include "silo/common/symbol_map.h"
 
 namespace silo {
 
-const silo::SymbolMap<AminoAcid, std::vector<AminoAcid::Symbol>> AminoAcid::AMBIGUITY_SYMBOLS{{{
-   {Symbol::GAP, Symbol::X},
-   {Symbol::A, Symbol::X},
-   {Symbol::C, Symbol::X},
-   {Symbol::D, Symbol::B, Symbol::X},
-   {Symbol::E, Symbol::Z, Symbol::X},
-   {Symbol::F, Symbol::X},
-   {Symbol::G, Symbol::X},
-   {Symbol::H, Symbol::X},
-   {Symbol::I, Symbol::J, Symbol::X},
-   {Symbol::K, Symbol::J, Symbol::X},
-   {Symbol::L, Symbol::X},
-   {Symbol::M, Symbol::X},
-   {Symbol::N, Symbol::B, Symbol::X},
-   {Symbol::O, Symbol::X},
-   {Symbol::P, Symbol::X},
-   {Symbol::Q, Symbol::Z, Symbol::X},
-   {Symbol::R, Symbol::X},
-   {Symbol::S, Symbol::X},
-   {Symbol::T, Symbol::X},
-   {Symbol::U, Symbol::X},
-   {Symbol::V, Symbol::X},
-   {Symbol::W, Symbol::X},
-   {Symbol::Y, Symbol::X},
-   {Symbol::B, Symbol::X},
-   {Symbol::J, Symbol::X},
-   {Symbol::Z, Symbol::X},
-   {Symbol::STOP, Symbol::X},
-   {Symbol::X},
+// Primary definition: what each symbol codes for.
+// Concrete amino acids code for themselves.
+// Ambiguity symbols code for the set of amino acids they represent per IUPAC.
+// X codes for all symbols (including GAP, STOP, and other ambiguity codes).
+const silo::SymbolMap<AminoAcid, std::vector<AminoAcid::Symbol>> AminoAcid::CODES_FOR{{{
+   {Symbol::GAP},           // GAP
+   {Symbol::A},             // Alanine
+   {Symbol::C},             // Cysteine
+   {Symbol::D},             // Aspartic Acid
+   {Symbol::E},             // Glutamic Acid
+   {Symbol::F},             // Phenylalanine
+   {Symbol::G},             // Glycine
+   {Symbol::H},             // Histidine
+   {Symbol::I},             // Isoleucine
+   {Symbol::K},             // Lysine
+   {Symbol::L},             // Leucine
+   {Symbol::M},             // Methionine
+   {Symbol::N},             // Asparagine
+   {Symbol::O},             // Pyrrolysine
+   {Symbol::P},             // Proline
+   {Symbol::Q},             // Glutamine
+   {Symbol::R},             // Arginine
+   {Symbol::S},             // Serine
+   {Symbol::T},             // Threonine
+   {Symbol::U},             // Selenocysteine
+   {Symbol::V},             // Valine
+   {Symbol::W},             // Tryptophan
+   {Symbol::Y},             // Tyrosine
+   {Symbol::D, Symbol::N},  // B - Aspartic acid or Asparagine
+   {Symbol::L, Symbol::I},  // J - Leucine or Isoleucine
+   {Symbol::Q, Symbol::E},  // Z - Glutamine or Glutamic acid
+   {Symbol::STOP},          // STOP
+   // X codes for every symbol
+   {Symbol::GAP, Symbol::A, Symbol::C, Symbol::D, Symbol::E, Symbol::F,    Symbol::G,
+    Symbol::H,   Symbol::I, Symbol::K, Symbol::L, Symbol::M, Symbol::N,    Symbol::O,
+    Symbol::P,   Symbol::Q, Symbol::R, Symbol::S, Symbol::T, Symbol::U,    Symbol::V,
+    Symbol::W,   Symbol::Y, Symbol::B, Symbol::J, Symbol::Z, Symbol::STOP, Symbol::X},
 }}};
+
+namespace {
+silo::SymbolMap<AminoAcid, std::vector<AminoAcid::Symbol>> deriveAmbiguitySymbols() {
+   silo::SymbolMap<AminoAcid, std::vector<AminoAcid::Symbol>> result;
+   for (auto symbol : AminoAcid::SYMBOLS) {
+      const auto& codes_for_symbol = AminoAcid::CODES_FOR.at(symbol);
+      std::vector<AminoAcid::Symbol> ambiguous;
+      for (auto candidate : AminoAcid::SYMBOLS) {
+         const auto& codes_for_candidate = AminoAcid::CODES_FOR.at(candidate);
+         // candidate is ambiguous for symbol if CODES_FOR[symbol] ⊆ CODES_FOR[candidate]
+         const bool is_superset = std::ranges::all_of(codes_for_symbol, [&](auto coded_symbol) {
+            return std::ranges::find(codes_for_candidate, coded_symbol) !=
+                   codes_for_candidate.end();
+         });
+         if (is_superset) {
+            ambiguous.push_back(candidate);
+         }
+      }
+      result[symbol] = std::move(ambiguous);
+   }
+   return result;
+}
+}  // namespace
+
+const silo::SymbolMap<AminoAcid, std::vector<AminoAcid::Symbol>> AminoAcid::AMBIGUITY_SYMBOLS =
+   deriveAmbiguitySymbols();
+
 }  // namespace silo

--- a/src/silo/common/aa_symbols.h
+++ b/src/silo/common/aa_symbols.h
@@ -104,6 +104,14 @@ class AminoAcid {
 
    static_assert(INVALID_MUTATION_SYMBOLS.size() + VALID_MUTATION_SYMBOLS.size() == SYMBOLS.size());
 
+   /// Maps each symbol to the set of symbols it can represent or match.
+   /// For example, B represents at least {D, N}, and X typically represents all symbols
+   /// (including ambiguity symbols and the symbol itself, as applicable).
+   static const silo::SymbolMap<AminoAcid, std::vector<AminoAcid::Symbol>> CODES_FOR;
+
+   /// Maps each symbol to all symbols whose CODES_FOR set is a superset.
+   /// I.e. AMBIGUITY_SYMBOLS[S] = {Y : CODES_FOR[S] ⊆ CODES_FOR[Y]}.
+   /// Derived from CODES_FOR.
    static const silo::SymbolMap<AminoAcid, std::vector<AminoAcid::Symbol>> AMBIGUITY_SYMBOLS;
 
    static constexpr Symbol SYMBOL_MISSING = Symbol::X;

--- a/src/silo/common/aa_symbols.test.cpp
+++ b/src/silo/common/aa_symbols.test.cpp
@@ -5,26 +5,26 @@
 #include <optional>
 
 #include <gtest/gtest.h>
-#include <spdlog/spdlog.h>
 
 using silo::AminoAcid;
+using Symbol = AminoAcid::Symbol;
 
 TEST(AminoAcidSymbol, enumShouldHaveSameLengthAsArrayOfSymbols) {
    EXPECT_EQ(AminoAcid::COUNT, AminoAcid::SYMBOLS.size());
 }
 
 TEST(AminoAcidSymbol, conversionFromCharacter) {
-   EXPECT_EQ(silo::AminoAcid::charToSymbol('-'), silo::AminoAcid::Symbol::GAP);
-   EXPECT_EQ(silo::AminoAcid::charToSymbol('.'), std::nullopt);
-   EXPECT_EQ(silo::AminoAcid::charToSymbol('A'), silo::AminoAcid::Symbol::A);
-   EXPECT_EQ(silo::AminoAcid::charToSymbol('N'), silo::AminoAcid::Symbol::N);
-   EXPECT_EQ(silo::AminoAcid::charToSymbol('J'), silo::AminoAcid::Symbol::J);
-   EXPECT_EQ(silo::AminoAcid::charToSymbol(')'), std::nullopt);
+   EXPECT_EQ(AminoAcid::charToSymbol('-'), Symbol::GAP);
+   EXPECT_EQ(AminoAcid::charToSymbol('.'), std::nullopt);
+   EXPECT_EQ(AminoAcid::charToSymbol('A'), Symbol::A);
+   EXPECT_EQ(AminoAcid::charToSymbol('N'), Symbol::N);
+   EXPECT_EQ(AminoAcid::charToSymbol('J'), Symbol::J);
+   EXPECT_EQ(AminoAcid::charToSymbol(')'), std::nullopt);
 }
 
 TEST(AminoAcidSymbol, conversionFromCharacterRoundTrip) {
-   for (AminoAcid::Symbol symbol : AminoAcid::SYMBOLS) {
-      char symbol_character = AminoAcid::symbolToChar(symbol);
+   for (const Symbol symbol : AminoAcid::SYMBOLS) {
+      const char symbol_character = AminoAcid::symbolToChar(symbol);
       auto maybe_round_tripped_symbol = AminoAcid::charToSymbol(symbol_character);
       ASSERT_TRUE(maybe_round_tripped_symbol.has_value());
       auto round_tripped_symbol = maybe_round_tripped_symbol.value();
@@ -32,26 +32,174 @@ TEST(AminoAcidSymbol, conversionFromCharacterRoundTrip) {
    }
 }
 
-TEST(AminoAcidSymbol, ambiguousSymbols) {
-   for (const auto& symbol : AminoAcid::SYMBOLS) {
-      auto ambiguous_symbols_for_symbol = AminoAcid::AMBIGUITY_SYMBOLS.at(symbol);
-      bool contains_self = std::ranges::find(ambiguous_symbols_for_symbol, symbol) !=
-                           ambiguous_symbols_for_symbol.end();
-      bool contains_x = std::ranges::find(ambiguous_symbols_for_symbol, AminoAcid::Symbol::X) !=
-                        ambiguous_symbols_for_symbol.end();
-      EXPECT_TRUE(contains_self);
-      EXPECT_TRUE(contains_x);
+TEST(AminoAcidSymbol, symbolsInOrder) {
+   for (auto symbol : AminoAcid::SYMBOLS) {
+      auto symbol_at_position = AminoAcid::SYMBOLS.at(static_cast<uint8_t>(symbol));
+      EXPECT_EQ(symbol_at_position, symbol);
    }
 }
 
-TEST(AminoAcidSymbol, symbolsInOrder) {
-   for (const auto& symbol : AminoAcid::SYMBOLS) {
-      auto symbol_at_symbol_position = AminoAcid::SYMBOLS.at(static_cast<uint8_t>(symbol));
-      SPDLOG_INFO(
-         "{} {}",
-         AminoAcid::symbolToChar(symbol_at_symbol_position),
-         AminoAcid::symbolToChar(symbol)
-      );
-      EXPECT_EQ(symbol_at_symbol_position, symbol);
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+
+// --- CODES_FOR tests ---
+
+TEST(AminoAcidSymbol, codesForConcreteSymbolsCodeForThemselves) {
+   for (auto symbol : AminoAcid::VALID_MUTATION_SYMBOLS) {
+      const auto& codes_for = AminoAcid::CODES_FOR.at(symbol);
+      EXPECT_EQ(codes_for.size(), 1) << "Concrete symbol " << AminoAcid::symbolToChar(symbol)
+                                     << " should code for exactly itself";
+      EXPECT_EQ(codes_for.at(0), symbol);
    }
 }
+
+TEST(AminoAcidSymbol, codesForSpecificAmbiguityCodes) {
+   auto contains = [](const std::vector<Symbol>& vec, Symbol symbol) {
+      return std::ranges::find(vec, symbol) != vec.end();
+   };
+
+   // B = D (Aspartic acid) or N (Asparagine)
+   {
+      const auto& codes = AminoAcid::CODES_FOR.at(Symbol::B);
+      EXPECT_EQ(codes.size(), 2);
+      EXPECT_TRUE(contains(codes, Symbol::D));
+      EXPECT_TRUE(contains(codes, Symbol::N));
+   }
+   // J = L (Leucine) or I (Isoleucine)
+   {
+      const auto& codes = AminoAcid::CODES_FOR.at(Symbol::J);
+      EXPECT_EQ(codes.size(), 2);
+      EXPECT_TRUE(contains(codes, Symbol::L));
+      EXPECT_TRUE(contains(codes, Symbol::I));
+   }
+   // Z = Q (Glutamine) or E (Glutamic acid)
+   {
+      const auto& codes = AminoAcid::CODES_FOR.at(Symbol::Z);
+      EXPECT_EQ(codes.size(), 2);
+      EXPECT_TRUE(contains(codes, Symbol::Q));
+      EXPECT_TRUE(contains(codes, Symbol::E));
+   }
+   // X = all symbols
+   {
+      const auto& codes = AminoAcid::CODES_FOR.at(Symbol::X);
+      EXPECT_EQ(codes.size(), AminoAcid::COUNT);
+   }
+}
+
+// --- AMBIGUITY_SYMBOLS tests ---
+
+TEST(AminoAcidSymbol, ambiguousSymbolsContainSelf) {
+   for (auto symbol : AminoAcid::SYMBOLS) {
+      const auto& ambiguous = AminoAcid::AMBIGUITY_SYMBOLS.at(symbol);
+      const bool contains_self = std::ranges::find(ambiguous, symbol) != ambiguous.end();
+      EXPECT_TRUE(contains_self) << "Symbol " << AminoAcid::symbolToChar(symbol)
+                                 << " should be in its own AMBIGUITY_SYMBOLS";
+   }
+}
+
+TEST(AminoAcidSymbol, ambiguousSymbolsContainX) {
+   for (auto symbol : AminoAcid::SYMBOLS) {
+      const auto& ambiguous = AminoAcid::AMBIGUITY_SYMBOLS.at(symbol);
+      const bool contains_x = std::ranges::find(ambiguous, Symbol::X) != ambiguous.end();
+      EXPECT_TRUE(contains_x) << "Symbol " << AminoAcid::symbolToChar(symbol)
+                              << " should have X in its AMBIGUITY_SYMBOLS";
+   }
+}
+
+TEST(AminoAcidSymbol, ambiguitySymbolsAreSupersetRelationOfCodesFor) {
+   // Verify AMBIGUITY_SYMBOLS[S] = {Y : CODES_FOR[S] ⊆ CODES_FOR[Y]}
+   for (auto symbol : AminoAcid::SYMBOLS) {
+      const auto& codes_for_symbol = AminoAcid::CODES_FOR.at(symbol);
+      const auto& ambiguous = AminoAcid::AMBIGUITY_SYMBOLS.at(symbol);
+
+      for (auto candidate : AminoAcid::SYMBOLS) {
+         const auto& codes_for_candidate = AminoAcid::CODES_FOR.at(candidate);
+
+         const bool is_superset = std::ranges::all_of(codes_for_symbol, [&](auto coded_symbol) {
+            return std::ranges::find(codes_for_candidate, coded_symbol) !=
+                   codes_for_candidate.end();
+         });
+         const bool in_ambiguous = std::ranges::find(ambiguous, candidate) != ambiguous.end();
+
+         EXPECT_EQ(is_superset, in_ambiguous)
+            << "Symbol " << AminoAcid::symbolToChar(symbol) << " vs candidate "
+            << AminoAcid::symbolToChar(candidate) << ": superset=" << is_superset
+            << " in_ambiguous=" << in_ambiguous;
+      }
+   }
+}
+
+TEST(AminoAcidSymbol, ambiguitySymbolsSpecificExamples) {
+   auto contains = [](const std::vector<Symbol>& vec, Symbol symbol) {
+      return std::ranges::find(vec, symbol) != vec.end();
+   };
+
+   // L (Leucine) should be matched by L, J (Leucine or Isoleucine), X
+   {
+      const auto& amb = AminoAcid::AMBIGUITY_SYMBOLS.at(Symbol::L);
+      EXPECT_TRUE(contains(amb, Symbol::L));
+      EXPECT_TRUE(contains(amb, Symbol::J));
+      EXPECT_TRUE(contains(amb, Symbol::X));
+      EXPECT_EQ(amb.size(), 3);
+   }
+
+   // K (Lysine) should NOT be matched by J (J = Leucine or Isoleucine)
+   {
+      const auto& amb = AminoAcid::AMBIGUITY_SYMBOLS.at(Symbol::K);
+      EXPECT_TRUE(contains(amb, Symbol::K));
+      EXPECT_TRUE(contains(amb, Symbol::X));
+      EXPECT_FALSE(contains(amb, Symbol::J));
+      EXPECT_EQ(amb.size(), 2);
+   }
+
+   // D (Aspartic Acid) should be matched by D, B (D or N), X
+   {
+      const auto& amb = AminoAcid::AMBIGUITY_SYMBOLS.at(Symbol::D);
+      EXPECT_TRUE(contains(amb, Symbol::D));
+      EXPECT_TRUE(contains(amb, Symbol::B));
+      EXPECT_TRUE(contains(amb, Symbol::X));
+      EXPECT_EQ(amb.size(), 3);
+   }
+
+   // N (Asparagine) should be matched by N, B (D or N), X
+   {
+      const auto& amb = AminoAcid::AMBIGUITY_SYMBOLS.at(Symbol::N);
+      EXPECT_TRUE(contains(amb, Symbol::N));
+      EXPECT_TRUE(contains(amb, Symbol::B));
+      EXPECT_TRUE(contains(amb, Symbol::X));
+      EXPECT_EQ(amb.size(), 3);
+   }
+
+   // E (Glutamic Acid) should be matched by E, Z (Q or E), X
+   {
+      const auto& amb = AminoAcid::AMBIGUITY_SYMBOLS.at(Symbol::E);
+      EXPECT_TRUE(contains(amb, Symbol::E));
+      EXPECT_TRUE(contains(amb, Symbol::Z));
+      EXPECT_TRUE(contains(amb, Symbol::X));
+      EXPECT_EQ(amb.size(), 3);
+   }
+
+   // GAP should be matched by GAP and X
+   {
+      const auto& amb = AminoAcid::AMBIGUITY_SYMBOLS.at(Symbol::GAP);
+      EXPECT_TRUE(contains(amb, Symbol::GAP));
+      EXPECT_TRUE(contains(amb, Symbol::X));
+      EXPECT_EQ(amb.size(), 2);
+   }
+
+   // X should only be matched by X itself
+   {
+      const auto& amb = AminoAcid::AMBIGUITY_SYMBOLS.at(Symbol::X);
+      EXPECT_EQ(amb.size(), 1);
+      EXPECT_TRUE(contains(amb, Symbol::X));
+   }
+
+   // B should be matched by B and X only
+   {
+      const auto& amb = AminoAcid::AMBIGUITY_SYMBOLS.at(Symbol::B);
+      EXPECT_TRUE(contains(amb, Symbol::B));
+      EXPECT_TRUE(contains(amb, Symbol::X));
+      EXPECT_EQ(amb.size(), 2);
+   }
+}
+
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/src/silo/common/nucleotide_symbols.cpp
+++ b/src/silo/common/nucleotide_symbols.cpp
@@ -1,23 +1,72 @@
 #include "silo/common/nucleotide_symbols.h"
 
+#include <algorithm>
+
 namespace silo {
 
-const silo::SymbolMap<Nucleotide, std::vector<Nucleotide::Symbol>> Nucleotide::AMBIGUITY_SYMBOLS{{{
-   {Symbol::GAP},
-   {Symbol::A, Symbol::R, Symbol::M, Symbol::W, Symbol::D, Symbol::H, Symbol::V, Symbol::N},
-   {Symbol::C, Symbol::Y, Symbol::M, Symbol::S, Symbol::B, Symbol::H, Symbol::V, Symbol::N},
-   {Symbol::G, Symbol::R, Symbol::K, Symbol::S, Symbol::B, Symbol::D, Symbol::V, Symbol::N},
-   {Symbol::T, Symbol::Y, Symbol::K, Symbol::W, Symbol::B, Symbol::D, Symbol::H, Symbol::N},
-   {Symbol::R},
-   {Symbol::Y},
-   {Symbol::S},
-   {Symbol::W},
-   {Symbol::K},
-   {Symbol::M},
-   {Symbol::B},
-   {Symbol::D},
-   {Symbol::H},
-   {Symbol::V},
-   {Symbol::N},
+// Primary definition: what each symbol codes for.
+// Concrete symbols code for themselves. Ambiguity symbols code for
+// the set of concrete symbols they represent per IUPAC conventions.
+// N codes for all symbols (including GAP and other ambiguity codes).
+const silo::SymbolMap<Nucleotide, std::vector<Nucleotide::Symbol>> Nucleotide::CODES_FOR{{{
+   {Symbol::GAP},                      // GAP
+   {Symbol::A},                        // A - Adenine
+   {Symbol::C},                        // C - Cytosine
+   {Symbol::G},                        // G - Guanine
+   {Symbol::T},                        // T - Thymine
+   {Symbol::A, Symbol::G},             // R - puRine
+   {Symbol::C, Symbol::T},             // Y - pYrimidine
+   {Symbol::G, Symbol::C},             // S - Strong
+   {Symbol::A, Symbol::T},             // W - Weak
+   {Symbol::G, Symbol::T},             // K - Keto
+   {Symbol::A, Symbol::C},             // M - aMino
+   {Symbol::C, Symbol::G, Symbol::T},  // B - not A
+   {Symbol::A, Symbol::G, Symbol::T},  // D - not C
+   {Symbol::A, Symbol::C, Symbol::T},  // H - not G
+   {Symbol::A, Symbol::C, Symbol::G},  // V - not T
+   // N codes for every symbol
+   {Symbol::GAP,
+    Symbol::A,
+    Symbol::C,
+    Symbol::G,
+    Symbol::T,
+    Symbol::R,
+    Symbol::Y,
+    Symbol::S,
+    Symbol::W,
+    Symbol::K,
+    Symbol::M,
+    Symbol::B,
+    Symbol::D,
+    Symbol::H,
+    Symbol::V,
+    Symbol::N},
 }}};
+
+namespace {
+silo::SymbolMap<Nucleotide, std::vector<Nucleotide::Symbol>> deriveAmbiguitySymbols() {
+   silo::SymbolMap<Nucleotide, std::vector<Nucleotide::Symbol>> result;
+   for (auto symbol : Nucleotide::SYMBOLS) {
+      const auto& codes_for_symbol = Nucleotide::CODES_FOR.at(symbol);
+      std::vector<Nucleotide::Symbol> ambiguous;
+      for (auto candidate : Nucleotide::SYMBOLS) {
+         const auto& codes_for_candidate = Nucleotide::CODES_FOR.at(candidate);
+         // candidate is ambiguous for symbol if CODES_FOR[symbol] ⊆ CODES_FOR[candidate]
+         const bool is_superset = std::ranges::all_of(codes_for_symbol, [&](auto coded_symbol) {
+            return std::ranges::find(codes_for_candidate, coded_symbol) !=
+                   codes_for_candidate.end();
+         });
+         if (is_superset) {
+            ambiguous.push_back(candidate);
+         }
+      }
+      result[symbol] = std::move(ambiguous);
+   }
+   return result;
+}
+}  // namespace
+
+const silo::SymbolMap<Nucleotide, std::vector<Nucleotide::Symbol>> Nucleotide::AMBIGUITY_SYMBOLS =
+   deriveAmbiguitySymbols();
+
 }  // namespace silo

--- a/src/silo/common/nucleotide_symbols.h
+++ b/src/silo/common/nucleotide_symbols.h
@@ -91,6 +91,15 @@ class Nucleotide {
 
    static_assert(INVALID_MUTATION_SYMBOLS.size() + VALID_MUTATION_SYMBOLS.size() == SYMBOLS.size());
 
+   /// Maps each symbol to the set of symbols it codes for.
+   /// The mapped set may include both concrete bases (GAP, A, C, G, T) and
+   /// ambiguity symbols (R, Y, ..., N), and can include the symbol itself.
+   /// For example, N codes for all nucleotide symbols.
+   static const silo::SymbolMap<Nucleotide, std::vector<Nucleotide::Symbol>> CODES_FOR;
+
+   /// Maps each symbol to all symbols whose CODES_FOR set is a superset.
+   /// I.e. AMBIGUITY_SYMBOLS[S] = {Y : CODES_FOR[S] ⊆ CODES_FOR[Y]}.
+   /// Derived from CODES_FOR.
    static const silo::SymbolMap<Nucleotide, std::vector<Nucleotide::Symbol>> AMBIGUITY_SYMBOLS;
 
    static constexpr Symbol SYMBOL_MISSING = Symbol::N;

--- a/src/silo/common/nucleotide_symbols.test.cpp
+++ b/src/silo/common/nucleotide_symbols.test.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 
 using silo::Nucleotide;
+using Symbol = Nucleotide::Symbol;
 
 TEST(NucleotideSymbol, enumShouldHaveSameLengthAsArrayOfSymbols) {
    EXPECT_EQ(Nucleotide::COUNT, Nucleotide::SYMBOLS.size());
@@ -12,15 +13,15 @@ TEST(NucleotideSymbol, enumShouldHaveSameLengthAsArrayOfSymbols) {
 
 TEST(NucleotideSymbol, conversionFromCharacter) {
    EXPECT_EQ(Nucleotide::charToSymbol('.'), std::nullopt);
-   EXPECT_EQ(Nucleotide::charToSymbol('-'), Nucleotide::Symbol::GAP);
-   EXPECT_EQ(Nucleotide::charToSymbol('A'), Nucleotide::Symbol::A);
-   EXPECT_EQ(Nucleotide::charToSymbol('N'), Nucleotide::Symbol::N);
+   EXPECT_EQ(Nucleotide::charToSymbol('-'), Symbol::GAP);
+   EXPECT_EQ(Nucleotide::charToSymbol('A'), Symbol::A);
+   EXPECT_EQ(Nucleotide::charToSymbol('N'), Symbol::N);
    EXPECT_EQ(Nucleotide::charToSymbol('X'), std::nullopt);
 }
 
 TEST(NucleotideSymbol, conversionFromCharacterRoundTrip) {
-   for (Nucleotide::Symbol symbol : Nucleotide::SYMBOLS) {
-      char symbol_character = Nucleotide::symbolToChar(symbol);
+   for (const Symbol symbol : Nucleotide::SYMBOLS) {
+      const char symbol_character = Nucleotide::symbolToChar(symbol);
       auto maybe_round_tripped_symbol = Nucleotide::charToSymbol(symbol_character);
       ASSERT_TRUE(maybe_round_tripped_symbol.has_value());
       auto round_tripped_symbol = maybe_round_tripped_symbol.value();
@@ -28,11 +29,212 @@ TEST(NucleotideSymbol, conversionFromCharacterRoundTrip) {
    }
 }
 
-TEST(NucleotideSymbol, ambiguousSymbols) {
-   for (const auto& symbol : Nucleotide::SYMBOLS) {
-      auto ambiguous_symbols_for_symbol = Nucleotide::AMBIGUITY_SYMBOLS.at(symbol);
-      bool contains_self = std::ranges::find(ambiguous_symbols_for_symbol, symbol) !=
-                           ambiguous_symbols_for_symbol.end();
-      EXPECT_TRUE(contains_self);
+TEST(NucleotideSymbol, symbolsInOrder) {
+   for (auto symbol : Nucleotide::SYMBOLS) {
+      auto symbol_at_position = Nucleotide::SYMBOLS.at(static_cast<uint8_t>(symbol));
+      EXPECT_EQ(symbol_at_position, symbol);
    }
 }
+
+// --- CODES_FOR tests ---
+
+TEST(NucleotideSymbol, codesForConcreteSymbolsCodeForThemselves) {
+   for (auto symbol : Nucleotide::VALID_MUTATION_SYMBOLS) {
+      const auto& codes_for = Nucleotide::CODES_FOR.at(symbol);
+      EXPECT_EQ(codes_for.size(), 1);
+      EXPECT_EQ(codes_for.at(0), symbol);
+   }
+}
+
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+
+TEST(NucleotideSymbol, codesForSpecificAmbiguityCodes) {
+   auto contains = [](const std::vector<Symbol>& vec, Symbol symbol) {
+      return std::ranges::find(vec, symbol) != vec.end();
+   };
+
+   // R = A or G
+   {
+      const auto& codes = Nucleotide::CODES_FOR.at(Symbol::R);
+      EXPECT_EQ(codes.size(), 2);
+      EXPECT_TRUE(contains(codes, Symbol::A));
+      EXPECT_TRUE(contains(codes, Symbol::G));
+   }
+   // Y = C or T
+   {
+      const auto& codes = Nucleotide::CODES_FOR.at(Symbol::Y);
+      EXPECT_EQ(codes.size(), 2);
+      EXPECT_TRUE(contains(codes, Symbol::C));
+      EXPECT_TRUE(contains(codes, Symbol::T));
+   }
+   // S = G or C
+   {
+      const auto& codes = Nucleotide::CODES_FOR.at(Symbol::S);
+      EXPECT_EQ(codes.size(), 2);
+      EXPECT_TRUE(contains(codes, Symbol::G));
+      EXPECT_TRUE(contains(codes, Symbol::C));
+   }
+   // W = A or T
+   {
+      const auto& codes = Nucleotide::CODES_FOR.at(Symbol::W);
+      EXPECT_EQ(codes.size(), 2);
+      EXPECT_TRUE(contains(codes, Symbol::A));
+      EXPECT_TRUE(contains(codes, Symbol::T));
+   }
+   // K = G or T
+   {
+      const auto& codes = Nucleotide::CODES_FOR.at(Symbol::K);
+      EXPECT_EQ(codes.size(), 2);
+      EXPECT_TRUE(contains(codes, Symbol::G));
+      EXPECT_TRUE(contains(codes, Symbol::T));
+   }
+   // M = A or C
+   {
+      const auto& codes = Nucleotide::CODES_FOR.at(Symbol::M);
+      EXPECT_EQ(codes.size(), 2);
+      EXPECT_TRUE(contains(codes, Symbol::A));
+      EXPECT_TRUE(contains(codes, Symbol::C));
+   }
+   // B = C, G, T (not A)
+   {
+      const auto& codes = Nucleotide::CODES_FOR.at(Symbol::B);
+      EXPECT_EQ(codes.size(), 3);
+      EXPECT_TRUE(contains(codes, Symbol::C));
+      EXPECT_TRUE(contains(codes, Symbol::G));
+      EXPECT_TRUE(contains(codes, Symbol::T));
+      EXPECT_FALSE(contains(codes, Symbol::A));
+   }
+   // D = A, G, T (not C)
+   {
+      const auto& codes = Nucleotide::CODES_FOR.at(Symbol::D);
+      EXPECT_EQ(codes.size(), 3);
+      EXPECT_TRUE(contains(codes, Symbol::A));
+      EXPECT_TRUE(contains(codes, Symbol::G));
+      EXPECT_TRUE(contains(codes, Symbol::T));
+      EXPECT_FALSE(contains(codes, Symbol::C));
+   }
+   // H = A, C, T (not G)
+   {
+      const auto& codes = Nucleotide::CODES_FOR.at(Symbol::H);
+      EXPECT_EQ(codes.size(), 3);
+      EXPECT_TRUE(contains(codes, Symbol::A));
+      EXPECT_TRUE(contains(codes, Symbol::C));
+      EXPECT_TRUE(contains(codes, Symbol::T));
+      EXPECT_FALSE(contains(codes, Symbol::G));
+   }
+   // V = A, C, G (not T)
+   {
+      const auto& codes = Nucleotide::CODES_FOR.at(Symbol::V);
+      EXPECT_EQ(codes.size(), 3);
+      EXPECT_TRUE(contains(codes, Symbol::A));
+      EXPECT_TRUE(contains(codes, Symbol::C));
+      EXPECT_TRUE(contains(codes, Symbol::G));
+      EXPECT_FALSE(contains(codes, Symbol::T));
+   }
+   // N = all symbols
+   {
+      const auto& codes = Nucleotide::CODES_FOR.at(Symbol::N);
+      EXPECT_EQ(codes.size(), Nucleotide::COUNT);
+   }
+}
+
+// --- AMBIGUITY_SYMBOLS tests ---
+
+TEST(NucleotideSymbol, ambiguousSymbolsContainSelf) {
+   for (auto symbol : Nucleotide::SYMBOLS) {
+      const auto& ambiguous = Nucleotide::AMBIGUITY_SYMBOLS.at(symbol);
+      const bool contains_self = std::ranges::find(ambiguous, symbol) != ambiguous.end();
+      EXPECT_TRUE(contains_self) << "Symbol " << Nucleotide::symbolToChar(symbol)
+                                 << " should be in its own AMBIGUITY_SYMBOLS";
+   }
+}
+
+TEST(NucleotideSymbol, ambiguousSymbolsContainN) {
+   for (auto symbol : Nucleotide::SYMBOLS) {
+      const auto& ambiguous = Nucleotide::AMBIGUITY_SYMBOLS.at(symbol);
+      const bool contains_n = std::ranges::find(ambiguous, Symbol::N) != ambiguous.end();
+      EXPECT_TRUE(contains_n) << "Symbol " << Nucleotide::symbolToChar(symbol)
+                              << " should have N in its AMBIGUITY_SYMBOLS";
+   }
+}
+
+TEST(NucleotideSymbol, ambiguitySymbolsAreSupersetRelationOfCodesFor) {
+   // Verify AMBIGUITY_SYMBOLS[S] = {Y : CODES_FOR[S] ⊆ CODES_FOR[Y]}
+   for (auto symbol : Nucleotide::SYMBOLS) {
+      const auto& codes_for_symbol = Nucleotide::CODES_FOR.at(symbol);
+      const auto& ambiguous = Nucleotide::AMBIGUITY_SYMBOLS.at(symbol);
+
+      for (auto candidate : Nucleotide::SYMBOLS) {
+         const auto& codes_for_candidate = Nucleotide::CODES_FOR.at(candidate);
+
+         const bool is_superset = std::ranges::all_of(codes_for_symbol, [&](auto coded_symbol) {
+            return std::ranges::find(codes_for_candidate, coded_symbol) !=
+                   codes_for_candidate.end();
+         });
+         const bool in_ambiguous = std::ranges::find(ambiguous, candidate) != ambiguous.end();
+
+         EXPECT_EQ(is_superset, in_ambiguous)
+            << "Symbol " << Nucleotide::symbolToChar(symbol) << " vs candidate "
+            << Nucleotide::symbolToChar(candidate) << ": superset=" << is_superset
+            << " in_ambiguous=" << in_ambiguous;
+      }
+   }
+}
+
+TEST(NucleotideSymbol, ambiguitySymbolsSpecificExamples) {
+   auto contains = [](const std::vector<Symbol>& vec, Symbol symbol) {
+      return std::ranges::find(vec, symbol) != vec.end();
+   };
+
+   // A should be matched by R(AG), M(AC), W(AT), D(AGT), H(ACT), V(ACG), N
+   {
+      const auto& amb = Nucleotide::AMBIGUITY_SYMBOLS.at(Symbol::A);
+      EXPECT_TRUE(contains(amb, Symbol::A));
+      EXPECT_TRUE(contains(amb, Symbol::R));
+      EXPECT_TRUE(contains(amb, Symbol::M));
+      EXPECT_TRUE(contains(amb, Symbol::W));
+      EXPECT_TRUE(contains(amb, Symbol::D));
+      EXPECT_TRUE(contains(amb, Symbol::H));
+      EXPECT_TRUE(contains(amb, Symbol::V));
+      EXPECT_TRUE(contains(amb, Symbol::N));
+      EXPECT_FALSE(contains(amb, Symbol::Y));
+      EXPECT_FALSE(contains(amb, Symbol::S));
+      EXPECT_FALSE(contains(amb, Symbol::K));
+      EXPECT_FALSE(contains(amb, Symbol::B));
+   }
+
+   // GAP should be matched by GAP and N
+   {
+      const auto& amb = Nucleotide::AMBIGUITY_SYMBOLS.at(Symbol::GAP);
+      EXPECT_TRUE(contains(amb, Symbol::GAP));
+      EXPECT_TRUE(contains(amb, Symbol::N));
+      EXPECT_EQ(amb.size(), 2);
+   }
+
+   // R(AG) should be matched by R, D(AGT), V(ACG), N
+   {
+      const auto& amb = Nucleotide::AMBIGUITY_SYMBOLS.at(Symbol::R);
+      EXPECT_TRUE(contains(amb, Symbol::R));
+      EXPECT_TRUE(contains(amb, Symbol::D));
+      EXPECT_TRUE(contains(amb, Symbol::V));
+      EXPECT_TRUE(contains(amb, Symbol::N));
+      EXPECT_EQ(amb.size(), 4);
+   }
+
+   // B(CGT) should be matched by B and N only
+   {
+      const auto& amb = Nucleotide::AMBIGUITY_SYMBOLS.at(Symbol::B);
+      EXPECT_TRUE(contains(amb, Symbol::B));
+      EXPECT_TRUE(contains(amb, Symbol::N));
+      EXPECT_EQ(amb.size(), 2);
+   }
+
+   // N should only be matched by N itself
+   {
+      const auto& amb = Nucleotide::AMBIGUITY_SYMBOLS.at(Symbol::N);
+      EXPECT_EQ(amb.size(), 1);
+      EXPECT_TRUE(contains(amb, Symbol::N));
+   }
+}
+
+// NOLINTEND(readability-function-cognitive-complexity)


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1038

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

With this PR, an ambiguous search for `-` will also return sequences that have `N` at that position. This enables better rewrite rules and behaves closer to user expectation

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
