### PR TITLE
feat(silo)!: use date32 type for dates instead of converting to string

### DIFF
--- a/endToEndTests/test/query.test.js
+++ b/endToEndTests/test/query.test.js
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { tableFromIPC } from 'apache-arrow';
+import { DataType, tableFromIPC } from 'apache-arrow';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -39,6 +39,10 @@ function arrowTableToObjects(table) {
       const value = column.get(i);
       if (value === null) {
         obj[field.name] = null;
+      } else if (DataType.isDate(field.type)) {
+        // Arrow JS reads Date32 columns as epoch-millisecond numbers (UTC midnight);
+        // In ndjson, SILO emits date columns as YYYY-MM-DD strings, so normalize to match.
+        obj[field.name] = new Date(value).toISOString().slice(0, 10);
       } else if (typeof value === 'bigint') {
         obj[field.name] = Number(value);
       } else if (value instanceof Uint8Array) {

--- a/src/silo/query_engine/exec_node/arrow_date32_compat.test.cpp
+++ b/src/silo/query_engine/exec_node/arrow_date32_compat.test.cpp
@@ -1,0 +1,189 @@
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <arrow/array/builder_binary.h>
+#include <gtest/gtest.h>
+
+#include <arrow/array/array_primitive.h>
+#include <arrow/array/builder_primitive.h>
+#include <arrow/compute/api.h>
+#include <arrow/result.h>
+#include <arrow/scalar.h>
+#include <arrow/status.h>
+#include <arrow/type.h>
+#include <arrow/type_fwd.h>
+
+#include "silo/common/date32.h"
+
+namespace {
+
+using silo::common::Date32;
+using silo::common::date32ToString;
+using silo::common::stringToDate32;
+
+TEST(SiloDate32MatchesArrowDate32, cTypesAreIdentical) {
+   // SILO's Date32 must be bit-identical to Arrow's Date32 c_type so that one
+   // can be reinterpreted as the other without conversion.
+   static_assert(std::is_same_v<Date32, int32_t>);
+   static_assert(std::is_same_v<arrow::Date32Type::c_type, int32_t>);
+   EXPECT_EQ(arrow::date32()->id(), arrow::Type::DATE32);
+}
+
+TEST(SiloDate32MatchesArrowDate32, dateUnitIsDays) {
+   // SILO encodes Date32 as days since 1970-01-01. Arrow's Date32 uses the
+   // same encoding (DateUnit::DAY since UNIX epoch).
+   EXPECT_EQ(arrow::Date32Type::UNIT, arrow::DateUnit::DAY);
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST(SiloDate32MatchesArrowDate32, builderAcceptsSiloDate32Values) {
+   const std::vector<std::string> dates = {
+      "1970-01-01",  // epoch
+      "1969-12-31",  // pre-epoch
+      "2000-02-29",  // century leap year
+      "2024-02-29",  // standard leap year
+      "1900-02-28",  // non-leap century
+      "2100-02-28",  // non-leap century in the future
+      "2020-12-24",
+      "2099-12-31",
+      "1900-01-01",
+   };
+
+   arrow::Date32Builder builder;
+   for (const auto& date_string : dates) {
+      const auto silo_value = stringToDate32(date_string);
+      ASSERT_TRUE(silo_value.has_value());
+      ASSERT_TRUE(builder.Append(silo_value.value()).ok());
+   }
+
+   ASSERT_TRUE(builder.AppendNull().ok());
+
+   std::shared_ptr<arrow::Array> array;
+   ASSERT_TRUE(builder.Finish(&array).ok());
+   ASSERT_EQ(array->type()->id(), arrow::Type::DATE32);
+
+   const auto& date_array = static_cast<const arrow::Date32Array&>(*array);
+   ASSERT_EQ(date_array.length(), static_cast<int64_t>(dates.size() + 1));
+
+   for (size_t i = 0; i < dates.size(); ++i) {
+      ASSERT_FALSE(date_array.IsNull(static_cast<int64_t>(i)));
+      const int32_t silo_value = stringToDate32(dates.at(i)).value();
+      const int32_t arrow_value = date_array.Value(static_cast<int64_t>(i));
+      EXPECT_EQ(silo_value, arrow_value) << "Mismatch for date " << dates.at(i);
+      EXPECT_EQ(date32ToString(arrow_value), dates.at(i));
+   }
+   EXPECT_TRUE(date_array.IsNull(static_cast<int64_t>(dates.size())));
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST(SiloDate32MatchesArrowDate32, arrowCastFromStringMatchesSiloEncoding) {
+   // Arrow's "cast from utf8 to date32" must produce the exact same int32
+   // value that SILO produces. If this ever diverges, the storage layer and
+   // the query result will disagree on what a date is.
+   const std::vector<std::string> dates = {
+      "1970-01-01",
+      "1969-12-31",
+      "2000-02-29",
+      "2024-02-29",
+      "2020-12-24",
+      "2099-12-31",
+      "1900-01-01",
+      "2025-01-01",
+   };
+
+   arrow::StringBuilder string_builder;
+   for (const auto& date_string : dates) {
+      ASSERT_TRUE(string_builder.Append(date_string).ok());
+   }
+   std::shared_ptr<arrow::Array> string_array;
+   ASSERT_TRUE(string_builder.Finish(&string_array).ok());
+
+   arrow::compute::CastOptions cast_options;
+   cast_options.to_type = arrow::date32();
+   const auto cast_result = arrow::compute::Cast(string_array, cast_options);
+   ASSERT_TRUE(cast_result.ok()) << cast_result.status().ToString();
+
+   const auto arrow_dates =
+      std::static_pointer_cast<arrow::Date32Array>(cast_result.ValueOrDie().make_array());
+   ASSERT_EQ(arrow_dates->length(), static_cast<int64_t>(dates.size()));
+
+   for (size_t i = 0; i < dates.size(); ++i) {
+      const int32_t silo_value = stringToDate32(dates.at(i)).value();
+      const int32_t arrow_value = arrow_dates->Value(static_cast<int64_t>(i));
+      EXPECT_EQ(silo_value, arrow_value) << "Encoding mismatch for date " << dates.at(i);
+   }
+}
+
+TEST(SiloDate32MatchesArrowDate32, scalarToStringMatchesSiloFormatting) {
+   // Round-trip through arrow::Date32Scalar to ensure the same int32 value
+   // is interpreted as the same calendar day.
+   struct Sample {
+      std::string string_value;
+      int32_t expected_int;
+   };
+   const std::vector<Sample> samples = {
+      {.string_value = "1970-01-01", .expected_int = 0},
+      {.string_value = "1969-12-31", .expected_int = -1},
+      {.string_value = "1969-12-30", .expected_int = -2},
+      {.string_value = "2020-01-01", .expected_int = 18262},
+      {.string_value = "2010-12-03", .expected_int = 14946},
+   };
+   for (const auto& sample : samples) {
+      const auto silo_value = stringToDate32(sample.string_value);
+      ASSERT_TRUE(silo_value.has_value());
+      EXPECT_EQ(silo_value.value(), sample.expected_int);
+
+      const arrow::Date32Scalar scalar{sample.expected_int};
+      EXPECT_EQ(scalar.value, sample.expected_int);
+      EXPECT_EQ(date32ToString(scalar.value), sample.string_value);
+   }
+}
+
+TEST(SiloDate32MatchesArrowDate32, dayArithmeticAgreesWithArrow) {
+   const auto jan1 = stringToDate32("2023-01-01").value();
+   const auto jan2 = stringToDate32("2023-01-02").value();
+   const auto dec31 = stringToDate32("2023-12-31").value();
+
+   arrow::Date32Builder builder;
+   ASSERT_TRUE(builder.Append(jan1).ok());
+   ASSERT_TRUE(builder.Append(jan2).ok());
+   ASSERT_TRUE(builder.Append(dec31).ok());
+
+   std::shared_ptr<arrow::Array> array;
+   ASSERT_TRUE(builder.Finish(&array).ok());
+   const auto& date_array = static_cast<const arrow::Date32Array&>(*array);
+
+   EXPECT_EQ(date_array.Value(1) - date_array.Value(0), 1);
+   EXPECT_EQ(date_array.Value(2) - date_array.Value(0), 364);
+}
+
+TEST(SiloDate32MatchesArrowDate32, extremalInt32ValuesRoundTripBitwise) {
+   // The Arrow Date32Builder accepts the full int32_t range. SILO must be
+   // able to store and read back any value Arrow produces, even if the
+   // resulting calendar date is outside the practical YYYY-MM-DD range.
+   const std::vector<int32_t> values = {
+      0,
+      -1,
+      1,
+      std::numeric_limits<int32_t>::min(),
+      std::numeric_limits<int32_t>::max(),
+   };
+
+   arrow::Date32Builder builder;
+   for (const auto value : values) {
+      ASSERT_TRUE(builder.Append(value).ok());
+   }
+   std::shared_ptr<arrow::Array> array;
+   ASSERT_TRUE(builder.Finish(&array).ok());
+   const auto& date_array = static_cast<const arrow::Date32Array&>(*array);
+
+   for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(date_array.Value(static_cast<int64_t>(i)), values.at(i));
+      const Date32 silo_value = date_array.Value(static_cast<int64_t>(i));
+      EXPECT_EQ(silo_value, values.at(i));
+   }
+}
+
+}  // namespace

--- a/src/silo/query_engine/exec_node/arrow_util.cpp
+++ b/src/silo/query_engine/exec_node/arrow_util.cpp
@@ -6,8 +6,9 @@ std::shared_ptr<arrow::DataType> columnTypeToArrowType(schema::ColumnType column
    switch (column_type) {
       case schema::ColumnType::STRING:
       case schema::ColumnType::INDEXED_STRING:
-      case schema::ColumnType::DATE32:
          return arrow::utf8();
+      case schema::ColumnType::DATE32:
+         return arrow::date32();
       case schema::ColumnType::BOOL:
          return arrow::boolean();
       case schema::ColumnType::INT32:

--- a/src/silo/query_engine/exec_node/arrow_util.h
+++ b/src/silo/query_engine/exec_node/arrow_util.h
@@ -77,8 +77,8 @@ struct ArrowBuilderSelector<storage::column::IntColumn> {
 
 template <>
 struct ArrowBuilderSelector<storage::column::Date32Column> {
-   using builder_type = arrow::StringBuilder;
-   using value_type = std::string;
+   using builder_type = arrow::Date32Builder;
+   using value_type = int32_t;
 };
 
 template <storage::column::Column ColumnType>

--- a/src/silo/query_engine/exec_node/ndjson_sink.cpp
+++ b/src/silo/query_engine/exec_node/ndjson_sink.cpp
@@ -11,6 +11,7 @@
 #include <nlohmann/json.hpp>
 
 #include "evobench/evobench.hpp"
+#include "silo/common/date32.h"
 #include "silo/common/panic.h"
 
 namespace silo::query_engine::exec_node {
@@ -96,6 +97,19 @@ class ArrayToJsonTypeVisitor : public arrow::ArrayVisitor {
          } else {
             const nlohmann::json json = array.GetView(row_base + i);
             output_stream.streams.at(i) << json;
+         }
+      }
+      return arrow::Status::OK();
+   }
+
+   arrow::Status Visit(const arrow::Date32Array& array) override {
+      for (size_t i = 0; i < BatchSize; ++i) {
+         if (array.IsNull(row_base + i)) {
+            output_stream.streams.at(i) << "null";
+         } else {
+            const std::string date_string = common::date32ToString(array.Value(row_base + i));
+            const nlohmann::json json_string = date_string;
+            output_stream.streams.at(i) << json_string.dump();
          }
       }
       return arrow::Status::OK();

--- a/src/silo/query_engine/exec_node/table_scan.cpp
+++ b/src/silo/query_engine/exec_node/table_scan.cpp
@@ -163,9 +163,6 @@ arrow::Status ColumnEntryAppender::operator()(
          } else if constexpr (std::is_same_v<Column, storage::column::IndexedStringColumn>) {
             auto value = column.getValueString(row_id);
             ARROW_RETURN_NOT_OK(array->Append(value));
-         } else if constexpr (std::is_same_v<Column, storage::column::Date32Column>) {
-            auto value = common::date32ToString(column.getValue(row_id));
-            ARROW_RETURN_NOT_OK(array->Append(value));
          } else {
             auto value = column.getValue(row_id);
             ARROW_RETURN_NOT_OK(array->Append(value));


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1225 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This contains a breaking change: in the arrow format, we will directly emit dates using arrow's date32 type. ndjson format will still convert them to strings

LAPIS will need to add a case statement for a DateVector here:
https://github.com/GenSpectrum/LAPIS/blob/05298cf0d2688ff13819db10f82022f3de698382/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt#L184-L191

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
