### PR TITLE
fix(silo): disambiguate unary/binary minus in SaneQL

### DIFF
--- a/src/silo/query_engine/saneql/lexer.cpp
+++ b/src/silo/query_engine/saneql/lexer.cpp
@@ -118,11 +118,6 @@ Token Lexer::readNumber() {
    const SourceLocation start = current_location;
    const size_t num_start = position;
 
-   // TODO(#1246) do not lex negative numbers
-   if (peek() == '-') {
-      advance();
-   }
-
    bool is_float = false;
    while (!isAtEnd() && (std::isalnum(static_cast<unsigned char>(peek())) || peek() == '.')) {
       if (peek() == '.') {
@@ -193,10 +188,6 @@ Token Lexer::nextToken() {
    }
 
    if (std::isdigit(static_cast<unsigned char>(current))) {
-      return readNumber();
-   }
-
-   if (current == '-' && std::isdigit(static_cast<unsigned char>(peekNext()))) {
       return readNumber();
    }
 
@@ -272,6 +263,9 @@ Token Lexer::nextToken() {
             return makeToken(TokenType::COLON_EQUALS, start);
          }
          throw ParseException(start, "Expected '::' or ':='");
+      case '-':
+         advance();
+         return makeToken(TokenType::MINUS, start);
       default:
          advance();
          throw ParseException(start, "Unexpected character '{}'", current);

--- a/src/silo/query_engine/saneql/lexer.cpp
+++ b/src/silo/query_engine/saneql/lexer.cpp
@@ -137,7 +137,7 @@ Token Lexer::readNumber() {
       return makeToken(TokenType::FLOAT_LITERAL, val, start);
    }
 
-   int64_t val = 0;
+   uint64_t val = 0;
    auto [ptr, ec] = fast_float::from_chars(num_str.data(), num_str.data() + num_str.size(), val);
    if (ec != std::errc() || ptr != num_str.end()) {
       throw ParseException(start, "Invalid integer literal");

--- a/src/silo/query_engine/saneql/lexer.test.cpp
+++ b/src/silo/query_engine/saneql/lexer.test.cpp
@@ -44,7 +44,7 @@ TEST(SaneQLLexer, tokenizesIntLiteral) {
 TEST(SaneQLLexer, invalidIntLiteral) {
    EXPECT_THAT(
       []() {
-         const std::string input = fmt::format("{}0", INT64_MAX);
+         const std::string input = fmt::format("{}0", UINT64_MAX);
          Lexer lexer(input);
          auto tokens = lexer.tokenizeAll();
       },

--- a/src/silo/query_engine/saneql/lexer.test.cpp
+++ b/src/silo/query_engine/saneql/lexer.test.cpp
@@ -91,9 +91,9 @@ TEST(SaneQLLexer, tokenizesNullLiteral) {
 }
 
 TEST(SaneQLLexer, tokenizesOperators) {
-   Lexer lexer("= <> < > <= >= && || !");
+   Lexer lexer("= <> < > <= >= && || ! -");
    auto tokens = lexer.tokenizeAll();
-   ASSERT_EQ(tokens.size(), 10);
+   ASSERT_EQ(tokens.size(), 11);
    EXPECT_EQ(tokens[0].type, TokenType::EQUALS);
    EXPECT_EQ(tokens[1].type, TokenType::NOT_EQUALS);
    EXPECT_EQ(tokens[2].type, TokenType::LESS_THAN);
@@ -103,6 +103,7 @@ TEST(SaneQLLexer, tokenizesOperators) {
    EXPECT_EQ(tokens[6].type, TokenType::AND);
    EXPECT_EQ(tokens[7].type, TokenType::OR);
    EXPECT_EQ(tokens[8].type, TokenType::NOT);
+   EXPECT_EQ(tokens[9].type, TokenType::MINUS);
 }
 
 TEST(SaneQLLexer, invalidPartialAnd) {
@@ -325,20 +326,33 @@ TEST(SaneQLLexer, quotedIdentifierWithNumericName) {
    EXPECT_EQ(tokens[0].getStringValue(), "2");
 }
 
-TEST(SaneQLLexer, tokenizesNegativeInt) {
+TEST(SaneQLLexer, tokenizesMinusInt) {
    Lexer lexer("-42");
    auto tokens = lexer.tokenizeAll();
-   ASSERT_EQ(tokens.size(), 2);
-   EXPECT_EQ(tokens[0].type, TokenType::INT_LITERAL);
-   EXPECT_EQ(tokens[0].getIntValue(), -42);
+   ASSERT_EQ(tokens.size(), 3);
+   EXPECT_EQ(tokens[0].type, TokenType::MINUS);
+   EXPECT_EQ(tokens[1].type, TokenType::INT_LITERAL);
+   EXPECT_EQ(tokens[1].getIntValue(), 42);
 }
 
-TEST(SaneQLLexer, tokenizesNegativeFloat) {
+TEST(SaneQLLexer, tokenizesMinusFloat) {
    Lexer lexer("-3.14");
    auto tokens = lexer.tokenizeAll();
-   ASSERT_EQ(tokens.size(), 2);
-   EXPECT_EQ(tokens[0].type, TokenType::FLOAT_LITERAL);
-   EXPECT_DOUBLE_EQ(tokens[0].getFloatValue(), -3.14);
+   ASSERT_EQ(tokens.size(), 3);
+   EXPECT_EQ(tokens[0].type, TokenType::MINUS);
+   EXPECT_EQ(tokens[1].type, TokenType::FLOAT_LITERAL);
+   EXPECT_DOUBLE_EQ(tokens[1].getFloatValue(), 3.14);
+}
+
+TEST(SaneQLLexer, disambiguatesMinusFromNegative) {
+   Lexer lexer("x -42");
+   auto tokens = lexer.tokenizeAll();
+   ASSERT_EQ(tokens.size(), 4);
+   EXPECT_EQ(tokens[0].type, TokenType::IDENTIFIER);
+   EXPECT_EQ(tokens[0].getStringValue(), "x");
+   EXPECT_EQ(tokens[1].type, TokenType::MINUS);
+   EXPECT_EQ(tokens[2].type, TokenType::INT_LITERAL);
+   EXPECT_EQ(tokens[2].getIntValue(), 42);
 }
 
 TEST(SaneQLLexer, tokenizesEmptyStringLiteral) {
@@ -490,29 +504,21 @@ TEST(SaneQLLexer, emptyQuotedIdentifierProducesEmptyString) {
    EXPECT_EQ(tokens[0].getStringValue(), "");
 }
 
-TEST(SaneQLLexer, negativeIntegerOverflowThrows) {
-   EXPECT_THAT(
-      []() {
-         const std::string input = fmt::format("-{}0", INT64_MAX);
-         Lexer lexer(input);
-         (void)lexer.tokenizeAll();
-      },
-      ThrowsMessage<ParseException>(
-         ::testing::HasSubstr("Parse error at 1:1: Invalid integer literal")
-      )
-   );
+TEST(SaneQLLexer, tokenizesMinusToken) {
+   Lexer lexer("-");
+   auto tokens = lexer.tokenizeAll();
+   ASSERT_EQ(tokens.size(), 2);
+   EXPECT_EQ(tokens[0].type, TokenType::MINUS);
+   EXPECT_EQ(tokens[1].type, TokenType::END_OF_FILE);
 }
 
-TEST(SaneQLLexer, dashNotFollowedByDigitThrows) {
-   EXPECT_THAT(
-      []() {
-         Lexer lexer("-");
-         (void)lexer.nextToken();
-      },
-      ThrowsMessage<ParseException>(
-         ::testing::HasSubstr("Parse error at 1:1: Unexpected character '-'")
-      )
-   );
+TEST(SaneQLLexer, dashFollowedByIdentifier) {
+   Lexer lexer("-x");
+   auto tokens = lexer.tokenizeAll();
+   ASSERT_EQ(tokens.size(), 3);
+   EXPECT_EQ(tokens[0].type, TokenType::MINUS);
+   EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+   EXPECT_EQ(tokens[1].getStringValue(), "x");
 }
 
 TEST(SaneQLLexer, multipleConsecutiveComments) {

--- a/src/silo/query_engine/saneql/parser.cpp
+++ b/src/silo/query_engine/saneql/parser.cpp
@@ -213,6 +213,25 @@ ast::ExpressionPtr Parser::parsePostfixExpr() {
    return expr;
 }
 
+ast::ExpressionPtr Parser::parseUnaryMinus() {
+   const SourceLocation loc = current().location;
+   expect(TokenType::MINUS);
+
+   if (check(TokenType::INT_LITERAL)) {
+      const int64_t val = current().getIntValue();
+      advance();
+      return ast::makeExpr(ast::IntLiteral{-val}, loc);
+   }
+
+   if (check(TokenType::FLOAT_LITERAL)) {
+      const double val = current().getFloatValue();
+      advance();
+      return ast::makeExpr(ast::FloatLiteral{-val}, loc);
+   }
+
+   throw ParseException(loc, "Expected number after '-'");
+}
+
 // NOLINTNEXTLINE(misc-no-recursion)
 ast::ExpressionPtr Parser::parsePrimaryExpr() {
    if (check(TokenType::LEFT_PAREN)) {
@@ -224,6 +243,10 @@ ast::ExpressionPtr Parser::parsePrimaryExpr() {
 
    if (check(TokenType::LEFT_BRACE)) {
       return parseSetOrRecordExpression();
+   }
+
+   if (check(TokenType::MINUS)) {
+      return parseUnaryMinus();
    }
 
    if (check(TokenType::IDENTIFIER)) {

--- a/src/silo/query_engine/saneql/parser.cpp
+++ b/src/silo/query_engine/saneql/parser.cpp
@@ -1,5 +1,8 @@
 #include "silo/query_engine/saneql/parser.h"
 
+#include <cstdint>
+#include <limits>
+
 #include "silo/query_engine/saneql/ast.h"
 #include "silo/query_engine/saneql/parse_exception.h"
 
@@ -218,9 +221,16 @@ ast::ExpressionPtr Parser::parseUnaryMinus() {
    expect(TokenType::MINUS);
 
    if (check(TokenType::INT_LITERAL)) {
-      const int64_t val = current().getIntValue();
+      const uint64_t val = current().getIntValue();
       advance();
-      return ast::makeExpr(ast::IntLiteral{-val}, loc);
+      constexpr auto INT64_MAX_AS_UINT = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+      if (val <= INT64_MAX_AS_UINT) {
+         return ast::makeExpr(ast::IntLiteral{-static_cast<int64_t>(val)}, loc);
+      }
+      if (val == INT64_MAX_AS_UINT + 1) {
+         return ast::makeExpr(ast::IntLiteral{std::numeric_limits<int64_t>::min()}, loc);
+      }
+      throw ParseException(loc, "Integer literal out of range");
    }
 
    if (check(TokenType::FLOAT_LITERAL)) {
@@ -333,9 +343,12 @@ ast::ExpressionPtr Parser::parseLiteral() {
    }
 
    if (check(TokenType::INT_LITERAL)) {
-      const int64_t val = current().getIntValue();
+      const uint64_t val = current().getIntValue();
+      if (val > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+         throw ParseException(loc, "Integer literal out of range");
+      }
       advance();
-      return ast::makeExpr(ast::IntLiteral{val}, loc);
+      return ast::makeExpr(ast::IntLiteral{static_cast<int64_t>(val)}, loc);
    }
 
    if (check(TokenType::FLOAT_LITERAL)) {

--- a/src/silo/query_engine/saneql/parser.h
+++ b/src/silo/query_engine/saneql/parser.h
@@ -34,6 +34,7 @@ class Parser {
    [[nodiscard]] ast::ExpressionPtr parseComparisonExpr();
    [[nodiscard]] ast::ExpressionPtr parsePostfixExpr();
    [[nodiscard]] ast::ExpressionPtr parsePrimaryExpr();
+   [[nodiscard]] ast::ExpressionPtr parseUnaryMinus();
    [[nodiscard]] ast::ExpressionPtr parseSetOrRecordExpression();
    [[nodiscard]] ast::ExpressionPtr parseIdentifierOrFunctionCall();
    [[nodiscard]] ast::ExpressionPtr parseLiteral();

--- a/src/silo/query_engine/saneql/parser.test.cpp
+++ b/src/silo/query_engine/saneql/parser.test.cpp
@@ -28,11 +28,26 @@ TEST(SaneQLParser, parsesIntLiteral) {
    EXPECT_EQ(expr->toString(), "42");
 }
 
+TEST(SaneQLParser, parsesNegativeIntLiteral) {
+   Parser parser("-42");
+   auto expr = parser.parse();
+   ASSERT_TRUE(std::holds_alternative<ast::IntLiteral>(expr->value));
+   EXPECT_EQ(std::get<ast::IntLiteral>(expr->value).value, -42);
+   EXPECT_EQ(expr->toString(), "-42");
+}
+
 TEST(SaneQLParser, parsesFloatLiteral) {
    Parser parser("3.14");
    auto expr = parser.parse();
    ASSERT_TRUE(std::holds_alternative<ast::FloatLiteral>(expr->value));
    EXPECT_DOUBLE_EQ(std::get<ast::FloatLiteral>(expr->value).value, 3.14);
+}
+
+TEST(SaneQLParser, parsesNegativeFloat) {
+   Parser parser("-3.14");
+   auto expr = parser.parse();
+   ASSERT_TRUE(std::holds_alternative<ast::FloatLiteral>(expr->value));
+   EXPECT_DOUBLE_EQ(std::get<ast::FloatLiteral>(expr->value).value, -3.14);
 }
 
 TEST(SaneQLParser, parsesBoolLiteral) {
@@ -549,21 +564,6 @@ TEST(SaneQLParser, parsesFalseLiteral) {
    EXPECT_EQ(expr->toString(), "false");
 }
 
-TEST(SaneQLParser, parsesNegativeFloat) {
-   Parser parser("-3.14");
-   auto expr = parser.parse();
-   ASSERT_TRUE(std::holds_alternative<ast::FloatLiteral>(expr->value));
-   EXPECT_DOUBLE_EQ(std::get<ast::FloatLiteral>(expr->value).value, -3.14);
-}
-
-TEST(SaneQLParser, parsesNegativeIntLiteral) {
-   Parser parser("-42");
-   auto expr = parser.parse();
-   ASSERT_TRUE(std::holds_alternative<ast::IntLiteral>(expr->value));
-   EXPECT_EQ(std::get<ast::IntLiteral>(expr->value).value, -42);
-   EXPECT_EQ(expr->toString(), "-42");
-}
-
 TEST(SaneQLParser, throwsOnMinusWithoutNumber) {
    EXPECT_THAT(
       []() {
@@ -571,6 +571,16 @@ TEST(SaneQLParser, throwsOnMinusWithoutNumber) {
          (void)parser.parse();
       },
       ThrowsMessage<ParseException>(::testing::HasSubstr("Expected number after '-'"))
+   );
+}
+
+TEST(SaneQLParser, throwsExpressionWithMinus) {
+   EXPECT_THAT(
+      []() {
+         Parser parser("x - 5");
+         (void)parser.parse();
+      },
+      ThrowsMessage<ParseException>(::testing::HasSubstr("Expected Eof but got Minus"))
    );
 }
 

--- a/src/silo/query_engine/saneql/parser.test.cpp
+++ b/src/silo/query_engine/saneql/parser.test.cpp
@@ -549,6 +549,31 @@ TEST(SaneQLParser, parsesFalseLiteral) {
    EXPECT_EQ(expr->toString(), "false");
 }
 
+TEST(SaneQLParser, parsesNegativeFloat) {
+   Parser parser("-3.14");
+   auto expr = parser.parse();
+   ASSERT_TRUE(std::holds_alternative<ast::FloatLiteral>(expr->value));
+   EXPECT_DOUBLE_EQ(std::get<ast::FloatLiteral>(expr->value).value, -3.14);
+}
+
+TEST(SaneQLParser, parsesNegativeIntLiteral) {
+   Parser parser("-42");
+   auto expr = parser.parse();
+   ASSERT_TRUE(std::holds_alternative<ast::IntLiteral>(expr->value));
+   EXPECT_EQ(std::get<ast::IntLiteral>(expr->value).value, -42);
+   EXPECT_EQ(expr->toString(), "-42");
+}
+
+TEST(SaneQLParser, throwsOnMinusWithoutNumber) {
+   EXPECT_THAT(
+      []() {
+         Parser parser("-'hello'");
+         (void)parser.parse();
+      },
+      ThrowsMessage<ParseException>(::testing::HasSubstr("Expected number after '-'"))
+   );
+}
+
 TEST(SaneQLParser, parsesTypeCastChaining) {
    Parser parser("a::t1::t2");
    auto expr = parser.parse();

--- a/src/silo/query_engine/saneql/parser.test.cpp
+++ b/src/silo/query_engine/saneql/parser.test.cpp
@@ -584,6 +584,47 @@ TEST(SaneQLParser, throwsExpressionWithMinus) {
    );
 }
 
+TEST(SaneQLParser, parsesInt64Max) {
+   Parser parser("9223372036854775807");
+   auto expr = parser.parse();
+   ASSERT_TRUE(std::holds_alternative<ast::IntLiteral>(expr->value));
+   EXPECT_EQ(std::get<ast::IntLiteral>(expr->value).value, INT64_MAX);
+}
+
+TEST(SaneQLParser, throwsOnInt64MaxPlusOne) {
+   EXPECT_THAT(
+      []() {
+         Parser parser("9223372036854775808");
+         (void)parser.parse();
+      },
+      ThrowsMessage<ParseException>(::testing::HasSubstr("Integer literal out of range"))
+   );
+}
+
+TEST(SaneQLParser, parsesNegativeInt64Max) {
+   Parser parser("-9223372036854775807");
+   auto expr = parser.parse();
+   ASSERT_TRUE(std::holds_alternative<ast::IntLiteral>(expr->value));
+   EXPECT_EQ(std::get<ast::IntLiteral>(expr->value).value, -INT64_MAX);
+}
+
+TEST(SaneQLParser, parsesInt64Min) {
+   Parser parser("-9223372036854775808");
+   auto expr = parser.parse();
+   ASSERT_TRUE(std::holds_alternative<ast::IntLiteral>(expr->value));
+   EXPECT_EQ(std::get<ast::IntLiteral>(expr->value).value, INT64_MIN);
+}
+
+TEST(SaneQLParser, throwsOnNegativeInt64MinMinusOne) {
+   EXPECT_THAT(
+      []() {
+         Parser parser("-9223372036854775809");
+         (void)parser.parse();
+      },
+      ThrowsMessage<ParseException>(::testing::HasSubstr("Integer literal out of range"))
+   );
+}
+
 TEST(SaneQLParser, parsesTypeCastChaining) {
    Parser parser("a::t1::t2");
    auto expr = parser.parse();

--- a/src/silo/query_engine/saneql/token.cpp
+++ b/src/silo/query_engine/saneql/token.cpp
@@ -42,6 +42,8 @@ std::string tokenTypeToString(TokenType type) {
          return "Or";
       case TokenType::NOT:
          return "Not";
+      case TokenType::MINUS:
+         return "Minus";
       case TokenType::LEFT_PAREN:
          return "LeftParen";
       case TokenType::RIGHT_PAREN:

--- a/src/silo/query_engine/saneql/token.cpp
+++ b/src/silo/query_engine/saneql/token.cpp
@@ -85,8 +85,8 @@ std::string Token::getStringValue() const {
    return std::get<std::string>(value);
 }
 
-int64_t Token::getIntValue() const {
-   return std::get<int64_t>(value);
+uint64_t Token::getIntValue() const {
+   return std::get<uint64_t>(value);
 }
 
 double Token::getFloatValue() const {

--- a/src/silo/query_engine/saneql/token.h
+++ b/src/silo/query_engine/saneql/token.h
@@ -38,7 +38,7 @@ enum class TokenType : uint8_t {
 
 [[nodiscard]] std::string tokenTypeToString(TokenType type);
 
-using TokenValue = std::variant<std::monostate, int64_t, double, std::string, bool>;
+using TokenValue = std::variant<std::monostate, uint64_t, double, std::string, bool>;
 
 struct Token {
    TokenType type;
@@ -48,7 +48,7 @@ struct Token {
    [[nodiscard]] std::string toString() const;
 
    [[nodiscard]] std::string getStringValue() const;
-   [[nodiscard]] int64_t getIntValue() const;
+   [[nodiscard]] uint64_t getIntValue() const;
    [[nodiscard]] double getFloatValue() const;
    [[nodiscard]] bool getBoolValue() const;
 };

--- a/src/silo/query_engine/saneql/token.h
+++ b/src/silo/query_engine/saneql/token.h
@@ -27,6 +27,7 @@ enum class TokenType : uint8_t {
    AND,
    OR,
    NOT,
+   MINUS,
    LEFT_PAREN,
    RIGHT_PAREN,
    LEFT_BRACE,


### PR DESCRIPTION
resolves #1246

### Summary

Introduces a separate `MINUS` token for the lexer so that the parser can sort it out.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [x] The implemented feature is covered by an appropriate test.
