### PR TITLE
feat(silo): add a limited `map` operator to saneql

### DIFF
--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -23,7 +23,7 @@ Every operator takes a table as input and produces a table as output. Internally
 Operators fall into two categories:
 
 - **Schema-preserving** (`filter`, `orderBy`, `limit`, `offset`, `randomize`): pass all input columns through unchanged. They select or reorder rows but do not add, remove, or rename fields.
-- **Schema-defining** (`groupBy`, `project`, `mutations`, `aminoAcidMutations`, `insertions`, `aminoAcidInsertions`, `mostRecentCommonAncestor`, `phyloSubtree`): produce a changed output schema. Each operator's section below documents its output fields.
+- **Schema-defining** (`groupBy`, `project`, `map`, `mutations`, `aminoAcidMutations`, `insertions`, `aminoAcidInsertions`, `mostRecentCommonAncestor`, `phyloSubtree`): produce a changed output schema. Each operator's section below documents its output fields.
 
 Simple example — count all sequences from Switzerland:
 
@@ -129,6 +129,22 @@ Sequence data columns use the naming convention `<sequenceName>` for aligned seq
 
 ```json
 {"primary_key": "key_31", "country": "Switzerland", "date": "2021-03-21", "pango_lineage": "B.1.1.7", "qc_value": 0.96}
+```
+
+### `map(expressions)`
+
+Adds columns to the table. `expressions` is a record of `name := value` assignments. For now only literal values are supported: integers, floats, strings (single-quoted), and booleans.
+
+```
+default.map({x := 3, label := 'cohort A', active := true})
+```
+
+All input columns are passed through unchanged and the new columns are appended. An assignment whose name matches an existing column replaces that column in place.
+
+**Output:** one row per input row containing all input columns plus the assigned columns. Integer literals become `INT32` (or `INT64` when out of `INT32` range), floats become `FLOAT`, single-quoted literals become `STRING`, and `true`/`false` become `BOOL`.
+
+```json
+{"primary_key": "key_31", "x": 3, "label": "cohort A", "active": true}
 ```
 
 ### `orderBy(fields)`

--- a/src/silo/query_engine/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/column_narrowing_pass.cpp
@@ -4,6 +4,7 @@
 #include "silo/query_engine/operators/aggregate_node.h"
 #include "silo/query_engine/operators/fetch_node.h"
 #include "silo/query_engine/operators/filter_node.h"
+#include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
@@ -102,6 +103,31 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::ZstdDecompres
       return std::move(node.child);
    }
    node.column_mapping = new_column_mapping;
+   return nullptr;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::MapNode& node) {
+   // A map keeps all of its child's columns and adds (or replaces) some via
+   // literal assignments. Literal assignments need nothing from the child, so
+   // only the required pass-through columns must still be provided by it.
+   RequiredColumns child_required;
+   for (const auto& required_column : required) {
+      const bool produced_by_map =
+         std::ranges::any_of(node.assignments, [&](const auto& assignment) {
+            return assignment.output_column.name == required_column.name;
+         });
+      if (!produced_by_map) {
+         child_required.push_back(required_column);
+      }
+   }
+   if (child_required.empty()) {
+      auto child_schema = node.child->getOutputSchema();
+      SILO_ASSERT(!child_schema.empty());
+      child_required.push_back(child_schema.front());
+   }
+   required = std::move(child_required);
+   applyToChild(node.child, *this);
    return nullptr;
 }
 

--- a/src/silo/query_engine/column_narrowing_pass.h
+++ b/src/silo/query_engine/column_narrowing_pass.h
@@ -9,6 +9,7 @@ namespace silo::query_engine::operators {
 class TableScanNode;
 class AggregateNode;
 class ProjectNode;
+class MapNode;
 class ZstdDecompressNode;
 class OrderByNode;
 class FetchNode;
@@ -36,6 +37,7 @@ class ColumnNarrowingPass {
    operators::QueryNodePtr operator()(operators::AggregateNode& node);
    operators::QueryNodePtr operator()(operators::ProjectNode& node);
    operators::QueryNodePtr operator()(operators::ZstdDecompressNode& node);
+   operators::QueryNodePtr operator()(operators::MapNode& node);
    operators::QueryNodePtr operator()(operators::OrderByNode& node);
    operators::QueryNodePtr operator()(operators::FetchNode& node);
    operators::QueryNodePtr operator()(operators::FilterNode& node);

--- a/src/silo/query_engine/filter/expressions/insertion_contains.cpp
+++ b/src/silo/query_engine/filter/expressions/insertion_contains.cpp
@@ -2,9 +2,6 @@
 
 #include <utility>
 
-#include <spdlog/spdlog.h>
-#include <boost/algorithm/string/join.hpp>
-
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/query_engine/copy_on_write_bitmap.h"
@@ -13,7 +10,6 @@
 #include "silo/query_engine/filter/operators/operator.h"
 #include "silo/query_engine/illegal_query_exception.h"
 #include "silo/query_engine/query_parse_sequence_name.h"
-#include "silo/storage/column/insertion_index.h"
 #include "silo/storage/column/sequence_column.h"
 #include "silo/storage/insertion_format_exception.h"
 
@@ -73,8 +69,8 @@ std::unique_ptr<operators::Operator> InsertionContains<SymbolType>::compile(
          try {
             auto search_result = sequence_store.insertion_index.search(position_idx, value);
             return CopyOnWriteBitmap(std::move(*search_result));
-         } catch (const silo::storage::InsertionFormatException& exception) {
-            throw silo::query_engine::IllegalQueryException(
+         } catch (const storage::InsertionFormatException& exception) {
+            throw IllegalQueryException(
                "The field 'value' in the InsertionContains expression does not contain a valid "
                "regex "
                "pattern: \"{}\". It must only consist of {} symbols and the regex symbol '.*'. "

--- a/src/silo/query_engine/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.cpp
@@ -8,6 +8,7 @@
 #include "silo/query_engine/operators/fetch_node.h"
 #include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/insertions_node.h"
+#include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/mutations_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
@@ -110,6 +111,12 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::FetchNode& nod
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr FilterPushdownPass::operator()(operators::ProjectNode& node) {
+   applyToNode(node.child, *this);
+   return nullptr;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr FilterPushdownPass::operator()(operators::MapNode& node) {
    applyToNode(node.child, *this);
    return nullptr;
 }

--- a/src/silo/query_engine/filter_pushdown_pass.h
+++ b/src/silo/query_engine/filter_pushdown_pass.h
@@ -7,6 +7,7 @@ namespace silo::query_engine::operators {
 class AggregateNode;
 class FetchNode;
 class FilterNode;
+class MapNode;
 class OrderByNode;
 class ProjectNode;
 class TableScanNode;
@@ -41,6 +42,7 @@ class FilterPushdownPass {
    operators::QueryNodePtr operator()(operators::OrderByNode& node);
    operators::QueryNodePtr operator()(operators::FetchNode& node);
    operators::QueryNodePtr operator()(operators::ProjectNode& node);
+   operators::QueryNodePtr operator()(operators::MapNode& node);
    operators::QueryNodePtr operator()(operators::ZstdDecompressNode& node);
 
    operators::QueryNodePtr operator()(operators::TableScanNode& node);

--- a/src/silo/query_engine/filter_pushdown_pass.test.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.test.cpp
@@ -8,6 +8,7 @@
 
 #include "silo/query_engine/filter/expressions/true.h"
 #include "silo/query_engine/operators/filter_node.h"
+#include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/schema/database_schema.h"
 #include "silo/storage/column/string_column.h"
@@ -51,6 +52,33 @@ TEST(FilterPushdownPass, eliminatesFilterNodeAboveTableScan) {
    // The FilterNode is gone; result is the TableScanNode directly.
    EXPECT_EQ(result->kind(), operators::NodeKind::TABLE_SCAN);
    auto* table_scan = dynamic_cast<operators::TableScanNode*>(result.get());
+   EXPECT_EQ(table_scan->filter->toString(), "And(And(True & True))");
+}
+
+// --- MapNode(FilterNode(TableScanNode)) ---
+
+TEST(FilterPushdownPass, pushesFilterThroughMapIntoTableScan) {
+   auto table = makeTable();
+   auto scan = std::make_unique<operators::TableScanNode>(
+      table, makeDummyFilter(), std::vector<silo::schema::ColumnIdentifier>{}
+   );
+   auto filter_node = std::make_unique<operators::FilterNode>(std::move(scan), makeDummyFilter());
+
+   std::vector<operators::MapNode::Assignment> assignments;
+   assignments.push_back(
+      {.output_column = {.name = "x", .type = silo::schema::ColumnType::INT64},
+       .expression = operators::MapNode::Int64Literal{.value = 3}}
+   );
+   auto map_node =
+      std::make_unique<operators::MapNode>(std::move(filter_node), std::move(assignments));
+
+   auto result = FilterPushdownPass::run(std::move(map_node));
+
+   // The MapNode is retained; the FilterNode below it was pushed into the TableScan.
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* map = dynamic_cast<operators::MapNode*>(result.get());
+   ASSERT_EQ(map->child->kind(), operators::NodeKind::TABLE_SCAN);
+   auto* table_scan = dynamic_cast<operators::TableScanNode*>(map->child.get());
    EXPECT_EQ(table_scan->filter->toString(), "And(And(True & True))");
 }
 

--- a/src/silo/query_engine/node_resolution_pass.cpp
+++ b/src/silo/query_engine/node_resolution_pass.cpp
@@ -10,6 +10,7 @@
 #include "silo/query_engine/operators/fetch_node.h"
 #include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/insertions_node.h"
+#include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/mutations_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
@@ -53,6 +54,12 @@ operators::QueryNodePtr NodeResolutionPass::operator()(operators::FilterNode& no
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr NodeResolutionPass::operator()(operators::ProjectNode& node) {
+   applyToNode(node.child, *this);
+   return nullptr;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr NodeResolutionPass::operator()(operators::MapNode& node) {
    applyToNode(node.child, *this);
    return nullptr;
 }

--- a/src/silo/query_engine/node_resolution_pass.h
+++ b/src/silo/query_engine/node_resolution_pass.h
@@ -10,6 +10,7 @@
 namespace silo::query_engine::operators {
 class AggregateNode;
 class ProjectNode;
+class MapNode;
 class OrderByNode;
 class FetchNode;
 class FilterNode;
@@ -37,6 +38,7 @@ class NodeResolutionPass {
    operators::QueryNodePtr operator()(operators::FilterNode& node);
    operators::QueryNodePtr operator()(operators::AggregateNode& node);
    operators::QueryNodePtr operator()(operators::ProjectNode& node);
+   operators::QueryNodePtr operator()(operators::MapNode& node);
    operators::QueryNodePtr operator()(operators::OrderByNode& node);
    operators::QueryNodePtr operator()(operators::FetchNode& node);
    operators::QueryNodePtr operator()(operators::ZstdDecompressNode& node);

--- a/src/silo/query_engine/node_resolution_pass.test.cpp
+++ b/src/silo/query_engine/node_resolution_pass.test.cpp
@@ -13,6 +13,7 @@
 #include "silo/query_engine/filter/expressions/true.h"
 #include "silo/query_engine/illegal_query_exception.h"
 #include "silo/query_engine/operators/filter_node.h"
+#include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/operators/unresolved_insertions_node.h"
 #include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
@@ -60,6 +61,15 @@ operators::QueryNodePtr makeNonScanChild() {
    return std::make_unique<operators::FilterNode>(
       makeTableScan(), std::make_unique<silo::query_engine::filter::expressions::True>()
    );
+}
+
+std::vector<operators::MapNode::Assignment> makeMapAssignments() {
+   std::vector<operators::MapNode::Assignment> assignments;
+   assignments.push_back(
+      {.output_column = {.name = "x", .type = silo::schema::ColumnType::INT64},
+       .expression = operators::MapNode::Int64Literal{.value = 3}}
+   );
+   return assignments;
 }
 
 // --- mutations() ---
@@ -153,6 +163,35 @@ TEST(NodeResolutionPassMostRecentCommonAncestor, onNonScanNodeThrows) {
       [&]() { (void)NodeResolutionPass::run(std::move(node)); },
       ThrowsMessage<IllegalQueryException>(
          ::testing::HasSubstr("mostRecentCommonAncestor() must be applied to a table scan")
+      )
+   );
+}
+
+// --- map() ---
+
+TEST(NodeResolutionPassMap, resolvesUnresolvedChildBelowMap) {
+   auto unresolved = std::make_unique<operators::UnresolvedInsertionsNode<Nucleotide>>(
+      makeTableScan(), std::vector<std::string>{}
+   );
+   auto map = std::make_unique<operators::MapNode>(std::move(unresolved), makeMapAssignments());
+
+   auto result = NodeResolutionPass::run(std::move(map));
+
+   // The MapNode is retained; its unresolved child was resolved into a concrete node.
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* resolved_map = dynamic_cast<operators::MapNode*>(result.get());
+   EXPECT_EQ(resolved_map->child->kind(), operators::NodeKind::INSERTIONS_NUCLEOTIDE);
+}
+
+TEST(NodeResolutionPassMap, propagatesChildErrorThroughMap) {
+   auto unresolved = std::make_unique<operators::UnresolvedInsertionsNode<Nucleotide>>(
+      makeNonScanChild(), std::vector<std::string>{}
+   );
+   auto map = std::make_unique<operators::MapNode>(std::move(unresolved), makeMapAssignments());
+   EXPECT_THAT(
+      [&]() { (void)NodeResolutionPass::run(std::move(map)); },
+      ThrowsMessage<IllegalQueryException>(
+         ::testing::HasSubstr("insertions() must be applied to a table scan")
       )
    );
 }

--- a/src/silo/query_engine/operator_visitor.h
+++ b/src/silo/query_engine/operator_visitor.h
@@ -8,6 +8,7 @@
 #include "silo/query_engine/operators/fetch_node.h"
 #include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/insertions_node.h"
+#include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/mutations_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
@@ -30,6 +31,8 @@ decltype(auto) visit(QueryNode& node, Func&& func) {
          return std::forward<Func>(func)(static_cast<AggregateNode&>(node));
       case NodeKind::PROJECT:
          return std::forward<Func>(func)(static_cast<ProjectNode&>(node));
+      case NodeKind::MAP:
+         return std::forward<Func>(func)(static_cast<MapNode&>(node));
       case NodeKind::ORDER_BY:
          return std::forward<Func>(func)(static_cast<OrderByNode&>(node));
       case NodeKind::FETCH:

--- a/src/silo/query_engine/operators/map_node.cpp
+++ b/src/silo/query_engine/operators/map_node.cpp
@@ -1,0 +1,74 @@
+#include "silo/query_engine/operators/map_node.h"
+
+#include <algorithm>
+#include <string>
+#include <variant>
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/acero/options.h>
+#include <arrow/compute/api.h>
+#include <arrow/datum.h>
+
+namespace silo::query_engine::operators {
+
+MapNode::MapNode(QueryNodePtr child, std::vector<Assignment> assignments)
+    : child(std::move(child)),
+      assignments(std::move(assignments)) {}
+
+std::vector<schema::ColumnIdentifier> MapNode::getOutputSchema() const {
+   auto output = child->getOutputSchema();
+   for (const auto& assignment : assignments) {
+      auto found = std::ranges::find_if(output, [&](const auto& column) {
+         return column.name == assignment.output_column.name;
+      });
+      if (found != output.end()) {
+         *found = assignment.output_column;
+      } else {
+         output.push_back(assignment.output_column);
+      }
+   }
+   return output;
+}
+
+arrow::Result<PartialArrowPlan> MapNode::toQueryPlan(
+   const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
+   const config::QueryOptions& query_options
+) const {
+   ARROW_ASSIGN_OR_RAISE(auto plan, child->toQueryPlan(tables, query_options));
+
+   // Map output column names to the assignment that produces them.
+   std::map<std::string, const Assignment*> assignment_by_name;
+   for (const auto& assignment : assignments) {
+      assignment_by_name[assignment.output_column.name] = &assignment;
+   }
+
+   const auto output_schema = getOutputSchema();
+   std::vector<arrow::Expression> expressions;
+   std::vector<std::string> names;
+   expressions.reserve(output_schema.size());
+   names.reserve(output_schema.size());
+   for (const auto& [name, type] : output_schema) {
+      names.push_back(name);
+      auto found = assignment_by_name.find(name);
+      if (found == assignment_by_name.end()) {
+         // Column passed through unchanged from the child.
+         expressions.push_back(arrow::compute::field_ref(name));
+         continue;
+      }
+      expressions.push_back(std::visit(
+         [](const auto& expression) {
+            return arrow::compute::literal(arrow::Datum(expression.value));
+         },
+         found->second->expression
+      ));
+   }
+
+   const arrow::acero::ProjectNodeOptions options{std::move(expressions), std::move(names)};
+   ARROW_ASSIGN_OR_RAISE(
+      plan.top_node,
+      arrow::acero::MakeExecNode("project", plan.plan.get(), {plan.top_node}, options)
+   );
+   return plan;
+}
+
+}  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/map_node.h
+++ b/src/silo/query_engine/operators/map_node.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include <arrow/result.h>
+#include <arrow/scalar.h>
+
+#include "silo/query_engine/operators/query_node.h"
+#include "silo/schema/database_schema.h"
+#include "silo/storage/table.h"
+
+namespace silo::query_engine::operators {
+
+/// Extends its child's output with additional columns. Each added column is
+/// assigned a literal value (e.g. `x := 3`). All of the child's columns are
+/// passed through unchanged; an assignment whose output name matches an
+/// existing column replaces that column in place.
+class MapNode final : public QueryNode {
+  public:
+   /// A literal value assigned to a new column, e.g. `x := 3`.
+   struct Int64Literal {
+      int64_t value;
+   };
+   struct FloatLiteral {
+      double value;
+   };
+   struct StringLiteral {
+      std::string value;
+   };
+   struct BoolLiteral {
+      bool value;
+   };
+
+   struct Assignment {
+      schema::ColumnIdentifier output_column;
+      std::variant<Int64Literal, FloatLiteral, StringLiteral, BoolLiteral> expression;
+   };
+
+   QueryNodePtr child;
+   std::vector<Assignment> assignments;
+
+   MapNode(QueryNodePtr child, std::vector<Assignment> assignments);
+
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
+
+   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+      const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
+      const config::QueryOptions& query_options
+   ) const override;
+
+   [[nodiscard]] NodeKind kind() const override { return NodeKind::MAP; }
+};
+
+}  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/map_node.test.cpp
+++ b/src/silo/query_engine/operators/map_node.test.cpp
@@ -1,0 +1,94 @@
+#include <nlohmann/json.hpp>
+
+#include "silo/test/query_fixture.test.h"
+
+namespace {
+using silo::ReferenceGenomes;
+using silo::test::QueryTestData;
+using silo::test::QueryTestScenario;
+
+nlohmann::json createData(const std::string& primaryKey, int value) {
+   return {
+      {"primaryKey", primaryKey},
+      {"int_value", value},
+      {"segment1", nullptr},
+      {"gene1", nullptr},
+      {"unaligned_segment1", nullptr}
+   };
+}
+
+const std::vector<nlohmann::json> DATA = {createData("id_0", 1), createData("id_1", 2)};
+
+const auto DATABASE_CONFIG =
+   R"(
+defaultNucleotideSequence: "segment1"
+schema:
+  instanceName: "dummy name"
+  metadata:
+    - name: "primaryKey"
+      type: "string"
+    - name: "int_value"
+      type: "int"
+  primaryKey: "primaryKey"
+)";
+
+const auto REFERENCE_GENOMES = ReferenceGenomes{
+   {{"segment1", "A"}},
+   {{"gene1", "*"}},
+};
+
+const QueryTestData TEST_DATA{
+   .ndjson_input_data = DATA,
+   .database_config = DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES
+};
+
+// Assigns a literal of each supported type to a new column.
+const QueryTestScenario MAP_LITERALS_SCENARIO = {
+   .name = "MAP_LITERALS",
+   .query =
+      R"(default.map({a := 3, b := 1.5, c := 'hello', d := true}).project({primaryKey, a, b, c, d}))",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"a", 3}, {"b", 1.5}, {"c", "hello"}, {"d", true}},
+       {{"primaryKey", "id_1"}, {"a", 3}, {"b", 1.5}, {"c", "hello"}, {"d", true}}}
+   )
+};
+
+// An assignment whose name matches an existing column replaces it in place.
+const QueryTestScenario MAP_OVERRIDE_SCENARIO = {
+   .name = "MAP_OVERRIDE",
+   .query = "default.map({int_value := 42}).project({primaryKey, int_value})",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"int_value", 42}}, {{"primaryKey", "id_1"}, {"int_value", 42}}}
+   )
+};
+
+const QueryTestScenario MAP_INT64_SCENARIO = {
+   .name = "MAP_INT64",
+   .query = "default.map({x := 3000000000}).project({primaryKey, x})",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"x", 3000000000}}, {{"primaryKey", "id_1"}, {"x", 3000000000}}}
+   )
+};
+
+// All projected columns are produced by the map; none are passed through from
+// the child. The table scan must still emit one row per input record (a prior
+// bug narrowed the scan to zero fields and returned no rows).
+const QueryTestScenario MAP_ONLY_MAPPED_COLUMN_SCENARIO = {
+   .name = "MAP_ONLY_MAPPED_COLUMN",
+   .query = "default.map({a := 1}).project({a})",
+   .expected_query_result = nlohmann::json({{{"a", 1}}, {{"a", 1}}})
+};
+
+}  // namespace
+
+QUERY_TEST(
+   MapTest,
+   TEST_DATA,
+   ::testing::Values(
+      MAP_LITERALS_SCENARIO,
+      MAP_OVERRIDE_SCENARIO,
+      MAP_INT64_SCENARIO,
+      MAP_ONLY_MAPPED_COLUMN_SCENARIO
+   )
+);

--- a/src/silo/query_engine/operators/query_node.h
+++ b/src/silo/query_engine/operators/query_node.h
@@ -16,6 +16,7 @@ namespace silo::query_engine::operators {
 enum class NodeKind : uint8_t {
    AGGREGATE,
    PROJECT,
+   MAP,
    ORDER_BY,
    FETCH,
    FILTER,

--- a/src/silo/query_engine/planner.cpp
+++ b/src/silo/query_engine/planner.cpp
@@ -17,13 +17,13 @@ namespace silo::query_engine {
 namespace {
 
 arrow::Result<QueryPlan> planQueryOrError(
-   const silo::query_engine::operators::QueryNode& node,
+   const operators::QueryNode& node,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
    const config::QueryOptions& query_options,
    std::string_view request_id
 ) {
    ARROW_ASSIGN_OR_RAISE(auto partial_query_plan, node.toQueryPlan(tables, query_options));
-   return query_engine::QueryPlan::makeQueryPlan(
+   return QueryPlan::makeQueryPlan(
       partial_query_plan.plan, partial_query_plan.top_node, request_id
    );
 }

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -1,6 +1,7 @@
 #include "silo/query_engine/saneql/ast_to_query.h"
 
 #include <chrono>
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -8,6 +9,7 @@
 #include <variant>
 #include <vector>
 
+#include <arrow/scalar.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <re2/re2.h>
@@ -45,6 +47,7 @@
 #include "silo/query_engine/operators/aggregate_node.h"
 #include "silo/query_engine/operators/fetch_node.h"
 #include "silo/query_engine/operators/filter_node.h"
+#include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
@@ -450,7 +453,7 @@ FilterPtr handleNOf(const BoundArguments& args) {
 }
 
 template <typename SymbolType>
-typename filter::expressions::MutationProfile<SymbolType>::Mutation parseMutationRecord(
+filter::expressions::MutationProfile<SymbolType>::Mutation parseMutationRecord(
    const ast::RecordLiteral& record
 ) {
    uint32_t position_idx = 0;
@@ -865,6 +868,78 @@ operators::QueryNodePtr handleProject(
 }
 
 namespace {
+
+using operators::MapNode;
+
+/// Parses a single `name := value` assignment of a map() record. For now only
+/// literals (int, float, string, bool) are supported as the assigned value.
+MapNode::Assignment parseMapAssignment(const ast::RecordField& field) {
+   const auto& value = *field.value;
+
+   if (std::holds_alternative<ast::IntLiteral>(value.value)) {
+      const int64_t int_value = std::get<ast::IntLiteral>(value.value).value;
+      return {
+         .output_column = {.name = field.name, .type = schema::ColumnType::INT64},
+         .expression = MapNode::Int64Literal{.value = int_value}
+      };
+   }
+   if (std::holds_alternative<ast::FloatLiteral>(value.value)) {
+      const double float_value = std::get<ast::FloatLiteral>(value.value).value;
+      return {
+         .output_column = {.name = field.name, .type = schema::ColumnType::FLOAT},
+         .expression = MapNode::FloatLiteral{.value = float_value}
+      };
+   }
+   if (std::holds_alternative<ast::StringLiteral>(value.value)) {
+      const std::string string_value = std::get<ast::StringLiteral>(value.value).value;
+      return {
+         .output_column = {.name = field.name, .type = schema::ColumnType::STRING},
+         .expression = MapNode::StringLiteral{.value = string_value}
+      };
+   }
+   if (std::holds_alternative<ast::BoolLiteral>(value.value)) {
+      const bool bool_value = std::get<ast::BoolLiteral>(value.value).value;
+      return {
+         .output_column = {.name = field.name, .type = schema::ColumnType::BOOL},
+         .expression = MapNode::BoolLiteral{.value = bool_value}
+      };
+   }
+
+   throw IllegalQueryException(
+      "map() field '{}' must be assigned a literal value (int, float, string, or bool) at {}:{}",
+      field.name,
+      value.location.line,
+      value.location.column
+   );
+}
+
+}  // namespace
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr handleMap(
+   const BoundArguments& args,
+   const Tables& tables,
+   const ChildConverter& convert_child
+) {
+   const auto& expressions_argument = args.at("expressions");
+   CHECK_SILO_QUERY(
+      std::holds_alternative<ast::RecordLiteral>(expressions_argument.value),
+      "map() expects a record of assignments like {x := 3, y := age}"
+   );
+   const auto& record = std::get<ast::RecordLiteral>(expressions_argument.value);
+   CHECK_SILO_QUERY(!record.fields.empty(), "map() requires at least one assignment");
+
+   std::vector<operators::MapNode::Assignment> assignments;
+   assignments.reserve(record.fields.size());
+   for (const auto& field : record.fields) {
+      assignments.push_back(parseMapAssignment(field));
+   }
+
+   auto child = convert_child(args.at("input"), tables);
+   return std::make_unique<operators::MapNode>(std::move(child), std::move(assignments));
+}
+
+namespace {
 constexpr std::string_view NUCLEOTIDE_MUTATIONS_FUNCTION_NAME = "mutations";
 constexpr std::string_view AMINO_ACID_MUTATIONS_FUNCTION_NAME = "aminoAcidMutations";
 }  // namespace
@@ -1095,6 +1170,8 @@ FunctionRegistry::FunctionRegistry() {
    );
 
    registerFunction("project", {{pos("input"), pos("fields")}}, handleProject);
+
+   registerFunction("map", {{pos("input"), pos("expressions")}}, handleMap);
 
    auto mutations_sig = FunctionSignature{
       {pos("input"), named("minProportion"), named("sequenceNames", false), named("fields", false)}

--- a/src/silo/query_engine/saneql/ast_to_query.test.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.test.cpp
@@ -354,6 +354,48 @@ TEST(AstToQueryProject, fieldNotInSchemaThrows) {
    );
 }
 
+// --- map ---
+
+TEST(AstToQueryMap, expressionsNotRecordLiteralThrows) {
+   auto tables = makeTablesWithDefault();
+   EXPECT_THAT(
+      [&tables]() { (void)parseAndConvertToQueryTree("default.map(id)", tables); },
+      ThrowsMessage<IllegalQueryException>(
+         ::testing::HasSubstr("map() expects a record of assignments like {x := 3, y := age}")
+      )
+   );
+}
+
+TEST(AstToQueryMap, emptyBracesAreNotARecordLiteral) {
+   auto tables = makeTablesWithDefault();
+   EXPECT_THAT(
+      [&tables]() { (void)parseAndConvertToQueryTree("default.map({})", tables); },
+      ThrowsMessage<IllegalQueryException>(
+         ::testing::HasSubstr("map() expects a record of assignments like {x := 3, y := age}")
+      )
+   );
+}
+
+TEST(AstToQueryMap, fieldReferenceRejectedForNow) {
+   auto tables = makeTablesWithDefault();
+   EXPECT_THAT(
+      [&tables]() { (void)parseAndConvertToQueryTree("default.map({x := id})", tables); },
+      ThrowsMessage<IllegalQueryException>(
+         ::testing::HasSubstr("map() field 'x' must be assigned a literal value")
+      )
+   );
+}
+
+TEST(AstToQueryMap, unsupportedValueThrows) {
+   auto tables = makeTablesWithDefault();
+   EXPECT_THAT(
+      [&tables]() { (void)parseAndConvertToQueryTree("default.map({x := count()})", tables); },
+      ThrowsMessage<IllegalQueryException>(
+         ::testing::HasSubstr("map() field 'x' must be assigned a literal value")
+      )
+   );
+}
+
 // --- orderBy ---
 
 TEST(AstToQueryOrderBy, fieldUnsupportedTypeThrows) {

--- a/src/silo/storage/column/insertion_index.cpp
+++ b/src/silo/storage/column/insertion_index.cpp
@@ -72,7 +72,7 @@ size_t ThreeMerHash<SymbolType>::operator()(
 template <typename SymbolType>
 std::unique_ptr<roaring::Roaring> InsertionPosition<SymbolType>::searchWithThreeMerIndex(
    const std::vector<std::array<typename SymbolType::Symbol, 3>>& search_three_mers,
-   const re2::RE2& search_pattern
+   const RE2& search_pattern
 ) const {
    // We perform a k-way intersection between the candidate sets of insertion ids.
    // The candidate insertions are selected based on the 3-mers within the search pattern.
@@ -118,7 +118,7 @@ std::unique_ptr<roaring::Roaring> InsertionPosition<SymbolType>::searchWithThree
       if (next_insertion_id != current_insertion_id) {
          if (count == search_three_mers.size()) {
             const auto& insertion = insertions[current_insertion_id];
-            if (re2::RE2::FullMatch(insertion.value, search_pattern)) {
+            if (RE2::FullMatch(insertion.value, search_pattern)) {
                *result |= insertion.row_ids;
             }
          }
@@ -131,7 +131,7 @@ std::unique_ptr<roaring::Roaring> InsertionPosition<SymbolType>::searchWithThree
 
    if (count == search_three_mers.size()) {
       const auto& insertion = insertions[current_insertion_id];
-      if (re2::RE2::FullMatch(insertion.value, search_pattern)) {
+      if (RE2::FullMatch(insertion.value, search_pattern)) {
          *result |= insertion.row_ids;
       }
    }
@@ -141,12 +141,12 @@ std::unique_ptr<roaring::Roaring> InsertionPosition<SymbolType>::searchWithThree
 
 template <typename SymbolType>
 std::unique_ptr<roaring::Roaring> InsertionPosition<SymbolType>::searchWithRegex(
-   const re2::RE2& regex_search_pattern
+   const RE2& regex_search_pattern
 ) const {
    auto result = std::make_unique<roaring::Roaring>();
-   for (const auto& insertion : insertions) {
-      if (re2::RE2::FullMatch(insertion.value, regex_search_pattern)) {
-         *result |= insertion.row_ids;
+   for (const auto& [value, row_ids] : insertions) {
+      if (RE2::FullMatch(value, regex_search_pattern)) {
+         *result |= row_ids;
       }
    }
    return result;
@@ -175,7 +175,7 @@ void InsertionPosition<Nucleotide>::buildThreeMerIndex() {
          for (const Nucleotide::Symbol symbol2 : Nucleotide::SYMBOLS) {
             for (const Nucleotide::Symbol symbol3 : Nucleotide::SYMBOLS) {
                if (unique_three_mers[symbol1][symbol2][symbol3]) {
-                  const std::array<Nucleotide::Symbol, 3> tuple{symbol1, symbol2, symbol3};
+                  const std::array tuple{symbol1, symbol2, symbol3};
                   three_mer_index.emplace(tuple, InsertionIds{})
                      .first->second.push_back(insertion_id);
                }
@@ -207,7 +207,7 @@ void InsertionPosition<AminoAcid>::buildThreeMerIndex() {
          for (const AminoAcid::Symbol symbol2 : AminoAcid::SYMBOLS) {
             for (const AminoAcid::Symbol symbol3 : AminoAcid::SYMBOLS) {
                if (unique_three_mers[symbol1][symbol2][symbol3]) {
-                  const std::array<AminoAcid::Symbol, 3> tuple{symbol1, symbol2, symbol3};
+                  const std::array tuple{symbol1, symbol2, symbol3};
                   three_mer_index.emplace(tuple, InsertionIds{})
                      .first->second.push_back(insertion_id);
                }
@@ -222,7 +222,7 @@ std::unique_ptr<roaring::Roaring> InsertionPosition<SymbolType>::search(
    const std::string& search_pattern
 ) const {
    const auto search_three_mers = extractThreeMers<SymbolType>(search_pattern);
-   const re2::RE2 regex_search_pattern(search_pattern);
+   const RE2 regex_search_pattern(search_pattern);
 
    if (!search_three_mers.empty()) {
       // We can only use the ThreeMerIndex if there is at least one 3-mer in the search pattern
@@ -235,7 +235,7 @@ template <typename SymbolType>
 void InsertionIndex<SymbolType>::addLazily(
    uint32_t position_idx,
    const std::string& insertion,
-   uint32_t row_id
+   const uint32_t row_id
 ) {
    auto& insertions_at_position =
       collected_insertions


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1285

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This adds a very limited map-operator to saneql. It is good to have this in the language, because it allows adding more generic expression support more easily with a smaller change set. Adding scalar expressions will be most intuitive in the map operator

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
