### PR TITLE
feat(preprocessing)!: remove deprecated preprocessing config and database config values

### DIFF
--- a/src/silo/config/database_config.cpp
+++ b/src/silo/config/database_config.cpp
@@ -96,17 +96,6 @@ bool YAML::convert<silo::config::DatabaseSchema>::decode(
 ) {
    schema.instance_name = node["instanceName"].as<std::string>();
    schema.primary_key = node["primaryKey"].as<std::string>();
-   // DEPRECATED: TODO(#737) fully remove them after the next major release
-   if (node["dateToSortBy"].IsDefined()) {
-      SPDLOG_WARN(
-         "DatabaseConfig field `dateToSortBy` is deprecated and will be removed in future releases."
-      );
-   }
-   if (node["partitionBy"].IsDefined()) {
-      SPDLOG_WARN(
-         "DatabaseConfig field `partitionBy` is deprecated and will be removed in future releases."
-      );
-   }
 
    if (!node["metadata"].IsSequence()) {
       return false;

--- a/src/silo/config/preprocessing_config.cpp
+++ b/src/silo/config/preprocessing_config.cpp
@@ -2,8 +2,6 @@
 
 #include <filesystem>
 
-#include <spdlog/spdlog.h>
-
 #include "config/config_interface.h"
 #include "silo/config/config_defaults.h"
 #include "silo/preprocessing/preprocessing_exception.h"
@@ -44,16 +42,6 @@ ConfigKeyPath ndjsonInputFilenameOptionKey() {
 }
 ConfigKeyPath withoutUnalignedSequencesOptionKey() {
    return YamlFile::stringToConfigKeyPath("withoutUnalignedSequences");
-}
-// DEPRECATED: TODO(#737) fully remove them after the next major release
-ConfigKeyPath intermediateResultsDirectoryOptionKey() {
-   return YamlFile::stringToConfigKeyPath("intermediateResultsDirectory");
-}
-ConfigKeyPath preprocessingDatabaseLocationOptionKey() {
-   return YamlFile::stringToConfigKeyPath("preprocessingDatabaseLocation");
-}
-ConfigKeyPath duckdbMemoryLimitInGTimeOptionKey() {
-   return YamlFile::stringToConfigKeyPath("duckdbMemoryLimitInG");
 }
 }  // namespace
 
@@ -117,16 +105,6 @@ ConfigSpecification PreprocessingConfig::getConfigSpecification() {
             withoutUnalignedSequencesOptionKey(),
             ConfigValue::fromBool(false),
             "Whether unaligned sequences should be omitted for each aligned nucleotide sequence."
-         ),
-         // DEPRECATED: TODO(#737) fully remove after next major release
-         ConfigAttributeSpecification::createWithoutDefault(
-            intermediateResultsDirectoryOptionKey(), ConfigValueType::PATH, "DEPRECATED."
-         ),
-         ConfigAttributeSpecification::createWithoutDefault(
-            preprocessingDatabaseLocationOptionKey(), ConfigValueType::PATH, "DEPRECATED."
-         ),
-         ConfigAttributeSpecification::createWithoutDefault(
-            duckdbMemoryLimitInGTimeOptionKey(), ConfigValueType::UINT32, "DEPRECATED."
          )
       }
    };
@@ -170,24 +148,6 @@ void PreprocessingConfig::overwriteFrom(const VerifiedConfigAttributes& config_s
    }
    if (auto var = config_source.getPath(ndjsonInputFilenameOptionKey())) {
       input_file = var.value();
-   }
-   if (auto var = config_source.getPath(intermediateResultsDirectoryOptionKey())) {
-      SPDLOG_WARN(
-         "The config value {} is deprecated. This will lead to errors in future versions.",
-         YamlFile::configKeyPathToString(intermediateResultsDirectoryOptionKey())
-      );
-   }
-   if (auto var = config_source.getPath(preprocessingDatabaseLocationOptionKey())) {
-      SPDLOG_WARN(
-         "The config value {} is deprecated. This will lead to errors in future versions.",
-         YamlFile::configKeyPathToString(preprocessingDatabaseLocationOptionKey())
-      );
-   }
-   if (auto var = config_source.getUint32(duckdbMemoryLimitInGTimeOptionKey())) {
-      SPDLOG_WARN(
-         "The config value {} is deprecated. This will lead to errors in future versions.",
-         YamlFile::configKeyPathToString(duckdbMemoryLimitInGTimeOptionKey())
-      );
    }
 }
 

--- a/src/silo/config/preprocessing_config.test.cpp
+++ b/src/silo/config/preprocessing_config.test.cpp
@@ -33,14 +33,11 @@ TEST(PreprocessingConfig, shouldReadConfigWithOverriddenDefaults) {
    config.overwriteFrom(YamlFile::fromYAML("inline", R"(
 inputDirectory: "./testBaseData/exampleDataset/"
 outputDirectory: "./output/custom/"
-intermediateResultsDirectory: "./output/overriddenTemp/"
 ndjsonInputFilename: "input_file.ndjson"
 lineageDefinitionFilenames:
   - "lineage_definition.yaml"
 phyloTreeFilename: "phylogenetic_tree.yaml"
-referenceGenomeFilename: "reference_genomes.json"
-preprocessingDatabaseLocation: "preprocessing.duckdb"
-duckdbMemoryLimitInG: 8)")
+referenceGenomeFilename: "reference_genomes.json")")
                            .verify(PreprocessingConfig::getConfigSpecification()));
 
    const std::filesystem::path input_directory = "./testBaseData/exampleDataset/";


### PR DESCRIPTION
resolves #737

### Summary
BREAKING CHANGE: remove deprecated preprocessing config values `intermediateResultsDirectory`, `preprocessingDatabaseLocation`, `duckdbMemoryLimitInG` and database config values `dateToSortBy`, `partitionBy`

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
