### PR TITLE
feat(silo): add references to input fields in `.map(...)` expressions

### DIFF
--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -133,10 +133,10 @@ Sequence data columns use the naming convention `<sequenceName>` for aligned seq
 
 ### `map(expressions)`
 
-Adds columns to the table. `expressions` is a record of `name := value` assignments. For now only literal values are supported: integers, floats, strings (single-quoted), and booleans.
+Adds columns to the table. `expressions` is a record of `name := value` assignments. For now only field references and the following literal values are supported: integers, floats, strings (single-quoted), and booleans.
 
 ```
-default.map({x := 3, label := 'cohort A', active := true})
+default.map({x := 3, label := 'cohort A', active := true, copy := country})
 ```
 
 All input columns are passed through unchanged and the new columns are appended. An assignment whose name matches an existing column replaces that column in place.
@@ -144,7 +144,7 @@ All input columns are passed through unchanged and the new columns are appended.
 **Output:** one row per input row containing all input columns plus the assigned columns. Integer literals become `INT32` (or `INT64` when out of `INT32` range), floats become `FLOAT`, single-quoted literals become `STRING`, and `true`/`false` become `BOOL`.
 
 ```json
-{"primary_key": "key_31", "x": 3, "label": "cohort A", "active": true}
+{"primary_key": "key_31", "x": 3, "label": "cohort A", "active": true, "copy": "Switzerland"}
 ```
 
 ### `orderBy(fields)`

--- a/src/silo/query_engine/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/column_narrowing_pass.cpp
@@ -109,8 +109,10 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::ZstdDecompres
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::MapNode& node) {
    // A map keeps all of its child's columns and adds (or replaces) some via
-   // literal assignments. Literal assignments need nothing from the child, so
-   // only the required pass-through columns must still be provided by it.
+   // scalar assignments. The child must still provide the required pass-through
+   // columns, plus any column referenced by an assignment (e.g. `y := age`):
+   // the map projects every assignment, so a referenced column is needed even if
+   // the assigned output column is not required downstream.
    RequiredColumns child_required;
    for (const auto& required_column : required) {
       const bool produced_by_map =
@@ -119,6 +121,13 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::MapNode& node
          });
       if (!produced_by_map) {
          child_required.push_back(required_column);
+      }
+   }
+   for (const auto& assignment : node.assignments) {
+      for (auto& referenced_column : assignment.expression->freeIUs()) {
+         if (std::ranges::find(child_required, referenced_column) == child_required.end()) {
+            child_required.push_back(std::move(referenced_column));
+         }
       }
    }
    if (child_required.empty()) {

--- a/src/silo/query_engine/expressions/expression.h
+++ b/src/silo/query_engine/expressions/expression.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "silo/query_engine/filter/operators/operator.h"
 #include "silo/schema/database_schema.h"
@@ -27,6 +28,12 @@ class Expression {
    [[nodiscard]] virtual schema::ColumnType type() const { return schema::ColumnType::BOOL; }
 
    [[nodiscard]] virtual std::string toString() const = 0;
+
+   /// The columns ("identifiable units") this expression references and that an
+   /// upstream node must therefore provide. Literals reference none; a column
+   /// reference yields that column. Used by column narrowing to keep the child
+   /// columns a scalar expression depends on alive.
+   [[nodiscard]] virtual std::vector<schema::ColumnIdentifier> freeIUs() const { return {}; }
 
    [[nodiscard]] virtual std::unique_ptr<Expression> rewrite(
       const storage::Table& table,

--- a/src/silo/query_engine/expressions/field_ref.cpp
+++ b/src/silo/query_engine/expressions/field_ref.cpp
@@ -1,0 +1,37 @@
+#include "silo/query_engine/expressions/field_ref.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "silo/common/panic.h"
+#include "silo/query_engine/filter/operators/operator.h"
+
+namespace silo::query_engine::expressions {
+
+FieldRef::FieldRef(schema::ColumnIdentifier column)
+    : column(std::move(column)) {}
+
+std::string FieldRef::toString() const {
+   return column.name;
+}
+
+std::vector<schema::ColumnIdentifier> FieldRef::freeIUs() const {
+   return {column};
+}
+
+std::unique_ptr<Expression> FieldRef::rewrite(
+   const storage::Table& /*table*/,
+   AmbiguityMode /*mode*/
+) const {
+   return std::make_unique<FieldRef>(column);
+}
+
+std::unique_ptr<filter::operators::Operator> FieldRef::compile(const storage::Table& /*table*/
+) const {
+   // A column reference is a scalar value, not a filter predicate.
+   SILO_UNIMPLEMENTED();
+}
+
+}  // namespace silo::query_engine::expressions

--- a/src/silo/query_engine/expressions/field_ref.h
+++ b/src/silo/query_engine/expressions/field_ref.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "silo/query_engine/expressions/expression.h"
+#include "silo/query_engine/filter/operators/operator.h"
+#include "silo/schema/database_schema.h"
+
+namespace silo::query_engine::expressions {
+
+/// References an existing column by name. As a scalar expression it evaluates to
+/// that column's value per row, e.g. `y := age`; its type() is the referenced
+/// column's type. It is not a filter predicate, so it cannot be compile()d into a
+/// filter operator.
+class FieldRef : public Expression {
+  public:
+   schema::ColumnIdentifier column;
+
+   explicit FieldRef(schema::ColumnIdentifier column);
+
+   [[nodiscard]] schema::ColumnType type() const override { return column.type; }
+
+   [[nodiscard]] std::string toString() const override;
+
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
+   [[nodiscard]] std::unique_ptr<Expression> rewrite(
+      const storage::Table& table,
+      AmbiguityMode mode
+   ) const override;
+
+   [[nodiscard]] std::unique_ptr<filter::operators::Operator> compile(const storage::Table& table
+   ) const override;
+};
+
+}  // namespace silo::query_engine::expressions

--- a/src/silo/query_engine/operators/map_node.cpp
+++ b/src/silo/query_engine/operators/map_node.cpp
@@ -9,6 +9,7 @@
 #include <arrow/datum.h>
 #include <nlohmann/json_fwd.hpp>
 
+#include "silo/query_engine/expressions/field_ref.h"
 #include "silo/query_engine/expressions/literal.h"
 
 namespace silo::query_engine::operators {
@@ -16,8 +17,8 @@ namespace silo::query_engine::operators {
 namespace {
 
 /// Translates a scalar expression into an Arrow compute expression for use in a
-/// projection. Only literals are currently supported; non-literal scalar expressions
-/// need to be evaluated against the column store first.
+/// projection. Literals and column references are supported; a boolean filter
+/// predicate would need to be evaluated against the column store first.
 arrow::Result<arrow::compute::Expression> scalarToArrowExpression(
    const expressions::Expression& expression
 ) {
@@ -32,6 +33,9 @@ arrow::Result<arrow::compute::Expression> scalarToArrowExpression(
    }
    if (const auto* literal = dynamic_cast<const expressions::BoolLiteral*>(&expression)) {
       return arrow::compute::literal(arrow::Datum(literal->value));
+   }
+   if (const auto* field_ref = dynamic_cast<const expressions::FieldRef*>(&expression)) {
+      return arrow::compute::field_ref(field_ref->column.name);
    }
    return arrow::Status::NotImplemented(
       "non-literal scalar expressions are not yet supported in map() assignments"

--- a/src/silo/query_engine/operators/map_node.test.cpp
+++ b/src/silo/query_engine/operators/map_node.test.cpp
@@ -71,6 +71,15 @@ const QueryTestScenario MAP_INT64_SCENARIO = {
    )
 };
 
+// A column reference assigns an existing column's value to a new column.
+const QueryTestScenario MAP_FIELD_REF_SCENARIO = {
+   .name = "MAP_FIELD_REF",
+   .query = "default.map({copied := int_value}).project({primaryKey, copied})",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"copied", 1}}, {{"primaryKey", "id_1"}, {"copied", 2}}}
+   )
+};
+
 // All projected columns are produced by the map; none are passed through from
 // the child. The table scan must still emit one row per input record (a prior
 // bug narrowed the scan to zero fields and returned no rows).
@@ -89,6 +98,7 @@ QUERY_TEST(
       MAP_LITERALS_SCENARIO,
       MAP_OVERRIDE_SCENARIO,
       MAP_INT64_SCENARIO,
+      MAP_FIELD_REF_SCENARIO,
       MAP_ONLY_MAPPED_COLUMN_SCENARIO
    )
 );

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -22,6 +22,7 @@
 #include "silo/query_engine/expressions/exact.h"
 #include "silo/query_engine/expressions/expression.h"
 #include "silo/query_engine/expressions/false.h"
+#include "silo/query_engine/expressions/field_ref.h"
 #include "silo/query_engine/expressions/float_between.h"
 #include "silo/query_engine/expressions/float_equals.h"
 #include "silo/query_engine/expressions/has_mutation.h"
@@ -856,10 +857,32 @@ namespace {
 
 using operators::MapNode;
 
-/// Parses a single `name := value` assignment of a map() record. For now only
-/// literals (int, float, string, bool) are supported as the assigned value.
-MapNode::Assignment parseMapAssignment(const ast::RecordField& field) {
+/// Parses a single `name := value` assignment of a map() record. The assigned
+/// value may be a literal (int, float, string, bool) or a reference to an
+/// existing column of the input (resolved against `child_schema`).
+MapNode::Assignment parseMapAssignment(
+   const ast::RecordField& field,
+   const std::vector<schema::ColumnIdentifier>& child_schema
+) {
    const auto& [value, location] = *field.value;
+
+   if (std::holds_alternative<ast::Identifier>(value)) {
+      const auto& name = std::get<ast::Identifier>(value).name;
+      auto found =
+         std::ranges::find_if(child_schema, [&](const auto& col) { return col.name == name; });
+      CHECK_SILO_QUERY(
+         found != child_schema.end(),
+         "map() field '{}' references unknown column '{}' at {}:{}",
+         field.name,
+         name,
+         location.line,
+         location.column
+      );
+      return {
+         .output_column = {.name = field.name, .type = found->type},
+         .expression = std::make_unique<expressions::FieldRef>(*found)
+      };
+   }
 
    if (std::holds_alternative<ast::IntLiteral>(value)) {
       const int64_t int_value = std::get<ast::IntLiteral>(value).value;
@@ -891,7 +914,8 @@ MapNode::Assignment parseMapAssignment(const ast::RecordField& field) {
    }
 
    throw IllegalQueryException(
-      "map() field '{}' must be assigned a literal value (int, float, string, or bool) at {}:{}",
+      "map() field '{}' must be assigned a literal value (int, float, string, or bool) or a "
+      "column reference at {}:{}",
       field.name,
       location.line,
       location.column
@@ -914,13 +938,15 @@ operators::QueryNodePtr handleMap(
    const auto& record = std::get<ast::RecordLiteral>(expressions_argument.value);
    CHECK_SILO_QUERY(!record.fields.empty(), "map() requires at least one assignment");
 
+   auto child = convert_child(args.at("input"), tables);
+   const auto child_schema = child->getOutputSchema();
+
    std::vector<operators::MapNode::Assignment> assignments;
    assignments.reserve(record.fields.size());
    for (const auto& field : record.fields) {
-      assignments.push_back(parseMapAssignment(field));
+      assignments.push_back(parseMapAssignment(field, child_schema));
    }
 
-   auto child = convert_child(args.at("input"), tables);
    return std::make_unique<operators::MapNode>(std::move(child), std::move(assignments));
 }
 

--- a/src/silo/query_engine/saneql/ast_to_query.test.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.test.cpp
@@ -377,12 +377,17 @@ TEST(AstToQueryMap, emptyBracesAreNotARecordLiteral) {
    );
 }
 
-TEST(AstToQueryMap, fieldReferenceRejectedForNow) {
+TEST(AstToQueryMap, fieldReferenceResolvesToColumn) {
+   auto tables = makeTablesWithDefault();
+   EXPECT_NO_THROW((void)parseAndConvertToQueryTree("default.map({x := id})", tables));
+}
+
+TEST(AstToQueryMap, fieldReferenceToUnknownColumnThrows) {
    auto tables = makeTablesWithDefault();
    EXPECT_THAT(
-      [&tables]() { (void)parseAndConvertToQueryTree("default.map({x := id})", tables); },
+      [&tables]() { (void)parseAndConvertToQueryTree("default.map({x := nope})", tables); },
       ThrowsMessage<IllegalQueryException>(
-         ::testing::HasSubstr("map() field 'x' must be assigned a literal value")
+         ::testing::HasSubstr("map() field 'x' references unknown column 'nope'")
       )
    );
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1291

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This adds a `FieldRef` expression to the map node.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
