### PR TITLE
ci: add to changelog and to release notes when serialization version changed

### DIFF
--- a/.github/scripts/annotate-changelog-serialization-version.sh
+++ b/.github/scripts/annotate-changelog-serialization-version.sh
@@ -2,12 +2,10 @@
 
 set -euo pipefail
 
-# Annotate CHANGELOG.md with a serialization version change note.
+# Check whether the serialization version changed since the last release,
+# and if so, annotate CHANGELOG.md on the release branch and commit+push.
 #
-# Compares the serialization version file between the latest release tag
-# and origin/main. If it changed, inserts a warning section into the
-# CHANGELOG.md entry for the given release version and commits+pushes
-# the change.
+# Delegates the actual changelog modification to insert-serialization-version-note.sh.
 #
 # Usage:
 #   ./annotate-changelog-serialization-version.sh --branch=<release-branch> --version=<release-version>
@@ -15,6 +13,8 @@ set -euo pipefail
 # Environment:
 #   SERIALIZATION_VERSION_FILE  path inside the repo (default: src/silo/common/serialization_version.txt)
 #   DRY_RUN                     if "true", skip commit+push (useful for local testing)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 SERIALIZATION_VERSION_FILE="${SERIALIZATION_VERSION_FILE:-src/silo/common/serialization_version.txt}"
 DRY_RUN="${DRY_RUN:-false}"
@@ -59,26 +59,7 @@ fi
 
 echo "Serialization version changed: $OLD_VER -> $NEW_VER"
 
-# Guard: skip if note already present in CHANGELOG.md for this version
-if grep -q "### ⚠ Serialization Version Changed" CHANGELOG.md; then
-  echo "Serialization version note already present in CHANGELOG.md, skipping"
-  exit 0
-fi
-
-# Insert note after the version heading for this release.
-ESCAPED_VERSION="${VERSION//./\\.}"
-awk -v ver="$ESCAPED_VERSION" '
-  /^## \[/ && $0 ~ "^## \\[" ver "\\]" && !done {
-    print
-    print ""
-    print "### ⚠ Serialization Version Changed"
-    print ""
-    print "The serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed."
-    done=1
-    next
-  }
-  {print}
-' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
+"${SCRIPT_DIR}/insert-serialization-version-note.sh" --version="$VERSION"
 
 if [ "$DRY_RUN" = "true" ]; then
   echo "DRY_RUN: would commit and push CHANGELOG.md changes"

--- a/.github/scripts/annotate-changelog-serialization-version.sh
+++ b/.github/scripts/annotate-changelog-serialization-version.sh
@@ -16,7 +16,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-SERIALIZATION_VERSION_FILE="${SERIALIZATION_VERSION_FILE:-src/silo/common/serialization_version.txt}"
 DRY_RUN="${DRY_RUN:-false}"
 
 BRANCH=""
@@ -49,15 +48,9 @@ fi
 
 echo "Previous tag: $PREV_TAG"
 
-OLD_VER=$(git show "${PREV_TAG}:${SERIALIZATION_VERSION_FILE}" 2>/dev/null || echo "unknown")
-NEW_VER=$(git show "origin/main:${SERIALIZATION_VERSION_FILE}" 2>/dev/null || echo "unknown")
-
-if [ "$OLD_VER" = "$NEW_VER" ]; then
-  echo "Serialization version unchanged ($OLD_VER), skipping"
+if ! "${SCRIPT_DIR}/detect-serialization-version-change.sh" --old-ref="$PREV_TAG" --new-ref="origin/main"; then
   exit 0
 fi
-
-echo "Serialization version changed: $OLD_VER -> $NEW_VER"
 
 "${SCRIPT_DIR}/insert-serialization-version-note.sh" --version="$VERSION" \
   < CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md

--- a/.github/scripts/annotate-changelog-serialization-version.sh
+++ b/.github/scripts/annotate-changelog-serialization-version.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Annotate CHANGELOG.md with a serialization version change note.
+#
+# Compares the serialization version file between the latest release tag
+# and origin/main. If it changed, inserts a warning section into the
+# CHANGELOG.md entry for the given release version and commits+pushes
+# the change.
+#
+# Usage:
+#   ./annotate-changelog-serialization-version.sh --branch=<release-branch> --version=<release-version>
+#
+# Environment:
+#   SERIALIZATION_VERSION_FILE  path inside the repo (default: src/silo/common/serialization_version.txt)
+#   DRY_RUN                     if "true", skip commit+push (useful for local testing)
+
+SERIALIZATION_VERSION_FILE="${SERIALIZATION_VERSION_FILE:-src/silo/common/serialization_version.txt}"
+DRY_RUN="${DRY_RUN:-false}"
+
+BRANCH=""
+VERSION=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --branch=*) BRANCH="${arg#--branch=}" ;;
+    --version=*) VERSION="${arg#--version=}" ;;
+    *) echo "Unknown argument: $arg"; exit 1 ;;
+  esac
+done
+
+if [ -z "$BRANCH" ] || [ -z "$VERSION" ]; then
+  echo "Usage: $0 --branch=<release-branch> --version=<release-version>"
+  exit 1
+fi
+
+echo "Release PR branch: $BRANCH, version: $VERSION"
+
+git fetch origin "$BRANCH"
+git checkout -B "$BRANCH" "origin/$BRANCH"
+git fetch --tags
+
+PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | head -1)
+if [ -z "$PREV_TAG" ]; then
+  echo "No previous release tag found, skipping"
+  exit 0
+fi
+
+echo "Previous tag: $PREV_TAG"
+
+OLD_VER=$(git show "${PREV_TAG}:${SERIALIZATION_VERSION_FILE}" 2>/dev/null || echo "unknown")
+NEW_VER=$(git show "origin/main:${SERIALIZATION_VERSION_FILE}" 2>/dev/null || echo "unknown")
+
+if [ "$OLD_VER" = "$NEW_VER" ]; then
+  echo "Serialization version unchanged ($OLD_VER), skipping"
+  exit 0
+fi
+
+echo "Serialization version changed: $OLD_VER -> $NEW_VER"
+
+# Guard: skip if note already present in CHANGELOG.md for this version
+if grep -q "### ⚠ Serialization Version Changed" CHANGELOG.md; then
+  echo "Serialization version note already present in CHANGELOG.md, skipping"
+  exit 0
+fi
+
+# Insert note after the version heading for this release.
+ESCAPED_VERSION="${VERSION//./\\.}"
+awk -v ver="$ESCAPED_VERSION" '
+  /^## \[/ && $0 ~ "^## \\[" ver "\\]" && !done {
+    print
+    print ""
+    print "### ⚠ Serialization Version Changed"
+    print ""
+    print "The serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed."
+    done=1
+    next
+  }
+  {print}
+' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo "DRY_RUN: would commit and push CHANGELOG.md changes"
+  exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git add CHANGELOG.md
+git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
+git commit -m "chore: annotate changelog with serialization version change"
+git push origin "$BRANCH"

--- a/.github/scripts/annotate-changelog-serialization-version.sh
+++ b/.github/scripts/annotate-changelog-serialization-version.sh
@@ -3,41 +3,38 @@
 set -euo pipefail
 
 # Check whether the serialization version changed since the last release,
-# and if so, annotate CHANGELOG.md on the release branch and commit+push.
+# and if so, annotate CHANGELOG.md and commit+push to the release branch.
 #
 # Delegates the actual text modification to insert-serialization-version-note.sh.
+# Commits and pushes to the currently checked-out branch (HEAD).
 #
 # Usage:
-#   ./annotate-changelog-serialization-version.sh --branch=<release-branch> --version=<release-version>
+#   ./annotate-changelog-serialization-version.sh --version=<release-version>
 #
 # Environment:
 #   SERIALIZATION_VERSION_FILE  path inside the repo (default: src/silo/common/serialization_version.txt)
 #   DRY_RUN                     if "true", skip commit+push (useful for local testing)
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(unset CDPATH; cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 DRY_RUN="${DRY_RUN:-false}"
 
-BRANCH=""
 VERSION=""
 
 for arg in "$@"; do
   case "$arg" in
-    --branch=*) BRANCH="${arg#--branch=}" ;;
     --version=*) VERSION="${arg#--version=}" ;;
     *) echo "Unknown argument: $arg"; exit 1 ;;
   esac
 done
 
-if [ -z "$BRANCH" ] || [ -z "$VERSION" ]; then
-  echo "Usage: $0 --branch=<release-branch> --version=<release-version>"
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 --version=<release-version>"
   exit 1
 fi
 
-echo "Release PR branch: $BRANCH, version: $VERSION"
+echo "Release version: $VERSION"
 
-git fetch origin "$BRANCH"
-git checkout -B "$BRANCH" "origin/$BRANCH"
 git fetch --tags
 
 PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | head -1)
@@ -65,4 +62,4 @@ git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 git add CHANGELOG.md
 git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
 git commit -m "chore: annotate changelog with serialization version change"
-git push origin "$BRANCH"
+git push origin HEAD

--- a/.github/scripts/annotate-changelog-serialization-version.sh
+++ b/.github/scripts/annotate-changelog-serialization-version.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Check whether the serialization version changed since the last release,
 # and if so, annotate CHANGELOG.md on the release branch and commit+push.
 #
-# Delegates the actual changelog modification to insert-serialization-version-note.sh.
+# Delegates the actual text modification to insert-serialization-version-note.sh.
 #
 # Usage:
 #   ./annotate-changelog-serialization-version.sh --branch=<release-branch> --version=<release-version>
@@ -59,7 +59,8 @@ fi
 
 echo "Serialization version changed: $OLD_VER -> $NEW_VER"
 
-"${SCRIPT_DIR}/insert-serialization-version-note.sh" --version="$VERSION"
+"${SCRIPT_DIR}/insert-serialization-version-note.sh" --version="$VERSION" \
+  < CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
 
 if [ "$DRY_RUN" = "true" ]; then
   echo "DRY_RUN: would commit and push CHANGELOG.md changes"

--- a/.github/scripts/annotate-changelog-serialization-version.sh
+++ b/.github/scripts/annotate-changelog-serialization-version.sh
@@ -24,12 +24,12 @@ VERSION=""
 for arg in "$@"; do
   case "$arg" in
     --version=*) VERSION="${arg#--version=}" ;;
-    *) echo "Unknown argument: $arg"; exit 1 ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
 
 if [ -z "$VERSION" ]; then
-  echo "Usage: $0 --version=<release-version>"
+  echo "Usage: $0 --version=<release-version>" >&2
   exit 1
 fi
 

--- a/.github/scripts/annotate-release-serialization-version.sh
+++ b/.github/scripts/annotate-release-serialization-version.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 #   DRY_RUN                     if "true", print transformed body but skip gh release edit
 #   GITHUB_TOKEN                required for gh release view/edit (unless DRY_RUN)
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(unset CDPATH; cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 DRY_RUN="${DRY_RUN:-false}"
 
@@ -25,12 +25,12 @@ TAG=""
 for arg in "$@"; do
   case "$arg" in
     --tag=*) TAG="${arg#--tag=}" ;;
-    *) echo "Unknown argument: $arg"; exit 1 ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
 
 if [ -z "$TAG" ]; then
-  echo "Usage: $0 --tag=<release-tag>"
+  echo "Usage: $0 --tag=<release-tag>" >&2
   exit 1
 fi
 
@@ -63,7 +63,8 @@ if [ "$DRY_RUN" = "true" ]; then
 fi
 
 BODY=$(gh release view "$TAG" --json body -q '.body // ""')
-NEW_BODY=$(echo "$BODY" | "${SCRIPT_DIR}/insert-serialization-version-note.sh" --version="$VERSION")
+# printf '%s' (not echo) avoids adding a spurious trailing newline to the piped body.
+NEW_BODY=$(printf '%s' "$BODY" | "${SCRIPT_DIR}/insert-serialization-version-note.sh" --version="$VERSION")
 
 if [ "$BODY" = "$NEW_BODY" ]; then
   echo "Release body unchanged (note already present or heading not found), skipping"

--- a/.github/scripts/annotate-release-serialization-version.sh
+++ b/.github/scripts/annotate-release-serialization-version.sh
@@ -5,16 +5,18 @@ set -euo pipefail
 # Annotate a GitHub Release with a serialization version change note.
 #
 # Compares the serialization version file between the current release tag
-# and the previous release tag. If it changed, appends a warning section
-# to the GitHub Release body.
+# and the previous release tag. If it changed, inserts a warning note
+# into the GitHub Release body using insert-serialization-version-note.sh.
 #
 # Usage:
 #   ./annotate-release-serialization-version.sh --tag=<release-tag>
 #
 # Environment:
 #   SERIALIZATION_VERSION_FILE  path inside the repo (default: src/silo/common/serialization_version.txt)
-#   DRY_RUN                     if "true", print what would be appended but skip gh release edit
+#   DRY_RUN                     if "true", print transformed body but skip gh release edit
 #   GITHUB_TOKEN                required for gh release view/edit (unless DRY_RUN)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 SERIALIZATION_VERSION_FILE="${SERIALIZATION_VERSION_FILE:-src/silo/common/serialization_version.txt}"
 DRY_RUN="${DRY_RUN:-false}"
@@ -56,22 +58,24 @@ fi
 
 echo "Serialization version changed: $OLD_VER -> $NEW_VER"
 
-NOTE=$'\n---\n\n### ⚠ Serialization Version Changed\n\nThe serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed.'
+# Strip leading 'v' from tag to get numeric version for heading match
+VERSION="${TAG#v}"
 
 if [ "$DRY_RUN" = "true" ]; then
-  echo "DRY_RUN: would append to release $TAG:"
-  echo "$NOTE"
+  echo "DRY_RUN: would update release $TAG body to:"
+  echo "---"
+  echo "(cannot fetch release body without GITHUB_TOKEN)"
   exit 0
 fi
 
 BODY=$(gh release view "$TAG" --json body -q .body)
+NEW_BODY=$(echo "$BODY" | "${SCRIPT_DIR}/insert-serialization-version-note.sh" --version="$VERSION")
 
-# Guard: skip if note already present in release body
-if echo "$BODY" | grep -q "### ⚠ Serialization Version Changed"; then
-  echo "Serialization version note already present in release $TAG, skipping"
+if [ "$BODY" = "$NEW_BODY" ]; then
+  echo "Release body unchanged (note already present or heading not found), skipping"
   exit 0
 fi
 
-gh release edit "$TAG" --notes "${BODY}${NOTE}"
+gh release edit "$TAG" --notes "$NEW_BODY"
 
 echo "Annotated GitHub release $TAG with serialization version note"

--- a/.github/scripts/annotate-release-serialization-version.sh
+++ b/.github/scripts/annotate-release-serialization-version.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Annotate a GitHub Release with a serialization version change note.
+#
+# Compares the serialization version file between the current release tag
+# and the previous release tag. If it changed, appends a warning section
+# to the GitHub Release body.
+#
+# Usage:
+#   ./annotate-release-serialization-version.sh --tag=<release-tag>
+#
+# Environment:
+#   SERIALIZATION_VERSION_FILE  path inside the repo (default: src/silo/common/serialization_version.txt)
+#   DRY_RUN                     if "true", print what would be appended but skip gh release edit
+#   GITHUB_TOKEN                required for gh release view/edit (unless DRY_RUN)
+
+SERIALIZATION_VERSION_FILE="${SERIALIZATION_VERSION_FILE:-src/silo/common/serialization_version.txt}"
+DRY_RUN="${DRY_RUN:-false}"
+
+TAG=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --tag=*) TAG="${arg#--tag=}" ;;
+    *) echo "Unknown argument: $arg"; exit 1 ;;
+  esac
+done
+
+if [ -z "$TAG" ]; then
+  echo "Usage: $0 --tag=<release-tag>"
+  exit 1
+fi
+
+echo "Release tag: $TAG"
+
+git fetch --tags
+
+# Find the previous release tag (second newest v* tag)
+PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p')
+if [ -z "$PREV_TAG" ]; then
+  echo "No previous release tag found, skipping"
+  exit 0
+fi
+
+echo "Previous tag: $PREV_TAG"
+
+OLD_VER=$(git show "${PREV_TAG}:${SERIALIZATION_VERSION_FILE}" 2>/dev/null || echo "unknown")
+NEW_VER=$(git show "${TAG}:${SERIALIZATION_VERSION_FILE}" 2>/dev/null || echo "unknown")
+
+if [ "$OLD_VER" = "$NEW_VER" ]; then
+  echo "Serialization version unchanged ($OLD_VER), skipping"
+  exit 0
+fi
+
+echo "Serialization version changed: $OLD_VER -> $NEW_VER"
+
+NOTE=$'\n---\n\n### ⚠ Serialization Version Changed\n\nThe serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed.'
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo "DRY_RUN: would append to release $TAG:"
+  echo "$NOTE"
+  exit 0
+fi
+
+BODY=$(gh release view "$TAG" --json body -q .body)
+
+# Guard: skip if note already present in release body
+if echo "$BODY" | grep -q "### ⚠ Serialization Version Changed"; then
+  echo "Serialization version note already present in release $TAG, skipping"
+  exit 0
+fi
+
+gh release edit "$TAG" --notes "${BODY}${NOTE}"
+
+echo "Annotated GitHub release $TAG with serialization version note"

--- a/.github/scripts/annotate-release-serialization-version.sh
+++ b/.github/scripts/annotate-release-serialization-version.sh
@@ -18,7 +18,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-SERIALIZATION_VERSION_FILE="${SERIALIZATION_VERSION_FILE:-src/silo/common/serialization_version.txt}"
 DRY_RUN="${DRY_RUN:-false}"
 
 TAG=""
@@ -48,15 +47,9 @@ fi
 
 echo "Previous tag: $PREV_TAG"
 
-OLD_VER=$(git show "${PREV_TAG}:${SERIALIZATION_VERSION_FILE}" 2>/dev/null || echo "unknown")
-NEW_VER=$(git show "${TAG}:${SERIALIZATION_VERSION_FILE}" 2>/dev/null || echo "unknown")
-
-if [ "$OLD_VER" = "$NEW_VER" ]; then
-  echo "Serialization version unchanged ($OLD_VER), skipping"
+if ! "${SCRIPT_DIR}/detect-serialization-version-change.sh" --old-ref="$PREV_TAG" --new-ref="$TAG"; then
   exit 0
 fi
-
-echo "Serialization version changed: $OLD_VER -> $NEW_VER"
 
 # Strip leading 'v' from tag to get numeric version for heading match
 VERSION="${TAG#v}"

--- a/.github/scripts/annotate-release-serialization-version.sh
+++ b/.github/scripts/annotate-release-serialization-version.sh
@@ -14,7 +14,8 @@ set -euo pipefail
 # Environment:
 #   SERIALIZATION_VERSION_FILE  path inside the repo (default: src/silo/common/serialization_version.txt)
 #   DRY_RUN                     if "true", print transformed body but skip gh release edit
-#   GITHUB_TOKEN                required for gh release view/edit (unless DRY_RUN)
+#   GH_TOKEN                    required for gh release view/edit (unless DRY_RUN)
+#                               (GITHUB_TOKEN also works as a fallback)
 
 SCRIPT_DIR="$(unset CDPATH; cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/.github/scripts/annotate-release-serialization-version.sh
+++ b/.github/scripts/annotate-release-serialization-version.sh
@@ -40,7 +40,7 @@ git fetch --tags
 
 # Find the release tag immediately before $TAG in version order.
 # Tags are listed newest-first; the tag after $TAG in this list is its predecessor.
-PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n "/^${TAG}$/{ n; p; q; }")
+PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | awk -v tag="$TAG" 'found { print; exit } $0 == tag { found=1 }')
 if [ -z "$PREV_TAG" ]; then
   echo "No previous release tag found, skipping"
   exit 0

--- a/.github/scripts/annotate-release-serialization-version.sh
+++ b/.github/scripts/annotate-release-serialization-version.sh
@@ -38,8 +38,9 @@ echo "Release tag: $TAG"
 
 git fetch --tags
 
-# Find the previous release tag (second newest v* tag)
-PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p')
+# Find the release tag immediately before $TAG in version order.
+# Tags are listed newest-first; the tag after $TAG in this list is its predecessor.
+PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n "/^${TAG}$/{ n; p; q; }")
 if [ -z "$PREV_TAG" ]; then
   echo "No previous release tag found, skipping"
   exit 0
@@ -61,7 +62,7 @@ if [ "$DRY_RUN" = "true" ]; then
   exit 0
 fi
 
-BODY=$(gh release view "$TAG" --json body -q .body)
+BODY=$(gh release view "$TAG" --json body -q '.body // ""')
 NEW_BODY=$(echo "$BODY" | "${SCRIPT_DIR}/insert-serialization-version-note.sh" --version="$VERSION")
 
 if [ "$BODY" = "$NEW_BODY" ]; then

--- a/.github/scripts/detect-serialization-version-change.sh
+++ b/.github/scripts/detect-serialization-version-change.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Detect whether the serialization version changed between two git refs.
+#
+# Exits 0 if the version changed, exits 1 if unchanged (or if either ref
+# is missing the file). This convention allows callers to use:
+#
+#   if ./detect-serialization-version-change.sh --old-ref=v1.0.0 --new-ref=origin/main; then
+#     echo "changed"
+#   fi
+#
+# Usage:
+#   ./detect-serialization-version-change.sh --old-ref=<git-ref> --new-ref=<git-ref>
+#
+# Environment:
+#   SERIALIZATION_VERSION_FILE  path inside the repo (default: src/silo/common/serialization_version.txt)
+
+SERIALIZATION_VERSION_FILE="${SERIALIZATION_VERSION_FILE:-src/silo/common/serialization_version.txt}"
+
+OLD_REF=""
+NEW_REF=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --old-ref=*) OLD_REF="${arg#--old-ref=}" ;;
+    --new-ref=*) NEW_REF="${arg#--new-ref=}" ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$OLD_REF" ] || [ -z "$NEW_REF" ]; then
+  echo "Usage: $0 --old-ref=<git-ref> --new-ref=<git-ref>" >&2
+  exit 1
+fi
+
+OLD_VER=$(git show "${OLD_REF}:${SERIALIZATION_VERSION_FILE}" 2>/dev/null || echo "unknown")
+NEW_VER=$(git show "${NEW_REF}:${SERIALIZATION_VERSION_FILE}" 2>/dev/null || echo "unknown")
+
+if [ "$OLD_VER" = "$NEW_VER" ]; then
+  echo "Serialization version unchanged ($OLD_VER)"
+  exit 1
+fi
+
+echo "Serialization version changed: $OLD_VER -> $NEW_VER"
+exit 0

--- a/.github/scripts/detect-serialization-version-change.sh
+++ b/.github/scripts/detect-serialization-version-change.sh
@@ -35,8 +35,14 @@ if [ -z "$OLD_REF" ] || [ -z "$NEW_REF" ]; then
   exit 1
 fi
 
-OLD_VER=$(git show "${OLD_REF}:${SERIALIZATION_VERSION_FILE}" 2>/dev/null || echo "unknown")
-NEW_VER=$(git show "${NEW_REF}:${SERIALIZATION_VERSION_FILE}" 2>/dev/null || echo "unknown")
+OLD_VER=$(git show "${OLD_REF}:${SERIALIZATION_VERSION_FILE}" 2>/dev/null) || {
+  echo "Serialization version file not found at ref $OLD_REF, skipping"
+  exit 1
+}
+NEW_VER=$(git show "${NEW_REF}:${SERIALIZATION_VERSION_FILE}" 2>/dev/null) || {
+  echo "Serialization version file not found at ref $NEW_REF, skipping"
+  exit 1
+}
 
 if [ "$OLD_VER" = "$NEW_VER" ]; then
   echo "Serialization version unchanged ($OLD_VER)"

--- a/.github/scripts/insert-serialization-version-note.sh
+++ b/.github/scripts/insert-serialization-version-note.sh
@@ -27,12 +27,11 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
-INPUT=$(cat)
-
 # Insert note after the version heading, scoped to that version's section.
 # Idempotent: if the note already exists within the section, passes through unchanged.
+# awk reads stdin directly (not via a shell variable) to preserve trailing newlines.
 ESCAPED_VERSION="${VERSION//./\\.}"
-echo "$INPUT" | awk -v ver="$ESCAPED_VERSION" '
+awk -v ver="$ESCAPED_VERSION" '
   # Detect next version heading (end of target section) — must run before
   # the start-section check so the heading line does not immediately close itself.
   in_section && /^## \[/ {

--- a/.github/scripts/insert-serialization-version-note.sh
+++ b/.github/scripts/insert-serialization-version-note.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Insert a "Serialization Version Changed" note into a CHANGELOG.md file.
+#
+# Pure text transformation — no git, no network. Modifies the file in place.
+# Idempotent: exits successfully without changes if the note already exists.
+#
+# Usage:
+#   ./insert-serialization-version-note.sh --version=<release-version> --changelog=<path>
+#
+# The note is inserted directly after the "## [<version>]" heading.
+
+VERSION=""
+CHANGELOG="CHANGELOG.md"
+
+for arg in "$@"; do
+  case "$arg" in
+    --version=*) VERSION="${arg#--version=}" ;;
+    --changelog=*) CHANGELOG="${arg#--changelog=}" ;;
+    *) echo "Unknown argument: $arg"; exit 1 ;;
+  esac
+done
+
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 --version=<release-version> [--changelog=<path>]"
+  exit 1
+fi
+
+if [ ! -f "$CHANGELOG" ]; then
+  echo "Changelog file not found: $CHANGELOG"
+  exit 1
+fi
+
+# Guard: skip if note already present
+if grep -q "### ⚠ Serialization Version Changed" "$CHANGELOG"; then
+  echo "Serialization version note already present in $CHANGELOG, skipping"
+  exit 0
+fi
+
+# Insert note after the version heading for this release.
+ESCAPED_VERSION="${VERSION//./\\.}"
+awk -v ver="$ESCAPED_VERSION" '
+  /^## \[/ && $0 ~ "^## \\[" ver "\\]" && !done {
+    print
+    print ""
+    print "### ⚠ Serialization Version Changed"
+    print ""
+    print "The serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed."
+    done=1
+    next
+  }
+  {print}
+' "$CHANGELOG" > "${CHANGELOG}.tmp" && mv "${CHANGELOG}.tmp" "$CHANGELOG"
+
+echo "Inserted serialization version note into $CHANGELOG for version $VERSION"

--- a/.github/scripts/insert-serialization-version-note.sh
+++ b/.github/scripts/insert-serialization-version-note.sh
@@ -33,17 +33,16 @@ INPUT=$(cat)
 # Idempotent: if the note already exists within the section, passes through unchanged.
 ESCAPED_VERSION="${VERSION//./\\.}"
 echo "$INPUT" | awk -v ver="$ESCAPED_VERSION" '
+  # Detect next version heading (end of target section) — must run before
+  # the start-section check so the heading line does not immediately close itself.
+  in_section && /^## \[/ {
+    in_section=0
+  }
   # Match the target version heading
   /^## \[/ && $0 ~ "^## \\[" ver "\\]" && !found_version {
     found_version=1
     in_section=1
     version_line=NR
-    print
-    next
-  }
-  # Detect next version heading (end of target section)
-  in_section && /^## \[/ {
-    in_section=0
   }
   # If we find the note already in the section, mark as duplicate
   in_section && /^### ⚠ Serialization Version Changed/ {

--- a/.github/scripts/insert-serialization-version-note.sh
+++ b/.github/scripts/insert-serialization-version-note.sh
@@ -2,46 +2,43 @@
 
 set -euo pipefail
 
-# Insert a "Serialization Version Changed" note into a CHANGELOG.md file.
+# Insert a "Serialization Version Changed" note into release markdown.
 #
-# Pure text transformation — no git, no network. Modifies the file in place.
-# Idempotent: exits successfully without changes if the note already exists.
+# Pure stdin/stdout text transformation — no git, no network, no files.
+# Idempotent: passes input through unchanged if the note already exists.
 #
 # Usage:
-#   ./insert-serialization-version-note.sh --version=<release-version> --changelog=<path>
+#   cat CHANGELOG.md | ./insert-serialization-version-note.sh --version=<X.Y.Z>
+#   gh release view ... | ./insert-serialization-version-note.sh --version=<X.Y.Z>
 #
-# The note is inserted directly after the "## [<version>]" heading.
+# The note is inserted directly after the "## [<version>]" heading line.
 
 VERSION=""
-CHANGELOG="CHANGELOG.md"
 
 for arg in "$@"; do
   case "$arg" in
     --version=*) VERSION="${arg#--version=}" ;;
-    --changelog=*) CHANGELOG="${arg#--changelog=}" ;;
-    *) echo "Unknown argument: $arg"; exit 1 ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
 
 if [ -z "$VERSION" ]; then
-  echo "Usage: $0 --version=<release-version> [--changelog=<path>]"
+  echo "Usage: $0 --version=<release-version>" >&2
   exit 1
 fi
 
-if [ ! -f "$CHANGELOG" ]; then
-  echo "Changelog file not found: $CHANGELOG"
-  exit 1
-fi
+INPUT=$(cat)
 
-# Guard: skip if note already present
-if grep -q "### ⚠ Serialization Version Changed" "$CHANGELOG"; then
-  echo "Serialization version note already present in $CHANGELOG, skipping"
+# Guard: if note already present, pass through unchanged
+if echo "$INPUT" | grep -q "### ⚠ Serialization Version Changed"; then
+  echo "Serialization version note already present, skipping" >&2
+  echo "$INPUT"
   exit 0
 fi
 
-# Insert note after the version heading for this release.
+# Insert note after the version heading
 ESCAPED_VERSION="${VERSION//./\\.}"
-awk -v ver="$ESCAPED_VERSION" '
+echo "$INPUT" | awk -v ver="$ESCAPED_VERSION" '
   /^## \[/ && $0 ~ "^## \\[" ver "\\]" && !done {
     print
     print ""
@@ -52,6 +49,4 @@ awk -v ver="$ESCAPED_VERSION" '
     next
   }
   {print}
-' "$CHANGELOG" > "${CHANGELOG}.tmp" && mv "${CHANGELOG}.tmp" "$CHANGELOG"
-
-echo "Inserted serialization version note into $CHANGELOG for version $VERSION"
+'

--- a/.github/scripts/insert-serialization-version-note.sh
+++ b/.github/scripts/insert-serialization-version-note.sh
@@ -29,24 +29,41 @@ fi
 
 INPUT=$(cat)
 
-# Guard: if note already present, pass through unchanged
-if echo "$INPUT" | grep -q "### ⚠ Serialization Version Changed"; then
-  echo "Serialization version note already present, skipping" >&2
-  echo "$INPUT"
-  exit 0
-fi
-
-# Insert note after the version heading
+# Insert note after the version heading, scoped to that version's section.
+# Idempotent: if the note already exists within the section, passes through unchanged.
 ESCAPED_VERSION="${VERSION//./\\.}"
 echo "$INPUT" | awk -v ver="$ESCAPED_VERSION" '
-  /^## \[/ && $0 ~ "^## \\[" ver "\\]" && !done {
+  # Match the target version heading
+  /^## \[/ && $0 ~ "^## \\[" ver "\\]" && !found_version {
+    found_version=1
+    in_section=1
+    version_line=NR
     print
-    print ""
-    print "### ⚠ Serialization Version Changed"
-    print ""
-    print "The serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed."
-    done=1
     next
   }
-  {print}
+  # Detect next version heading (end of target section)
+  in_section && /^## \[/ {
+    in_section=0
+  }
+  # If we find the note already in the section, mark as duplicate
+  in_section && /^### ⚠ Serialization Version Changed/ {
+    already_present=1
+  }
+  {lines[NR]=$0}
+  END {
+    if (already_present || !found_version) {
+      # Pass through unchanged
+      for (i=1; i<=NR; i++) print lines[i]
+    } else {
+      for (i=1; i<=NR; i++) {
+        print lines[i]
+        if (i == version_line) {
+          print ""
+          print "### ⚠ Serialization Version Changed"
+          print ""
+          print "The serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed."
+        }
+      }
+    }
+  }
 '

--- a/.github/scripts/test-insert-serialization-version-note.sh
+++ b/.github/scripts/test-insert-serialization-version-note.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR}/insert-serialization-version-note.sh"
+
+PASSED=0
+FAILED=0
+
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $name"
+    PASSED=$((PASSED + 1))
+  else
+    echo "  FAIL: $name"
+    diff <(echo "$expected") <(echo "$actual") || true
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# --- Test 1: Normal insertion ---
+echo "Test 1: Normal insertion"
+INPUT='## [0.5.0](url)
+
+### Features
+* y
+
+## [0.4.0](url)
+
+### Features
+* x'
+
+EXPECTED='## [0.5.0](url)
+
+### ⚠ Serialization Version Changed
+
+The serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed.
+
+### Features
+* y
+
+## [0.4.0](url)
+
+### Features
+* x'
+
+OUTPUT=$(echo "$INPUT" | "$SCRIPT" --version=0.5.0)
+check "insert after 0.5.0 heading" "$EXPECTED" "$OUTPUT"
+
+# --- Test 2: Idempotency — note already in target section ---
+echo "Test 2: Idempotency (note already in 0.5.0 section)"
+INPUT='## [0.5.0](url)
+
+### ⚠ Serialization Version Changed
+
+Note.
+
+### Features
+* y'
+
+OUTPUT=$(echo "$INPUT" | "$SCRIPT" --version=0.5.0)
+check "no duplicate note" "$INPUT" "$OUTPUT"
+
+# --- Test 3: Note in older version only — should still insert into new ---
+echo "Test 3: Scoped guard (note in 0.4.0, insert into 0.5.0)"
+INPUT='## [0.5.0](url)
+
+### Features
+* y
+
+## [0.4.0](url)
+
+### ⚠ Serialization Version Changed
+
+Note.
+
+### Features
+* x'
+
+EXPECTED='## [0.5.0](url)
+
+### ⚠ Serialization Version Changed
+
+The serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed.
+
+### Features
+* y
+
+## [0.4.0](url)
+
+### ⚠ Serialization Version Changed
+
+Note.
+
+### Features
+* x'
+
+OUTPUT=$(echo "$INPUT" | "$SCRIPT" --version=0.5.0)
+check "insert into 0.5.0, preserve 0.4.0 note" "$EXPECTED" "$OUTPUT"
+
+# --- Test 4: Single section (release body format) ---
+echo "Test 4: Release body format"
+INPUT='## [0.11.3](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.11.2...v0.11.3) (2026-05-18)
+
+
+### Features
+
+* feature ([abc](url))'
+
+EXPECTED='## [0.11.3](https://github.com/GenSpectrum/LAPIS-SILO/compare/v0.11.2...v0.11.3) (2026-05-18)
+
+### ⚠ Serialization Version Changed
+
+The serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed.
+
+
+### Features
+
+* feature ([abc](url))'
+
+OUTPUT=$(echo "$INPUT" | "$SCRIPT" --version=0.11.3)
+check "insert into release body" "$EXPECTED" "$OUTPUT"
+
+# --- Test 5: No matching version — passthrough ---
+echo "Test 5: No matching version heading"
+INPUT='## [0.5.0](url)
+
+### Features
+* y'
+
+OUTPUT=$(echo "$INPUT" | "$SCRIPT" --version=0.9.0)
+check "passthrough unchanged" "$INPUT" "$OUTPUT"
+
+# --- Summary ---
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,10 @@ jobs:
             exit 0
           fi
 
+          git fetch origin "$BRANCH"
+          git checkout -B "$BRANCH" "origin/$BRANCH"
+
           ./.github/scripts/annotate-changelog-serialization-version.sh \
-            --branch="$BRANCH" \
             --version="$VERSION"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,50 +59,9 @@ jobs:
             exit 0
           fi
 
-          echo "Release PR branch: $BRANCH, version: $VERSION"
-
-          git fetch origin "$BRANCH"
-          git checkout "$BRANCH"
-          git fetch --tags
-
-          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | head -1)
-          if [ -z "$PREV_TAG" ]; then
-            echo "No previous release tag found, skipping"
-            exit 0
-          fi
-
-          OLD_VER=$(git show "${PREV_TAG}:src/silo/common/serialization_version.txt" 2>/dev/null || echo "unknown")
-          NEW_VER=$(git show "origin/main:src/silo/common/serialization_version.txt" 2>/dev/null || echo "unknown")
-
-          if [ "$OLD_VER" = "$NEW_VER" ]; then
-            echo "Serialization version unchanged ($OLD_VER), skipping"
-            exit 0
-          fi
-
-          echo "Serialization version changed: $OLD_VER -> $NEW_VER"
-
-          # Insert note after the version heading for this release.
-          # Use awk to insert after the line matching the version heading.
-          ESCAPED_VERSION=$(echo "$VERSION" | sed 's/\./\\./g')
-          awk -v ver="$ESCAPED_VERSION" '
-            /^## \[/ && $0 ~ "^## \\[" ver "\\]" && !done {
-              print
-              print ""
-              print "### ⚠ Serialization Version Changed"
-              print ""
-              print "The serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed."
-              done=1
-              next
-            }
-            {print}
-          ' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
-          git commit -m "chore: annotate changelog with serialization version change"
-          git push origin "$BRANCH"
+          ./.github/scripts/annotate-changelog-serialization-version.sh \
+            --branch="$BRANCH" \
+            --version="$VERSION"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -118,37 +77,8 @@ jobs:
           github.event_name == 'push'
           && steps.release.outputs.release_created == 'true'
         run: |
-          set -euo pipefail
-
-          TAG="${{ steps.release.outputs.tag_name }}"
-          echo "Release tag: $TAG"
-
-          git fetch --tags
-
-          # Find the previous release tag (second newest v* tag)
-          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p')
-          if [ -z "$PREV_TAG" ]; then
-            echo "No previous release tag found, skipping"
-            exit 0
-          fi
-
-          echo "Previous tag: $PREV_TAG"
-
-          OLD_VER=$(git show "${PREV_TAG}:src/silo/common/serialization_version.txt" 2>/dev/null || echo "unknown")
-          NEW_VER=$(git show "${TAG}:src/silo/common/serialization_version.txt" 2>/dev/null || echo "unknown")
-
-          if [ "$OLD_VER" = "$NEW_VER" ]; then
-            echo "Serialization version unchanged ($OLD_VER), skipping"
-            exit 0
-          fi
-
-          echo "Serialization version changed: $OLD_VER -> $NEW_VER"
-
-          BODY=$(gh release view "$TAG" --json body -q .body)
-          NOTE=$'\n---\n\n### ⚠ Serialization Version Changed\n\nThe serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed.'
-          gh release edit "$TAG" --notes "${BODY}${NOTE}"
-
-          echo "Annotated GitHub release $TAG with serialization version note"
+          ./.github/scripts/annotate-release-serialization-version.sh \
+            --tag="${{ steps.release.outputs.tag_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          PR_JSON='${{ steps.release.outputs.pr }}'
+          # PR_JSON is passed via the environment (see env: below) rather than
+          # interpolated into the script, so single quotes or other shell
+          # metacharacters in the payload cannot break parsing or inject commands.
           BRANCH=$(echo "$PR_JSON" | jq -r '.headBranchName // empty')
           VERSION=$(echo "$PR_JSON" | jq -r '.title // empty' | grep -oP '\d+\.\d+\.\d+' || true)
 
@@ -66,6 +68,7 @@ jobs:
             --version="$VERSION"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
 
       - uses: actions/checkout@v6
         if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           ./.github/scripts/annotate-release-serialization-version.sh \
             --tag="${{ steps.release.outputs.tag_name }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   dependencyImage:
     name: Build dependency image (${{ matrix.arch }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,122 @@ jobs:
           ${{ toJson(steps.release.outputs) }}
           EOF
 
+      - uses: actions/checkout@v6
+        if: >-
+          github.event_name == 'push'
+          && steps.release.outputs.prs_created == 'true'
+        with:
+          fetch-depth: 0
+
+      - name: Annotate changelog with serialization version change
+        if: >-
+          github.event_name == 'push'
+          && steps.release.outputs.prs_created == 'true'
+        run: |
+          set -euo pipefail
+
+          PR_JSON='${{ steps.release.outputs.pr }}'
+          BRANCH=$(echo "$PR_JSON" | jq -r '.headBranchName')
+          VERSION=$(echo "$PR_JSON" | jq -r '.title' | grep -oP '\d+\.\d+\.\d+')
+
+          if [ -z "$BRANCH" ] || [ -z "$VERSION" ]; then
+            echo "Could not determine branch ($BRANCH) or version ($VERSION), skipping"
+            exit 0
+          fi
+
+          echo "Release PR branch: $BRANCH, version: $VERSION"
+
+          git fetch origin "$BRANCH"
+          git checkout "$BRANCH"
+          git fetch --tags
+
+          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous release tag found, skipping"
+            exit 0
+          fi
+
+          OLD_VER=$(git show "${PREV_TAG}:src/silo/common/serialization_version.txt" 2>/dev/null || echo "unknown")
+          NEW_VER=$(git show "origin/main:src/silo/common/serialization_version.txt" 2>/dev/null || echo "unknown")
+
+          if [ "$OLD_VER" = "$NEW_VER" ]; then
+            echo "Serialization version unchanged ($OLD_VER), skipping"
+            exit 0
+          fi
+
+          echo "Serialization version changed: $OLD_VER -> $NEW_VER"
+
+          # Insert note after the version heading for this release.
+          # Use awk to insert after the line matching the version heading.
+          ESCAPED_VERSION=$(echo "$VERSION" | sed 's/\./\\./g')
+          awk -v ver="$ESCAPED_VERSION" '
+            /^## \[/ && $0 ~ "^## \\[" ver "\\]" && !done {
+              print
+              print ""
+              print "### ⚠ Serialization Version Changed"
+              print ""
+              print "The serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed."
+              done=1
+              next
+            }
+            {print}
+          ' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
+          git commit -m "chore: annotate changelog with serialization version change"
+          git push origin "$BRANCH"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v6
+        if: >-
+          github.event_name == 'push'
+          && steps.release.outputs.release_created == 'true'
+        with:
+          fetch-depth: 0
+
+      - name: Annotate GitHub release with serialization version change
+        if: >-
+          github.event_name == 'push'
+          && steps.release.outputs.release_created == 'true'
+        run: |
+          set -euo pipefail
+
+          TAG="${{ steps.release.outputs.tag_name }}"
+          echo "Release tag: $TAG"
+
+          git fetch --tags
+
+          # Find the previous release tag (second newest v* tag)
+          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p')
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous release tag found, skipping"
+            exit 0
+          fi
+
+          echo "Previous tag: $PREV_TAG"
+
+          OLD_VER=$(git show "${PREV_TAG}:src/silo/common/serialization_version.txt" 2>/dev/null || echo "unknown")
+          NEW_VER=$(git show "${TAG}:src/silo/common/serialization_version.txt" 2>/dev/null || echo "unknown")
+
+          if [ "$OLD_VER" = "$NEW_VER" ]; then
+            echo "Serialization version unchanged ($OLD_VER), skipping"
+            exit 0
+          fi
+
+          echo "Serialization version changed: $OLD_VER -> $NEW_VER"
+
+          BODY=$(gh release view "$TAG" --json body -q .body)
+          NOTE=$'\n---\n\n### ⚠ Serialization Version Changed\n\nThe serialization version changed in this release. Databases serialized with previous SILO versions are incompatible and need to be re-preprocessed.'
+          gh release edit "$TAG" --notes "${BODY}${NOTE}"
+
+          echo "Annotated GitHub release $TAG with serialization version note"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   dependencyImage:
     name: Build dependency image (${{ matrix.arch }})
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
           set -euo pipefail
 
           PR_JSON='${{ steps.release.outputs.pr }}'
-          BRANCH=$(echo "$PR_JSON" | jq -r '.headBranchName')
-          VERSION=$(echo "$PR_JSON" | jq -r '.title' | grep -oP '\d+\.\d+\.\d+')
+          BRANCH=$(echo "$PR_JSON" | jq -r '.headBranchName // empty')
+          VERSION=$(echo "$PR_JSON" | jq -r '.title // empty' | grep -oP '\d+\.\d+\.\d+' || true)
 
           if [ -z "$BRANCH" ] || [ -z "$VERSION" ]; then
             echo "Could not determine branch ($BRANCH) or version ($VERSION), skipping"


### PR DESCRIPTION

resolves #1224

### Summary

Adds two CI steps to the `release-please` job in `ci.yml` that automatically detect serialization version changes and surface them in release notes:

1. **Annotate CHANGELOG.md on the release PR branch** — After release-please creates/updates its PR, compares `serialization_version.txt` between the latest release tag and `origin/main`. If changed, commits a "⚠ Serialization Version Changed" section into `CHANGELOG.md` on the release branch.

2. **Annotate the GitHub Release** — After the release PR is merged, appends the same note to the GitHub Release body via `gh release edit`.

Both steps are no-ops when the serialization version hasn't changed.

### Why this approach

Release-please has no plugin/hook system for injecting custom content into the changelog — it only derives changelog entries from conventional commit messages. The available extension points (`changelog-sections`, strategies, updaters) don't support file-diff-based annotations.

We considered requiring developers to use a specific commit message format (e.g. `feat(serialization): ...`) when bumping the serialization version, but this is error-prone — bumps are often bundled into feature commits and would be silently missed.

Instead, this approach detects the change automatically by comparing the `serialization_version.txt` file between releases. It runs *after* release-please force-pushes its branch, so the note is re-applied on every update cycle and doesn't interfere with release-please's operation.

## PR Checklist

- [x] All necessary documentation has been adapted or there is an issue to do so.
- [ ] ~~The implemented feature is covered by an appropriate test.~~
