### PR TITLE
docs: improve documentation to include named argument examples in groupBy expression

### DIFF
--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -102,8 +102,8 @@ Aggregates rows, producing counts or other aggregate values. `aggregates` is a r
 Currently supported aggregate function: `count()`.
 
 ```
-default.groupBy({count:=count()})
-default.groupBy({count:=count()}, {pango_lineage})
+default.groupBy(aggregates:={count:=count()})
+default.groupBy(aggregates:={count:=count()}, columns:={pango_lineage})
 default.groupBy({count:=count()}, {country, pango_lineage})
 ```
 


### PR DESCRIPTION
When showing the front-end documentation to @chaoran-chen I noticed these examples could be improved