### PR TITLE
feat: add `unionAll` operator to SaneQL queries

### DIFF
--- a/.agents/skills/query-silo/SKILL.md
+++ b/.agents/skills/query-silo/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: query-silo
+description: >
+  Query a locally running SILO instance using queryLocalSilo.sh. Use when user says
+  "query silo", "run query", "test query", "try this query", or wants to
+  execute a SaneQL query against the local API.
+---
+
+## How to query
+
+Use `queryLocalSilo.sh` (in this skill's directory) to send SaneQL queries to the local SILO API (port 8081):
+
+```bash
+.agents/skills/query-silo/queryLocalSilo.sh "default.groupBy({count:=count()})"
+```
+
+The script sends a `POST /query` with `Content-Type: text/plain` and prints the NDJSON response followed by the HTTP status code.
+
+### Status code only
+
+```bash
+.agents/skills/query-silo/queryLocalSilo.sh -s "default.filter(country='CH').project({primaryKey})"
+```
+
+### Query language
+
+Queries use **SaneQL**. Common patterns:
+
+```
+default                                          -- full table scan
+default.filter(column='value')                   -- filter rows
+default.project({col1, col2})                    -- select columns
+default.groupBy({count:=count()}, {col})         -- aggregate
+default.map({new_col := expression})             -- add computed column
+default.orderBy({asc(col)})                      -- sort
+default.mutations(minProportion:=0.5)            -- nucleotide mutations
+unionAll(pipeline1, pipeline2)                   -- concatenate two pipelines
+```
+
+Chaining: `default.filter(...).project({...}).groupBy({...}).orderBy({...})`
+
+### Error responses
+
+On error, the response body contains `{"error": "...", "message": "..."}` with a non-200 status code.
+
+### Notes
+
+- The API must be running on port 8081 before querying.
+- Response format is NDJSON (one JSON object per line).
+- Always quote the query string to prevent shell expansion of `{}` and `()`.
+- SILO instance contains dummy dataset with 100 sequences.
+  Database config (schema definition) is in `testBaseData/exampleDataset/database_config.yaml`. 

--- a/.agents/skills/query-silo/queryLocalSilo.sh
+++ b/.agents/skills/query-silo/queryLocalSilo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Usage: ./query.sh "query"         — full output
-#        ./query.sh -s "query"      — status code only
+# Usage: ./queryLocalSilo.sh "query"         — full output
+#        ./queryLocalSilo.sh -s "query"      — status code only
 if [ "$1" = "-s" ]; then
   curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8081/query \
     -H 'Content-Type: text/plain' -d "$2"

--- a/.agents/skills/query-silo/queryLocalSilo.sh
+++ b/.agents/skills/query-silo/queryLocalSilo.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Usage: ./query.sh "query"         — full output
+#        ./query.sh -s "query"      — status code only
+if [ "$1" = "-s" ]; then
+  curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8081/query \
+    -H 'Content-Type: text/plain' -d "$2"
+else
+  curl -s -X POST http://localhost:8081/query \
+    -H 'Content-Type: text/plain' -w '\n%{http_code}\n' -d "$1"
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ C++23 high-performance genomic sequence indexing engine. Uses Arrow Acero for qu
 
 **Key Technologies:** C++23, CMake, Conan, GTest, spdlog, Arrow Acero, Boost, simdjson
 
+Documentation (for devs and users) in `documentation/`.
+
 ## Build & Test
 
 ```bash

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -288,7 +288,7 @@ default.filter(pango_lineage = 'B.1.1.7').phyloSubtree('usherTree')
 
 Concatenates the output of two pipelines. `unionAll` can be called as a standalone function or with piped syntax:
 
-Both inputs must have the same schema (same column names and types). Column order does not matter — the right child is automatically reordered to match the left child's column order.
+Both inputs must have the same schema (same column names, types, and order).
 
 All rows from both inputs are included — duplicates are preserved (UNION ALL, not UNION).
 
@@ -353,7 +353,7 @@ unionAll(
 )
 ```
 
-**Output:** all rows from the left input followed by all rows from the right input, with the left input's column order.
+**Output:** all rows from both inputs. The order of rows is not guaranteed.
 
 ---
 

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -326,8 +326,25 @@ unionAll(
 
 **Restrictions:**
 
-- `.filter(...)` above a `unionAll` is not supported. Apply filters inside each child pipeline instead.
 - `mutations()`, `aminoAcidMutations()`, `insertions()`, and similar operators that require a table scan cannot be applied to the result of a `unionAll`. They can however be used inside each child.
+
+Filters above a `unionAll` are automatically pushed into both children:
+
+```
+unionAll(
+  default.project({primaryKey, country}),
+  default.project({primaryKey, country})
+).filter(country='CH')
+```
+
+is equivalent to:
+
+```
+unionAll(
+  default.filter(country='CH').project({primaryKey, country}),
+  default.filter(country='CH').project({primaryKey, country})
+)
+```
 
 **Output:** all rows from the left input followed by all rows from the right input, with the left input's column order.
 

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -20,10 +20,11 @@ The table name is `default` for now.
 
 Every operator takes a table as input and produces a table as output. Internally these tables are Apache Arrow record batches; externally they are streamed as NDJSON or Arrow IPC. The **response schema** — which fields are returned and their types — is always the output schema of the **last operator** in the pipeline.
 
-Operators fall into two categories:
+Operators fall into three categories:
 
 - **Schema-preserving** (`filter`, `orderBy`, `limit`, `offset`, `randomize`): pass all input columns through unchanged. They select or reorder rows but do not add, remove, or rename fields.
 - **Schema-defining** (`groupBy`, `project`, `map`, `mutations`, `aminoAcidMutations`, `insertions`, `aminoAcidInsertions`, `mostRecentCommonAncestor`, `phyloSubtree`): produce a changed output schema. Each operator's section below documents its output fields.
+- **Combining** (`unionAll`): takes two pipelines and concatenates their output. The output schema matches the children's schema.
 
 Simple example — count all sequences from Switzerland:
 
@@ -288,6 +289,47 @@ default.filter(pango_lineage = 'B.1.1.7').phyloSubtree('usherTree')
 ```json
 {"subtreeNewick": "((key_83:0.00027051)NODE_0000077:3.291e-05,(...)NODE_0000079:1e-06)NODE_0000076;", "missingNodeCount": 0}
 ```
+
+### `unionAll(left, right)`
+
+Concatenates the output of two pipelines. Unlike the other operators, `unionAll` is a **standalone function** — it is not chained on a single pipeline but takes two pipeline expressions as arguments.
+
+Both inputs must have the same schema (same column names and types). Column order does not matter — the right child is automatically reordered to match the left child's column order.
+
+All rows from both inputs are included — duplicates are preserved (UNION ALL, not UNION).
+
+```
+unionAll(
+  default.filter(division='Aargau').project({division}),
+  default.filter(division='Bern').project({division})
+)
+```
+
+The result can be piped into downstream operators:
+
+```
+unionAll(
+  default.filter(division='Aargau').project({division}),
+  default.filter(division='Bern').project({division})
+).groupBy({count:=count()}, {division})
+ .orderBy({asc(division)})
+```
+
+`unionAll` calls can be nested:
+
+```
+unionAll(
+  unionAll(pipelineA, pipelineB),
+  unionAll(pipelineC, pipelineD)
+)
+```
+
+**Restrictions:**
+
+- `.filter(...)` above a `unionAll` is not supported. Apply filters inside each child pipeline instead.
+- `mutations()`, `aminoAcidMutations()`, `insertions()`, and similar operators that require a table scan cannot be applied to the result of a `unionAll`. They can however be used inside each child.
+
+**Output:** all rows from the left input followed by all rows from the right input, with the left input's column order.
 
 ---
 
@@ -566,4 +608,14 @@ default
   .filter(aminoAcidInsertionContains(position:=214, value:='.*PE', sequenceName:='S'))
   .aminoAcidInsertions()
   .orderBy({insertedSymbols, position})
+```
+
+### Combine two filtered groups with unionAll
+
+```
+unionAll(
+  default.filter(division='Aargau').project({division}),
+  default.filter(division='Bern').project({division})
+).groupBy({count:=count()}, {division})
+ .orderBy({asc(division)})
 ```

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -20,12 +20,6 @@ The table name is `default` for now.
 
 Every operator takes a table as input and produces a table as output. Internally these tables are Apache Arrow record batches; externally they are streamed as NDJSON or Arrow IPC. The **response schema** — which fields are returned and their types — is always the output schema of the **last operator** in the pipeline.
 
-Operators fall into three categories:
-
-- **Schema-preserving** (`filter`, `orderBy`, `limit`, `offset`, `randomize`): pass all input columns through unchanged. They select or reorder rows but do not add, remove, or rename fields.
-- **Schema-defining** (`groupBy`, `project`, `map`, `mutations`, `aminoAcidMutations`, `insertions`, `aminoAcidInsertions`, `mostRecentCommonAncestor`, `phyloSubtree`): produce a changed output schema. Each operator's section below documents its output fields.
-- **Combining** (`unionAll`): takes two pipelines and concatenates their output. The output schema matches the children's schema.
-
 Simple example — count all sequences from Switzerland:
 
 ```

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -292,7 +292,7 @@ default.filter(pango_lineage = 'B.1.1.7').phyloSubtree('usherTree')
 
 ### `unionAll(left, right)`
 
-Concatenates the output of two pipelines. Unlike the other operators, `unionAll` is a **standalone function** — it is not chained on a single pipeline but takes two pipeline expressions as arguments.
+Concatenates the output of two pipelines. `unionAll` can be called as a standalone function or with piped syntax:
 
 Both inputs must have the same schema (same column names and types). Column order does not matter — the right child is automatically reordered to match the left child's column order.
 
@@ -303,6 +303,19 @@ unionAll(
   default.filter(division='Aargau').project({division}),
   default.filter(division='Bern').project({division})
 )
+```
+
+Or equivalently using piped syntax:
+
+```
+default.filter(division='Aargau').project({division})
+  .unionAll(default.filter(division='Bern').project({division}))
+```
+
+Named arguments are also supported:
+
+```
+unionAll(left := <pipeline1>, right := <pipeline2>)
 ```
 
 The result can be piped into downstream operators:

--- a/endToEndTests/test/queries/UnionAll.json
+++ b/endToEndTests/test/queries/UnionAll.json
@@ -1,0 +1,14 @@
+{
+  "testCaseName": "UnionAll of two filtered pipelines with groupBy",
+  "query": "unionAll(default.filter(division='Aargau').project({division}), default.filter(division='Bern').project({division})).groupBy({count:=count()},{division}).orderBy({asc(division)})",
+  "expectedQueryResult": [
+    {
+      "division": "Aargau",
+      "count": 6
+    },
+    {
+      "division": "Bern",
+      "count": 9
+    }
+  ]
+}

--- a/src/silo/query_engine/AGENTS.md
+++ b/src/silo/query_engine/AGENTS.md
@@ -10,19 +10,19 @@ SaneQL string
   → Parser (saneql/parser.cpp) → AST (saneql/ast.h)
   → ast_to_query.cpp → QueryNode tree (operators/*.h)
   → ColumnNarrowingPass → FilterPushdownPass → NodeResolutionPass
-  → toQueryPlan() → Arrow Acero ExecPlan (PartialArrowPlan)
+  → addToExecPlan() → Arrow Acero ExecPlan (single shared plan)
   → QueryPlan execution → send result
 ```
 
 ## Key Concepts
 
 - **QueryNode** (`operators/query_node.h`): Base class for all plan nodes.
-- **Optimization passes** run sequentially on the QueryNode tree before `toQueryPlan()`.
+- **Optimization passes** run sequentially on the QueryNode tree before `addToExecPlan()`.
 - **FunctionRegistry**: Maps SaneQL function names to handlers that produce QueryNode trees.
 
 ## Arrow Acero Lifecycle
 
-- Each `toQueryPlan()` creates its own `ExecPlan` via `ExecPlan::Make()` which uses a **global shared thread pool** (`threaded_exec_context()`).
+- The planner creates a single `ExecPlan` via `ExecPlan::Make()` and passes it to the root node's `addToExecPlan()`. All nodes add their exec nodes to this shared plan.
 - `SinkNodeOptions` takes a pointer to an `AsyncGenerator` that is populated when the plan runs.
 - After `StartProducing()`, drain the generator until it returns `nullopt`.
 - `StopProducing()` sets a cancelled flag; `plan->finished()` may then resolve with `Cancelled` status — this is normal, not an error.

--- a/src/silo/query_engine/AGENTS.md
+++ b/src/silo/query_engine/AGENTS.md
@@ -1,5 +1,8 @@
 # Query Engine
 
+Contains code for public query API.
+IMPORTANT: Changes here may require updates to query docs: `documentation/query_documentation.md`.
+
 ## Pipeline
 
 ```

--- a/src/silo/query_engine/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/column_narrowing_pass.cpp
@@ -191,8 +191,7 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr ColumnNarrowingPass::operator()(
-   operators::UnresolvedPhyloSubtreeNode& node
+operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedPhyloSubtreeNode& node
 ) {
    applyToChild(node.child, *this);
    return nullptr;
@@ -208,17 +207,13 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnionAllNode&
    return nullptr;
 }
 
-template operators::QueryNodePtr ColumnNarrowingPass::operator()(
-   operators::UnresolvedMutationsNode<silo::Nucleotide>&
-);
-template operators::QueryNodePtr ColumnNarrowingPass::operator()(
-   operators::UnresolvedMutationsNode<silo::AminoAcid>&
-);
-template operators::QueryNodePtr ColumnNarrowingPass::operator()(
-   operators::UnresolvedInsertionsNode<silo::Nucleotide>&
-);
-template operators::QueryNodePtr ColumnNarrowingPass::operator()(
-   operators::UnresolvedInsertionsNode<silo::AminoAcid>&
-);
+template operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedMutationsNode<
+                                                                 silo::Nucleotide>&);
+template operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedMutationsNode<
+                                                                 silo::AminoAcid>&);
+template operators::QueryNodePtr ColumnNarrowingPass::
+operator()(operators::UnresolvedInsertionsNode<silo::Nucleotide>&);
+template operators::QueryNodePtr ColumnNarrowingPass::
+operator()(operators::UnresolvedInsertionsNode<silo::AminoAcid>&);
 
 }  // namespace silo::query_engine

--- a/src/silo/query_engine/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/column_narrowing_pass.cpp
@@ -200,10 +200,10 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedPhy
 // NOLINTNEXTLINE(misc-no-recursion,readability-make-member-function-const)
 operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnionAllNode& node) {
    // Narrow columns in each child independently using the same required set.
-   for (auto& child : node.children) {
-      ColumnNarrowingPass child_pass(required);
-      applyToChild(child, child_pass);
-   }
+   ColumnNarrowingPass left_pass(required);
+   applyToChild(node.left, left_pass);
+   ColumnNarrowingPass right_pass(required);
+   applyToChild(node.right, right_pass);
    return nullptr;
 }
 

--- a/src/silo/query_engine/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/column_narrowing_pass.cpp
@@ -9,6 +9,7 @@
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/operators/unresolved_insertions_node.h"
+#include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/unresolved_mutations_node.h"
 #include "silo/query_engine/operators/unresolved_phylo_subtree_node.h"
@@ -193,6 +194,16 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(
 operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedPhyloSubtreeNode& node
 ) {
    applyToChild(node.child, *this);
+   return nullptr;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnionAllNode& node) {
+   // Narrow columns in each child independently using the same required set.
+   for (auto& child : node.children) {
+      ColumnNarrowingPass child_pass(required);
+      applyToChild(child, child_pass);
+   }
    return nullptr;
 }
 

--- a/src/silo/query_engine/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/column_narrowing_pass.cpp
@@ -197,7 +197,7 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedPhy
    return nullptr;
 }
 
-// NOLINTNEXTLINE(misc-no-recursion)
+// NOLINTNEXTLINE(misc-no-recursion,readability-make-member-function-const)
 operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnionAllNode& node) {
    // Narrow columns in each child independently using the same required set.
    for (auto& child : node.children) {

--- a/src/silo/query_engine/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/column_narrowing_pass.cpp
@@ -8,8 +8,8 @@
 #include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
-#include "silo/query_engine/operators/unresolved_insertions_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
+#include "silo/query_engine/operators/unresolved_insertions_node.h"
 #include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/unresolved_mutations_node.h"
 #include "silo/query_engine/operators/unresolved_phylo_subtree_node.h"
@@ -191,7 +191,8 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedPhyloSubtreeNode& node
+operators::QueryNodePtr ColumnNarrowingPass::operator()(
+   operators::UnresolvedPhyloSubtreeNode& node
 ) {
    applyToChild(node.child, *this);
    return nullptr;
@@ -207,13 +208,17 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnionAllNode&
    return nullptr;
 }
 
-template operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedMutationsNode<
-                                                                 silo::Nucleotide>&);
-template operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedMutationsNode<
-                                                                 silo::AminoAcid>&);
-template operators::QueryNodePtr ColumnNarrowingPass::
-operator()(operators::UnresolvedInsertionsNode<silo::Nucleotide>&);
-template operators::QueryNodePtr ColumnNarrowingPass::
-operator()(operators::UnresolvedInsertionsNode<silo::AminoAcid>&);
+template operators::QueryNodePtr ColumnNarrowingPass::operator()(
+   operators::UnresolvedMutationsNode<silo::Nucleotide>&
+);
+template operators::QueryNodePtr ColumnNarrowingPass::operator()(
+   operators::UnresolvedMutationsNode<silo::AminoAcid>&
+);
+template operators::QueryNodePtr ColumnNarrowingPass::operator()(
+   operators::UnresolvedInsertionsNode<silo::Nucleotide>&
+);
+template operators::QueryNodePtr ColumnNarrowingPass::operator()(
+   operators::UnresolvedInsertionsNode<silo::AminoAcid>&
+);
 
 }  // namespace silo::query_engine

--- a/src/silo/query_engine/column_narrowing_pass.h
+++ b/src/silo/query_engine/column_narrowing_pass.h
@@ -18,6 +18,7 @@ template <typename SymbolType>
 class UnresolvedMutationsNode;
 template <typename SymbolType>
 class UnresolvedInsertionsNode;
+class UnionAllNode;
 class UnresolvedMostRecentCommonAncestorNode;
 class UnresolvedPhyloSubtreeNode;
 }  // namespace silo::query_engine::operators
@@ -47,6 +48,7 @@ class ColumnNarrowingPass {
    operators::QueryNodePtr operator()(operators::UnresolvedInsertionsNode<SymbolType>& node);
    operators::QueryNodePtr operator()(operators::UnresolvedMostRecentCommonAncestorNode& node);
    operators::QueryNodePtr operator()(operators::UnresolvedPhyloSubtreeNode& node);
+   operators::QueryNodePtr operator()(operators::UnionAllNode& node);
 
    // Post-pushdown nodes are leaves that don't participate in column narrowing.
    template <typename T>

--- a/src/silo/query_engine/expressions/and.h
+++ b/src/silo/query_engine/expressions/and.h
@@ -23,6 +23,15 @@ class And : public Expression {
   public:
    explicit And(ExpressionVector&& children);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      ExpressionVector cloned;
+      cloned.reserve(children.size());
+      for (const auto& child : children) {
+         cloned.push_back(child->clone());
+      }
+      return std::make_unique<And>(std::move(cloned));
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::AND;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/bool_equals.h
+++ b/src/silo/query_engine/expressions/bool_equals.h
@@ -16,6 +16,10 @@ struct BoolEquals : public Expression {
   public:
    explicit BoolEquals(std::string column_name, std::optional<bool> value);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<BoolEquals>(column_name, value);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::BOOL_EQUALS;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/date_between.h
+++ b/src/silo/query_engine/expressions/date_between.h
@@ -29,6 +29,10 @@ class DateBetween : public Expression {
       std::optional<silo::common::Date32> date_to
    );
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<DateBetween>(column_name, date_from, date_to);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::DATE_BETWEEN;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/date_equals.h
+++ b/src/silo/query_engine/expressions/date_equals.h
@@ -18,6 +18,10 @@ class DateEquals : public Expression {
   public:
    explicit DateEquals(std::string column_name, std::optional<silo::common::Date32> value);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<DateEquals>(column_name, value);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::DATE_EQUALS;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/exact.h
+++ b/src/silo/query_engine/expressions/exact.h
@@ -14,6 +14,10 @@ class Exact : public Expression {
   public:
    explicit Exact(std::unique_ptr<Expression> child);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<Exact>(child->clone());
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::EXACT;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/expression.h
+++ b/src/silo/query_engine/expressions/expression.h
@@ -81,6 +81,8 @@ class Expression {
       AmbiguityMode mode
    ) const = 0;
 
+   [[nodiscard]] virtual std::unique_ptr<Expression> clone() const = 0;
+
    [[nodiscard]] virtual std::unique_ptr<filter::operators::Operator> compile(
       const storage::Table& table
    ) const = 0;

--- a/src/silo/query_engine/expressions/field_ref.h
+++ b/src/silo/query_engine/expressions/field_ref.h
@@ -22,6 +22,10 @@ class FieldRef : public Expression {
 
    [[nodiscard]] schema::ColumnType type() const override { return column.type; }
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<FieldRef>(column);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::FIELD_REF;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/float_between.h
+++ b/src/silo/query_engine/expressions/float_between.h
@@ -22,6 +22,10 @@ class FloatBetween : public Expression {
       std::optional<double> to
    );
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<FloatBetween>(column_name, from, to);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::FLOAT_BETWEEN;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/float_equals.h
+++ b/src/silo/query_engine/expressions/float_equals.h
@@ -16,6 +16,10 @@ class FloatEquals : public Expression {
   public:
    FloatEquals(std::string column_name, std::optional<double> value);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<FloatEquals>(column_name, value);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::FLOAT_EQUALS;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/has_mutation.h
+++ b/src/silo/query_engine/expressions/has_mutation.h
@@ -25,6 +25,10 @@ class HasMutation : public Expression {
   public:
    explicit HasMutation(std::optional<std::string> sequence_name, uint32_t position_idx);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<HasMutation>(sequence_name, position_idx);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = std::is_same_v<SymbolType, Nucleotide>
                                    ? Kind::HAS_MUTATION_NUCLEOTIDE

--- a/src/silo/query_engine/expressions/insertion_contains.h
+++ b/src/silo/query_engine/expressions/insertion_contains.h
@@ -30,6 +30,10 @@ class InsertionContains : public Expression {
       std::string value
    );
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<InsertionContains>(sequence_name, position_idx, value);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = std::is_same_v<SymbolType, Nucleotide>
                                    ? Kind::INSERTION_CONTAINS_NUCLEOTIDE

--- a/src/silo/query_engine/expressions/int_between.h
+++ b/src/silo/query_engine/expressions/int_between.h
@@ -25,6 +25,10 @@ class IntBetween : public Expression {
       std::optional<int32_t> to
    );
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<IntBetween>(column_name, from, to);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::INT_BETWEEN;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/int_equals.h
+++ b/src/silo/query_engine/expressions/int_equals.h
@@ -19,6 +19,10 @@ class IntEquals : public Expression {
   public:
    explicit IntEquals(std::string column_name, std::optional<int32_t> value);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<IntEquals>(column_name, value);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::INT_EQUALS;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/is_null.h
+++ b/src/silo/query_engine/expressions/is_null.h
@@ -15,6 +15,10 @@ class IsNull : public Expression {
   public:
    explicit IsNull(std::string column_name);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<IsNull>(column_name);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::IS_NULL;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/lineage_filter.h
+++ b/src/silo/query_engine/expressions/lineage_filter.h
@@ -22,6 +22,10 @@ class LineageFilter : public Expression {
       std::optional<silo::common::RecombinantEdgeFollowingMode> sublineage_mode
    );
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<LineageFilter>(column_name, lineage, sublineage_mode);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::LINEAGE_FILTER;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/literal.h
+++ b/src/silo/query_engine/expressions/literal.h
@@ -26,6 +26,10 @@ class Int64Literal : public Expression {
    static constexpr Kind KIND = Kind::INT64_LITERAL;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<Int64Literal>(value);
+   }
+
    [[nodiscard]] std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
@@ -47,6 +51,10 @@ class FloatLiteral : public Expression {
 
    static constexpr Kind KIND = Kind::FLOAT_LITERAL;
    [[nodiscard]] Kind kind() const override { return KIND; }
+
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<FloatLiteral>(value);
+   }
 
    [[nodiscard]] std::string toString() const override;
 
@@ -70,6 +78,10 @@ class StringLiteral : public Expression {
    static constexpr Kind KIND = Kind::STRING_LITERAL;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<StringLiteral>(value);
+   }
+
    [[nodiscard]] std::string toString() const override;
 
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
@@ -91,6 +103,10 @@ class BoolLiteral : public Expression {
 
    static constexpr Kind KIND = Kind::BOOL_LITERAL;
    [[nodiscard]] Kind kind() const override { return KIND; }
+
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<BoolLiteral>(value);
+   }
 
    [[nodiscard]] std::string toString() const override;
 

--- a/src/silo/query_engine/expressions/maybe.h
+++ b/src/silo/query_engine/expressions/maybe.h
@@ -16,6 +16,10 @@ class Maybe : public Expression {
   public:
    explicit Maybe(std::unique_ptr<Expression> child);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<Maybe>(child->clone());
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::MAYBE;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/mutation_profile.h
+++ b/src/silo/query_engine/expressions/mutation_profile.h
@@ -69,6 +69,10 @@ class MutationProfile : public Expression {
       ProfileInput input
    );
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<MutationProfile>(sequence_name, distance, input);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = std::is_same_v<SymbolType, Nucleotide>
                                    ? Kind::MUTATION_PROFILE_NUCLEOTIDE

--- a/src/silo/query_engine/expressions/negation.h
+++ b/src/silo/query_engine/expressions/negation.h
@@ -19,6 +19,10 @@ class Negation : public Expression {
   public:
    explicit Negation(std::unique_ptr<Expression> child);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<Negation>(child->clone());
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::NEGATION;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/nof.h
+++ b/src/silo/query_engine/expressions/nof.h
@@ -32,6 +32,15 @@ class NOf : public Expression {
   public:
    explicit NOf(ExpressionVector&& children, int number_of_matchers, bool match_exactly);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      ExpressionVector cloned;
+      cloned.reserve(children.size());
+      for (const auto& child : children) {
+         cloned.push_back(child->clone());
+      }
+      return std::make_unique<NOf>(std::move(cloned), number_of_matchers, match_exactly);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::N_OF;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/or.h
+++ b/src/silo/query_engine/expressions/or.h
@@ -14,6 +14,15 @@ class Or : public Expression {
   public:
    explicit Or(ExpressionVector&& children);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      ExpressionVector cloned;
+      cloned.reserve(children.size());
+      for (const auto& child : children) {
+         cloned.push_back(child->clone());
+      }
+      return std::make_unique<Or>(std::move(cloned));
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::OR;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/phylo_child_filter.h
+++ b/src/silo/query_engine/expressions/phylo_child_filter.h
@@ -15,6 +15,10 @@ class PhyloChildFilter : public Expression {
   public:
    explicit PhyloChildFilter(std::string column_name, std::string internal_node);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<PhyloChildFilter>(column_name, internal_node);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::PHYLO_CHILD_FILTER;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/string_equals.h
+++ b/src/silo/query_engine/expressions/string_equals.h
@@ -16,6 +16,10 @@ class StringEquals : public Expression {
   public:
    explicit StringEquals(std::string column_name, std::optional<std::string> value);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<StringEquals>(column_name, value);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::STRING_EQUALS;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/string_in_set.h
+++ b/src/silo/query_engine/expressions/string_in_set.h
@@ -21,6 +21,10 @@ class StringInSet : public Expression {
   public:
    explicit StringInSet(std::string column_name, std::unordered_set<std::string> value);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<StringInSet>(column_name, values);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::STRING_IN_SET;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/string_search.h
+++ b/src/silo/query_engine/expressions/string_search.h
@@ -19,6 +19,12 @@ class StringSearch : public Expression {
   public:
    explicit StringSearch(std::string column_name, std::unique_ptr<re2::RE2> search_expression);
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<StringSearch>(
+         column_name, std::make_unique<re2::RE2>(search_expression->pattern())
+      );
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = Kind::STRING_SEARCH;
    [[nodiscard]] Kind kind() const override { return KIND; }

--- a/src/silo/query_engine/expressions/symbol_equals.h
+++ b/src/silo/query_engine/expressions/symbol_equals.h
@@ -47,6 +47,10 @@ class SymbolEquals : public Expression {
       SymbolOrDot<SymbolType> value
    );
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<SymbolEquals>(sequence_name, position_idx, value);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = std::is_same_v<SymbolType, Nucleotide>
                                    ? Kind::SYMBOL_EQUALS_NUCLEOTIDE

--- a/src/silo/query_engine/expressions/symbol_in_set.h
+++ b/src/silo/query_engine/expressions/symbol_in_set.h
@@ -33,6 +33,10 @@ class SymbolInSet : public Expression {
       std::vector<typename SymbolType::Symbol> symbols
    );
 
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<SymbolInSet>(sequence_name, position_idx, symbols);
+   }
+
    [[nodiscard]] std::string toString() const override;
    static constexpr Kind KIND = std::is_same_v<SymbolType, Nucleotide>
                                    ? Kind::SYMBOL_IN_SET_NUCLEOTIDE

--- a/src/silo/query_engine/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.cpp
@@ -163,7 +163,7 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedPhyl
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& node) const {
+operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& node) {
    // Filters cannot be pushed across a union all boundary.
    // If a FilterNode above was already absorbed into current_filters, reject the query.
    // Users must apply filters inside each child of the unionAll instead.

--- a/src/silo/query_engine/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.cpp
@@ -15,6 +15,7 @@
 #include "silo/query_engine/operators/phylo_subtree_node.h"
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
+#include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/zstd_decompress_node.h"
 
 namespace silo::query_engine {
@@ -157,6 +158,17 @@ operators::QueryNodePtr FilterPushdownPass::operator()(
 operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedPhyloSubtreeNode& node
 ) {
    applyToNode(node.child, *this);
+   return nullptr;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& node) {
+   // Filters cannot be pushed across a union all boundary.
+   // Each child is optimized independently with a fresh pass.
+   for (auto& child : node.children) {
+      FilterPushdownPass child_pass;
+      applyToNode(child, child_pass);
+   }
    return nullptr;
 }
 

--- a/src/silo/query_engine/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.cpp
@@ -173,10 +173,10 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& 
       "Apply the filter inside each child of the unionAll instead."
    );
    // Each child is optimized independently with a fresh pass.
-   for (auto& child : node.children) {
-      FilterPushdownPass child_pass;
-      applyToNode(child, child_pass);
-   }
+   FilterPushdownPass left_pass;
+   applyToNode(node.left, left_pass);
+   FilterPushdownPass right_pass;
+   applyToNode(node.right, right_pass);
    return nullptr;
 }
 

--- a/src/silo/query_engine/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.cpp
@@ -163,7 +163,7 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedPhyl
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& node) {
+operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& node) const {
    // Filters cannot be pushed across a union all boundary.
    // If a FilterNode above was already absorbed into current_filters, reject the query.
    // Users must apply filters inside each child of the unionAll instead.

--- a/src/silo/query_engine/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.cpp
@@ -3,6 +3,7 @@
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/query_engine/expressions/and.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/query_engine/operator_visitor.h"
 #include "silo/query_engine/operators/aggregate_node.h"
 #include "silo/query_engine/operators/fetch_node.h"
@@ -164,6 +165,13 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedPhyl
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& node) {
    // Filters cannot be pushed across a union all boundary.
+   // If a FilterNode above was already absorbed into current_filters, reject the query.
+   // Users must apply filters inside each child of the unionAll instead.
+   CHECK_SILO_QUERY(
+      current_filters.empty(),
+      "filter above unionAll is not supported. "
+      "Apply the filter inside each child of the unionAll instead."
+   );
    // Each child is optimized independently with a fresh pass.
    for (auto& child : node.children) {
       FilterPushdownPass child_pass;

--- a/src/silo/query_engine/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.cpp
@@ -3,7 +3,6 @@
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/query_engine/expressions/and.h"
-#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/query_engine/operator_visitor.h"
 #include "silo/query_engine/operators/aggregate_node.h"
 #include "silo/query_engine/operators/fetch_node.h"
@@ -164,18 +163,15 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedPhyl
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& node) {
-   // Filters cannot be pushed across a union all boundary.
-   // If a FilterNode above was already absorbed into current_filters, reject the query.
-   // Users must apply filters inside each child of the unionAll instead.
-   CHECK_SILO_QUERY(
-      current_filters.empty(),
-      "filter above unionAll is not supported. "
-      "Apply the filter inside each child of the unionAll instead."
-   );
-   // Each child is optimized independently with a fresh pass.
-   FilterPushdownPass left_pass;
-   applyToNode(node.left, left_pass);
+   // Push parent filters into both children. Clone for right, move originals into left.
    FilterPushdownPass right_pass;
+   for (const auto& filter : current_filters) {
+      right_pass.current_filters.push_back(filter->clone());
+   }
+   FilterPushdownPass left_pass;
+   left_pass.current_filters = std::move(current_filters);
+
+   applyToNode(node.left, left_pass);
    applyToNode(node.right, right_pass);
    return nullptr;
 }

--- a/src/silo/query_engine/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.cpp
@@ -86,8 +86,7 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::PhyloSubtreeNo
    node.filter = std::make_unique<expressions::And>(std::move(current_filters));
    return nullptr;
 }
-operators::QueryNodePtr FilterPushdownPass::operator()(
-   operators::MostRecentCommonAncestorNode& node
+operators::QueryNodePtr FilterPushdownPass::operator()(operators::MostRecentCommonAncestorNode& node
 ) {
    current_filters.push_back(std::move(node.filter));
    node.filter = std::make_unique<expressions::And>(std::move(current_filters));
@@ -157,8 +156,7 @@ operators::QueryNodePtr FilterPushdownPass::operator()(
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(
-   operators::UnresolvedPhyloSubtreeNode& node
+operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedPhyloSubtreeNode& node
 ) {
    applyToNode(node.child, *this);
    return nullptr;
@@ -182,17 +180,13 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& 
    return nullptr;
 }
 
-template operators::QueryNodePtr FilterPushdownPass::operator()(
-   operators::UnresolvedMutationsNode<silo::Nucleotide>&
-);
-template operators::QueryNodePtr FilterPushdownPass::operator()(
-   operators::UnresolvedMutationsNode<silo::AminoAcid>&
-);
-template operators::QueryNodePtr FilterPushdownPass::operator()(
-   operators::UnresolvedInsertionsNode<silo::Nucleotide>&
-);
-template operators::QueryNodePtr FilterPushdownPass::operator()(
-   operators::UnresolvedInsertionsNode<silo::AminoAcid>&
-);
+template operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedMutationsNode<
+                                                                silo::Nucleotide>&);
+template operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedMutationsNode<
+                                                                silo::AminoAcid>&);
+template operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedInsertionsNode<
+                                                                silo::Nucleotide>&);
+template operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedInsertionsNode<
+                                                                silo::AminoAcid>&);
 
 }  // namespace silo::query_engine

--- a/src/silo/query_engine/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.cpp
@@ -86,7 +86,8 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::PhyloSubtreeNo
    node.filter = std::make_unique<expressions::And>(std::move(current_filters));
    return nullptr;
 }
-operators::QueryNodePtr FilterPushdownPass::operator()(operators::MostRecentCommonAncestorNode& node
+operators::QueryNodePtr FilterPushdownPass::operator()(
+   operators::MostRecentCommonAncestorNode& node
 ) {
    current_filters.push_back(std::move(node.filter));
    node.filter = std::make_unique<expressions::And>(std::move(current_filters));
@@ -156,7 +157,8 @@ operators::QueryNodePtr FilterPushdownPass::operator()(
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedPhyloSubtreeNode& node
+operators::QueryNodePtr FilterPushdownPass::operator()(
+   operators::UnresolvedPhyloSubtreeNode& node
 ) {
    applyToNode(node.child, *this);
    return nullptr;
@@ -180,13 +182,17 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& 
    return nullptr;
 }
 
-template operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedMutationsNode<
-                                                                silo::Nucleotide>&);
-template operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedMutationsNode<
-                                                                silo::AminoAcid>&);
-template operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedInsertionsNode<
-                                                                silo::Nucleotide>&);
-template operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedInsertionsNode<
-                                                                silo::AminoAcid>&);
+template operators::QueryNodePtr FilterPushdownPass::operator()(
+   operators::UnresolvedMutationsNode<silo::Nucleotide>&
+);
+template operators::QueryNodePtr FilterPushdownPass::operator()(
+   operators::UnresolvedMutationsNode<silo::AminoAcid>&
+);
+template operators::QueryNodePtr FilterPushdownPass::operator()(
+   operators::UnresolvedInsertionsNode<silo::Nucleotide>&
+);
+template operators::QueryNodePtr FilterPushdownPass::operator()(
+   operators::UnresolvedInsertionsNode<silo::AminoAcid>&
+);
 
 }  // namespace silo::query_engine

--- a/src/silo/query_engine/filter_pushdown_pass.h
+++ b/src/silo/query_engine/filter_pushdown_pass.h
@@ -23,6 +23,7 @@ template <typename SymbolType>
 class UnresolvedInsertionsNode;
 class UnresolvedPhyloSubtreeNode;
 class UnresolvedMostRecentCommonAncestorNode;
+class UnionAllNode;
 class ZstdDecompressNode;
 
 }  // namespace silo::query_engine::operators
@@ -59,6 +60,7 @@ class FilterPushdownPass {
    operators::QueryNodePtr operator()(operators::UnresolvedInsertionsNode<SymbolType>& node);
    operators::QueryNodePtr operator()(operators::UnresolvedPhyloSubtreeNode& node);
    operators::QueryNodePtr operator()(operators::UnresolvedMostRecentCommonAncestorNode& node);
+   operators::QueryNodePtr operator()(operators::UnionAllNode& node);
 
    // All other nodes (TableScanNode, MutationsNode, etc.) are leaves here.
    template <typename T>

--- a/src/silo/query_engine/filter_pushdown_pass.h
+++ b/src/silo/query_engine/filter_pushdown_pass.h
@@ -60,7 +60,7 @@ class FilterPushdownPass {
    operators::QueryNodePtr operator()(operators::UnresolvedInsertionsNode<SymbolType>& node);
    operators::QueryNodePtr operator()(operators::UnresolvedPhyloSubtreeNode& node);
    operators::QueryNodePtr operator()(operators::UnresolvedMostRecentCommonAncestorNode& node);
-   operators::QueryNodePtr operator()(operators::UnionAllNode& node);
+   operators::QueryNodePtr operator()(operators::UnionAllNode& node) const;
 
    // All other nodes (TableScanNode, MutationsNode, etc.) are leaves here.
    template <typename T>

--- a/src/silo/query_engine/filter_pushdown_pass.h
+++ b/src/silo/query_engine/filter_pushdown_pass.h
@@ -60,7 +60,7 @@ class FilterPushdownPass {
    operators::QueryNodePtr operator()(operators::UnresolvedInsertionsNode<SymbolType>& node);
    operators::QueryNodePtr operator()(operators::UnresolvedPhyloSubtreeNode& node);
    operators::QueryNodePtr operator()(operators::UnresolvedMostRecentCommonAncestorNode& node);
-   operators::QueryNodePtr operator()(operators::UnionAllNode& node) const;
+   operators::QueryNodePtr operator()(operators::UnionAllNode& node);
 
    // All other nodes (TableScanNode, MutationsNode, etc.) are leaves here.
    template <typename T>

--- a/src/silo/query_engine/node_resolution_pass.cpp
+++ b/src/silo/query_engine/node_resolution_pass.cpp
@@ -18,6 +18,7 @@
 #include "silo/query_engine/operators/phylo_subtree_node.h"
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
+#include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/unresolved_phylo_subtree_node.h"
 #include "silo/query_engine/operators/zstd_decompress_node.h"
@@ -216,6 +217,14 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
       std::move(node.column_name),
       node.print_nodes_not_in_tree
    );
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnionAllNode& node) {
+   for (auto& child : node.children) {
+      applyToNode(child, *this);
+   }
+   return nullptr;
 }
 
 template operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedMutationsNode<

--- a/src/silo/query_engine/node_resolution_pass.cpp
+++ b/src/silo/query_engine/node_resolution_pass.cpp
@@ -221,9 +221,8 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnionAllNode& node) {
-   for (auto& child : node.children) {
-      applyToNode(child, *this);
-   }
+   applyToNode(node.left, *this);
+   applyToNode(node.right, *this);
    return nullptr;
 }
 

--- a/src/silo/query_engine/node_resolution_pass.cpp
+++ b/src/silo/query_engine/node_resolution_pass.cpp
@@ -178,8 +178,10 @@ operators::QueryNodePtr NodeResolutionPass::operator()(operators::AggregateNode&
    applyToNode(node.child, *this);
 
    // Full aggregations (COUNT(*) and only a filter below can be optimized)
-   if (node.group_by_fields.empty() && node.aggregates.size() == 1 &&
-       node.aggregates[0].function == operators::AggregateFunction::COUNT) {
+   if (
+      node.group_by_fields.empty() && node.aggregates.size() == 1 &&
+      node.aggregates[0].function == operators::AggregateFunction::COUNT
+   ) {
       auto scan = getTableScanOrNone(*node.child);
       if (scan.has_value()) {
          return std::make_unique<operators::CountFilterNode>(
@@ -191,7 +193,8 @@ operators::QueryNodePtr NodeResolutionPass::operator()(operators::AggregateNode&
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedPhyloSubtreeNode& node
+operators::QueryNodePtr NodeResolutionPass::operator()(
+   operators::UnresolvedPhyloSubtreeNode& node
 ) {
    auto scan = getTableScanOrNone(*node.child);
    CHECK_SILO_QUERY(scan.has_value(), "phyloSubtree() must be applied to a table scan");
@@ -227,13 +230,17 @@ operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnionAllNode& 
    return nullptr;
 }
 
-template operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedMutationsNode<
-                                                                silo::Nucleotide>&);
-template operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedMutationsNode<
-                                                                silo::AminoAcid>&);
-template operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedInsertionsNode<
-                                                                silo::Nucleotide>&);
-template operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedInsertionsNode<
-                                                                silo::AminoAcid>&);
+template operators::QueryNodePtr NodeResolutionPass::operator()(
+   operators::UnresolvedMutationsNode<silo::Nucleotide>&
+);
+template operators::QueryNodePtr NodeResolutionPass::operator()(
+   operators::UnresolvedMutationsNode<silo::AminoAcid>&
+);
+template operators::QueryNodePtr NodeResolutionPass::operator()(
+   operators::UnresolvedInsertionsNode<silo::Nucleotide>&
+);
+template operators::QueryNodePtr NodeResolutionPass::operator()(
+   operators::UnresolvedInsertionsNode<silo::AminoAcid>&
+);
 
 }  // namespace silo::query_engine

--- a/src/silo/query_engine/node_resolution_pass.cpp
+++ b/src/silo/query_engine/node_resolution_pass.cpp
@@ -178,10 +178,8 @@ operators::QueryNodePtr NodeResolutionPass::operator()(operators::AggregateNode&
    applyToNode(node.child, *this);
 
    // Full aggregations (COUNT(*) and only a filter below can be optimized)
-   if (
-      node.group_by_fields.empty() && node.aggregates.size() == 1 &&
-      node.aggregates[0].function == operators::AggregateFunction::COUNT
-   ) {
+   if (node.group_by_fields.empty() && node.aggregates.size() == 1 &&
+       node.aggregates[0].function == operators::AggregateFunction::COUNT) {
       auto scan = getTableScanOrNone(*node.child);
       if (scan.has_value()) {
          return std::make_unique<operators::CountFilterNode>(
@@ -193,8 +191,7 @@ operators::QueryNodePtr NodeResolutionPass::operator()(operators::AggregateNode&
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr NodeResolutionPass::operator()(
-   operators::UnresolvedPhyloSubtreeNode& node
+operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedPhyloSubtreeNode& node
 ) {
    auto scan = getTableScanOrNone(*node.child);
    CHECK_SILO_QUERY(scan.has_value(), "phyloSubtree() must be applied to a table scan");
@@ -230,17 +227,13 @@ operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnionAllNode& 
    return nullptr;
 }
 
-template operators::QueryNodePtr NodeResolutionPass::operator()(
-   operators::UnresolvedMutationsNode<silo::Nucleotide>&
-);
-template operators::QueryNodePtr NodeResolutionPass::operator()(
-   operators::UnresolvedMutationsNode<silo::AminoAcid>&
-);
-template operators::QueryNodePtr NodeResolutionPass::operator()(
-   operators::UnresolvedInsertionsNode<silo::Nucleotide>&
-);
-template operators::QueryNodePtr NodeResolutionPass::operator()(
-   operators::UnresolvedInsertionsNode<silo::AminoAcid>&
-);
+template operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedMutationsNode<
+                                                                silo::Nucleotide>&);
+template operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedMutationsNode<
+                                                                silo::AminoAcid>&);
+template operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedInsertionsNode<
+                                                                silo::Nucleotide>&);
+template operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedInsertionsNode<
+                                                                silo::AminoAcid>&);
 
 }  // namespace silo::query_engine

--- a/src/silo/query_engine/node_resolution_pass.h
+++ b/src/silo/query_engine/node_resolution_pass.h
@@ -18,6 +18,7 @@ template <typename SymbolType>
 class UnresolvedMutationsNode;
 template <typename SymbolType>
 class UnresolvedInsertionsNode;
+class UnionAllNode;
 class UnresolvedMostRecentCommonAncestorNode;
 class UnresolvedPhyloSubtreeNode;
 class ZstdDecompressNode;
@@ -48,6 +49,7 @@ class NodeResolutionPass {
    operators::QueryNodePtr operator()(operators::UnresolvedInsertionsNode<SymbolType>& node);
    operators::QueryNodePtr operator()(operators::UnresolvedMostRecentCommonAncestorNode& node);
    operators::QueryNodePtr operator()(operators::UnresolvedPhyloSubtreeNode& node);
+   operators::QueryNodePtr operator()(operators::UnionAllNode& node);
 
    // Post-resolution nodes are leaves that don't participate in this pass.
    template <typename T>

--- a/src/silo/query_engine/operator_visitor.h
+++ b/src/silo/query_engine/operator_visitor.h
@@ -45,8 +45,9 @@ decltype(auto) visit(QueryNode& node, Func&& func) {
             static_cast<UnresolvedMutationsNode<silo::Nucleotide>&>(node)
          );
       case NodeKind::UNRESOLVED_MUTATIONS_AMINO_ACID:
-         return std::forward<Func>(func)(static_cast<UnresolvedMutationsNode<silo::AminoAcid>&>(node
-         ));
+         return std::forward<Func>(func)(
+            static_cast<UnresolvedMutationsNode<silo::AminoAcid>&>(node)
+         );
       case NodeKind::UNRESOLVED_INSERTIONS_NUCLEOTIDE:
          return std::forward<Func>(func)(
             static_cast<UnresolvedInsertionsNode<silo::Nucleotide>&>(node)
@@ -56,7 +57,8 @@ decltype(auto) visit(QueryNode& node, Func&& func) {
             static_cast<UnresolvedInsertionsNode<silo::AminoAcid>&>(node)
          );
       case NodeKind::UNRESOLVED_MOST_RECENT_COMMON_ANCESTOR:
-         return std::forward<Func>(func)(static_cast<UnresolvedMostRecentCommonAncestorNode&>(node)
+         return std::forward<Func>(func)(
+            static_cast<UnresolvedMostRecentCommonAncestorNode&>(node)
          );
       case NodeKind::UNRESOLVED_PHYLO_SUBTREE:
          return std::forward<Func>(func)(static_cast<UnresolvedPhyloSubtreeNode&>(node));

--- a/src/silo/query_engine/operator_visitor.h
+++ b/src/silo/query_engine/operator_visitor.h
@@ -45,9 +45,8 @@ decltype(auto) visit(QueryNode& node, Func&& func) {
             static_cast<UnresolvedMutationsNode<silo::Nucleotide>&>(node)
          );
       case NodeKind::UNRESOLVED_MUTATIONS_AMINO_ACID:
-         return std::forward<Func>(func)(
-            static_cast<UnresolvedMutationsNode<silo::AminoAcid>&>(node)
-         );
+         return std::forward<Func>(func)(static_cast<UnresolvedMutationsNode<silo::AminoAcid>&>(node
+         ));
       case NodeKind::UNRESOLVED_INSERTIONS_NUCLEOTIDE:
          return std::forward<Func>(func)(
             static_cast<UnresolvedInsertionsNode<silo::Nucleotide>&>(node)
@@ -57,8 +56,7 @@ decltype(auto) visit(QueryNode& node, Func&& func) {
             static_cast<UnresolvedInsertionsNode<silo::AminoAcid>&>(node)
          );
       case NodeKind::UNRESOLVED_MOST_RECENT_COMMON_ANCESTOR:
-         return std::forward<Func>(func)(
-            static_cast<UnresolvedMostRecentCommonAncestorNode&>(node)
+         return std::forward<Func>(func)(static_cast<UnresolvedMostRecentCommonAncestorNode&>(node)
          );
       case NodeKind::UNRESOLVED_PHYLO_SUBTREE:
          return std::forward<Func>(func)(static_cast<UnresolvedPhyloSubtreeNode&>(node));

--- a/src/silo/query_engine/operator_visitor.h
+++ b/src/silo/query_engine/operator_visitor.h
@@ -15,6 +15,7 @@
 #include "silo/query_engine/operators/phylo_subtree_node.h"
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
+#include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/unresolved_insertions_node.h"
 #include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/unresolved_mutations_node.h"
@@ -77,6 +78,8 @@ decltype(auto) visit(QueryNode& node, Func&& func) {
          return std::forward<Func>(func)(static_cast<CountFilterNode&>(node));
       case NodeKind::ZSTD_DECOMPRESS:
          return std::forward<Func>(func)(static_cast<ZstdDecompressNode&>(node));
+      case NodeKind::UNION_ALL:
+         return std::forward<Func>(func)(static_cast<UnionAllNode&>(node));
    }
    SILO_UNREACHABLE();
 }

--- a/src/silo/query_engine/operators/aggregate_node.cpp
+++ b/src/silo/query_engine/operators/aggregate_node.cpp
@@ -112,25 +112,19 @@ std::vector<schema::ColumnIdentifier> AggregateNode::getOutputSchema() const {
    return output_fields;
 }
 
-arrow::Result<PartialArrowPlan> AggregateNode::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> AggregateNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
    const config::QueryOptions& query_options
 ) const {
-   ARROW_ASSIGN_OR_RAISE(auto plan, child->toQueryPlan(tables, query_options));
+   ARROW_ASSIGN_OR_RAISE(auto* child_node, child->addToExecPlan(plan, tables, query_options));
 
-   auto input_schema = plan.top_node->output_schema();
+   auto input_schema = child_node->output_schema();
 
    const arrow::acero::AggregateNodeOptions aggregate_node_options =
       buildAggregateOptions(group_by_fields, aggregates, *input_schema);
 
-   ARROW_ASSIGN_OR_RAISE(
-      plan.top_node,
-      arrow::acero::MakeExecNode(
-         "aggregate", plan.plan.get(), {plan.top_node}, aggregate_node_options
-      )
-   );
-
-   return plan;
+   return arrow::acero::MakeExecNode("aggregate", &plan, {child_node}, aggregate_node_options);
 }
 
 nlohmann::json AggregateNode::toJson() const {

--- a/src/silo/query_engine/operators/aggregate_node.h
+++ b/src/silo/query_engine/operators/aggregate_node.h
@@ -39,7 +39,8 @@ class AggregateNode final : public QueryNode {
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/operators/count_filter_node.cpp
+++ b/src/silo/query_engine/operators/count_filter_node.cpp
@@ -32,7 +32,8 @@ std::vector<schema::ColumnIdentifier> CountFilterNode::getOutputSchema() const {
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-arrow::Result<PartialArrowPlan> CountFilterNode::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> CountFilterNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& /*tables*/,
    const config::QueryOptions& /*query_options*/
 ) const {
@@ -59,8 +60,6 @@ arrow::Result<PartialArrowPlan> CountFilterNode::toQueryPlan(
       return arrow::Future{result};
    };
 
-   ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
-
    const std::vector<schema::ColumnIdentifier> output_schema = getOutputSchema();
 
    const arrow::acero::SourceNodeOptions options{
@@ -68,11 +67,7 @@ arrow::Result<PartialArrowPlan> CountFilterNode::toQueryPlan(
       std::move(producer),
       arrow::Ordering::Implicit()
    };
-   ARROW_ASSIGN_OR_RAISE(
-      auto node, arrow::acero::MakeExecNode("source", arrow_plan.get(), {}, options)
-   );
-
-   return PartialArrowPlan{.top_node = node, .plan = arrow_plan};
+   return arrow::acero::MakeExecNode("source", &plan, {}, options);
 }
 
 nlohmann::json CountFilterNode::toJson() const {

--- a/src/silo/query_engine/operators/count_filter_node.h
+++ b/src/silo/query_engine/operators/count_filter_node.h
@@ -26,7 +26,8 @@ class CountFilterNode final : public QueryNode {
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/operators/fetch_node.cpp
+++ b/src/silo/query_engine/operators/fetch_node.cpp
@@ -29,16 +29,15 @@ std::vector<schema::ColumnIdentifier> FetchNode::getOutputSchema() const {
    return child->getOutputSchema();
 }
 
-arrow::Result<PartialArrowPlan> FetchNode::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> FetchNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
    const config::QueryOptions& query_options
 ) const {
-   ARROW_ASSIGN_OR_RAISE(auto partial, child->toQueryPlan(tables, query_options));
-   auto* arrow_plan = partial.plan.get();
-   auto* node = partial.top_node;
+   ARROW_ASSIGN_OR_RAISE(auto* child_node, child->addToExecPlan(plan, tables, query_options));
 
    CHECK_SILO_QUERY(
-      !node->ordering().is_unordered(),
+      !child_node->ordering().is_unordered(),
       "Offset and limit can only be applied if the output of the operation has some ordering. "
       "Implicit ordering such as in the case of Details/Fasta is also allowed, Aggregated "
       "however produces unordered results."
@@ -47,14 +46,9 @@ arrow::Result<PartialArrowPlan> FetchNode::toQueryPlan(
    const arrow::acero::FetchNodeOptions fetch_options(
       offset.value_or(0), count.value_or(std::numeric_limits<int64_t>::max())
    );
-   ARROW_ASSIGN_OR_RAISE(
-      node,
-      arrow::acero::MakeExecNode(
-         std::string{arrow::acero::FetchNodeOptions::kName}, arrow_plan, {node}, fetch_options
-      )
+   return arrow::acero::MakeExecNode(
+      std::string{arrow::acero::FetchNodeOptions::kName}, &plan, {child_node}, fetch_options
    );
-
-   return PartialArrowPlan{.top_node = node, .plan = partial.plan};
 }
 
 nlohmann::json FetchNode::toJson() const {

--- a/src/silo/query_engine/operators/fetch_node.h
+++ b/src/silo/query_engine/operators/fetch_node.h
@@ -24,7 +24,8 @@ class FetchNode final : public QueryNode {
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/operators/filter_node.cpp
+++ b/src/silo/query_engine/operators/filter_node.cpp
@@ -14,7 +14,8 @@ std::vector<schema::ColumnIdentifier> FilterNode::getOutputSchema() const {
    return child->getOutputSchema();
 }
 
-arrow::Result<PartialArrowPlan> FilterNode::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> FilterNode::addToExecPlan(
+   arrow::acero::ExecPlan& /*plan*/,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& /*tables*/,
    const config::QueryOptions& /*query_options*/
 ) const {

--- a/src/silo/query_engine/operators/filter_node.h
+++ b/src/silo/query_engine/operators/filter_node.h
@@ -24,7 +24,8 @@ class FilterNode final : public QueryNode {
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/operators/insertions_node.cpp
+++ b/src/silo/query_engine/operators/insertions_node.cpp
@@ -126,7 +126,8 @@ arrow::Status addAggregatedInsertionsToInsertionCounts(
 
 template <typename SymbolType>
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-arrow::Result<PartialArrowPlan> InsertionsNode<SymbolType>::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> InsertionsNode<SymbolType>::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& /*tables*/,
    const config::QueryOptions& /*query_options*/
 ) const {
@@ -170,18 +171,12 @@ arrow::Result<PartialArrowPlan> InsertionsNode<SymbolType>::toQueryPlan(
       return arrow::Future{result};
    };
 
-   ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
-
    const arrow::acero::SourceNodeOptions options{
       exec_node::columnsToArrowSchema(output_fields),
       std::move(producer),
       arrow::Ordering::Implicit()
    };
-   ARROW_ASSIGN_OR_RAISE(
-      auto node, arrow::acero::MakeExecNode("source", arrow_plan.get(), {}, options)
-   );
-
-   return PartialArrowPlan{.top_node = node, .plan = arrow_plan};
+   return arrow::acero::MakeExecNode("source", &plan, {}, options);
 }
 
 template <typename SymbolType>

--- a/src/silo/query_engine/operators/insertions_node.h
+++ b/src/silo/query_engine/operators/insertions_node.h
@@ -50,7 +50,8 @@ class InsertionsNode final : public QueryNode {
       return fields;
    }
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/operators/map_node.cpp
+++ b/src/silo/query_engine/operators/map_node.cpp
@@ -63,11 +63,12 @@ std::vector<schema::ColumnIdentifier> MapNode::getOutputSchema() const {
    return output;
 }
 
-arrow::Result<PartialArrowPlan> MapNode::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> MapNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
    const config::QueryOptions& query_options
 ) const {
-   ARROW_ASSIGN_OR_RAISE(auto plan, child->toQueryPlan(tables, query_options));
+   ARROW_ASSIGN_OR_RAISE(auto* child_node, child->addToExecPlan(plan, tables, query_options));
 
    // Map output column names to the assignment that produces them.
    std::map<std::string, const Assignment*> assignment_by_name;
@@ -95,11 +96,7 @@ arrow::Result<PartialArrowPlan> MapNode::toQueryPlan(
    }
 
    const arrow::acero::ProjectNodeOptions options{std::move(expressions), std::move(names)};
-   ARROW_ASSIGN_OR_RAISE(
-      plan.top_node,
-      arrow::acero::MakeExecNode("project", plan.plan.get(), {plan.top_node}, options)
-   );
-   return plan;
+   return arrow::acero::MakeExecNode("project", &plan, {child_node}, options);
 }
 
 nlohmann::json MapNode::toJson() const {

--- a/src/silo/query_engine/operators/map_node.h
+++ b/src/silo/query_engine/operators/map_node.h
@@ -32,7 +32,8 @@ class MapNode final : public QueryNode {
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/operators/most_recent_common_ancestor_node.cpp
+++ b/src/silo/query_engine/operators/most_recent_common_ancestor_node.cpp
@@ -84,7 +84,8 @@ std::vector<schema::ColumnIdentifier> MostRecentCommonAncestorNode::getOutputSch
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-arrow::Result<PartialArrowPlan> MostRecentCommonAncestorNode::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> MostRecentCommonAncestorNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& /*tables*/,
    const config::QueryOptions& /*query_options*/
 ) const {
@@ -169,18 +170,12 @@ arrow::Result<PartialArrowPlan> MostRecentCommonAncestorNode::toQueryPlan(
       return arrow::Future{result};
    };
 
-   ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
-
    const arrow::acero::SourceNodeOptions options{
       exec_node::columnsToArrowSchema(output_fields),
       std::move(producer),
       arrow::Ordering::Implicit()
    };
-   ARROW_ASSIGN_OR_RAISE(
-      auto node, arrow::acero::MakeExecNode("source", arrow_plan.get(), {}, options)
-   );
-
-   return PartialArrowPlan{.top_node = node, .plan = arrow_plan};
+   return arrow::acero::MakeExecNode("source", &plan, {}, options);
 }
 
 nlohmann::json MostRecentCommonAncestorNode::toJson() const {

--- a/src/silo/query_engine/operators/most_recent_common_ancestor_node.h
+++ b/src/silo/query_engine/operators/most_recent_common_ancestor_node.h
@@ -33,7 +33,8 @@ class MostRecentCommonAncestorNode final : public QueryNode {
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/operators/mutations_node.cpp
+++ b/src/silo/query_engine/operators/mutations_node.cpp
@@ -376,7 +376,8 @@ arrow::Status addMutationsToOutput(
 
 template <typename SymbolType>
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-arrow::Result<PartialArrowPlan> MutationsNode<SymbolType>::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> MutationsNode<SymbolType>::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& /*tables*/,
    const config::QueryOptions& /*query_options*/
 ) const {
@@ -425,18 +426,12 @@ arrow::Result<PartialArrowPlan> MutationsNode<SymbolType>::toQueryPlan(
       return arrow::Future{result};
    };
 
-   ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
-
    const arrow::acero::SourceNodeOptions options{
       exec_node::columnsToArrowSchema(output_fields),
       std::move(producer),
       arrow::Ordering::Implicit()
    };
-   ARROW_ASSIGN_OR_RAISE(
-      auto node, arrow::acero::MakeExecNode("source", arrow_plan.get(), {}, options)
-   );
-
-   return PartialArrowPlan{.top_node = node, .plan = arrow_plan};
+   return arrow::acero::MakeExecNode("source", &plan, {}, options);
 }
 
 template <typename SymbolType>

--- a/src/silo/query_engine/operators/mutations_node.h
+++ b/src/silo/query_engine/operators/mutations_node.h
@@ -89,7 +89,8 @@ class MutationsNode final : public QueryNode {
       return output_fields;
    }
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/operators/order_by_node.cpp
+++ b/src/silo/query_engine/operators/order_by_node.cpp
@@ -43,34 +43,38 @@ uint64_t hash64(uint64_t value, uint64_t seed) {
    return value;
 }
 
-arrow::Result<arrow::acero::ExecNode*> removeRandomizeColumn(const PartialArrowPlan& plan) {
+arrow::Result<arrow::acero::ExecNode*> removeRandomizeColumn(
+   arrow::acero::ExecPlan& plan,
+   arrow::acero::ExecNode* top_node
+) {
    std::vector<arrow::Expression> field_refs;
-   for (const auto& field : plan.top_node->output_schema()->fields()) {
+   for (const auto& field : top_node->output_schema()->fields()) {
       if (field->name() != RANDOMIZE_HASH_FIELD_NAME) {
          field_refs.push_back(arrow::compute::field_ref(field->name()));
       }
    }
    auto options = arrow::acero::ProjectNodeOptions(field_refs);
-   return arrow::acero::MakeExecNode("project", plan.plan.get(), {plan.top_node}, options);
+   return arrow::acero::MakeExecNode("project", &plan, {top_node}, options);
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 arrow::Result<arrow::acero::ExecNode*> addRandomizeColumn(
-   PartialArrowPlan plan,
+   arrow::acero::ExecPlan& plan,
+   arrow::acero::ExecNode* top_node,
    size_t randomize_seed
 ) {
    arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> sequenced_batches;
    std::shared_ptr<arrow::Schema> schema_of_sequence_batches;
    ARROW_ASSIGN_OR_RAISE(
-      plan.top_node,
+      top_node,
       arrow::acero::MakeExecNode(
          "sink",
-         plan.plan.get(),
-         {plan.top_node},
+         &plan,
+         {top_node},
          arrow::acero::SinkNodeOptions{&sequenced_batches, &schema_of_sequence_batches}
       )
    );
-   plan.top_node->SetLabel("input to randomize column projection");
+   top_node->SetLabel("input to randomize column projection");
    auto output_schema_fields = schema_of_sequence_batches->fields();
    output_schema_fields.emplace_back(
       std::make_shared<arrow::Field>(RANDOMIZE_HASH_FIELD_NAME, arrow::uint64())
@@ -115,40 +119,38 @@ arrow::Result<arrow::acero::ExecNode*> addRandomizeColumn(
       );
    };
    ARROW_ASSIGN_OR_RAISE(
-      plan.top_node,
+      top_node,
       arrow::acero::MakeExecNode(
          "source",
-         plan.plan.get(),
+         &plan,
          {},
          arrow::acero::SourceNodeOptions{output_schema, std::move(sequenced_batches_with_hash_id)}
       )
    );
-   plan.top_node->SetLabel("output of randomize column projection");
-   return plan.top_node;
+   top_node->SetLabel("output of randomize column projection");
+   return top_node;
 }
 
 arrow::Result<arrow::acero::ExecNode*> addSortNode(
-   PartialArrowPlan plan,
+   arrow::acero::ExecPlan& plan,
+   arrow::acero::ExecNode* top_node,
    const std::vector<schema::ColumnIdentifier>& output_fields,
    const arrow::Ordering& ordering
 ) {
    arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> generator;
    ARROW_ASSIGN_OR_RAISE(
-      plan.top_node,
+      top_node,
       arrow::acero::MakeExecNode(
          "order_by_sink",
-         plan.plan.get(),
-         {plan.top_node},
+         &plan,
+         {top_node},
          arrow::acero::OrderBySinkNodeOptions{arrow::SortOptions{ordering}, &generator}
       )
    );
-   plan.top_node->SetLabel("order by");
+   top_node->SetLabel("order by");
    auto schema = exec_node::columnsToArrowSchema(output_fields);
    return arrow::acero::MakeExecNode(
-      "source",
-      plan.plan.get(),
-      {},
-      arrow::acero::SourceNodeOptions{schema, std::move(generator), ordering}
+      "source", &plan, {}, arrow::acero::SourceNodeOptions{schema, std::move(generator), ordering}
    );
 }
 
@@ -168,7 +170,8 @@ std::vector<schema::ColumnIdentifier> OrderByNode::getOutputSchema() const {
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-arrow::Result<PartialArrowPlan> OrderByNode::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> OrderByNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
    const config::QueryOptions& query_options
 ) const {
@@ -180,7 +183,7 @@ arrow::Result<PartialArrowPlan> OrderByNode::toQueryPlan(
       field_names.push_back(identifier.name);
    }
 
-   ARROW_ASSIGN_OR_RAISE(auto plan, child->toQueryPlan(tables, query_options));
+   ARROW_ASSIGN_OR_RAISE(auto* top_node, child->addToExecPlan(plan, tables, query_options));
 
    using arrow::compute::NullPlacement;
    using arrow::compute::SortOrder;
@@ -195,7 +198,7 @@ arrow::Result<PartialArrowPlan> OrderByNode::toQueryPlan(
    }
 
    if (sort_keys.empty()) {
-      return plan;
+      return top_node;
    }
 
    auto first_sort_key = sort_keys.at(0);
@@ -205,16 +208,16 @@ arrow::Result<PartialArrowPlan> OrderByNode::toQueryPlan(
    const arrow::Ordering ordering{sort_keys, null_placement};
 
    if (randomize_seed.has_value()) {
-      ARROW_ASSIGN_OR_RAISE(plan.top_node, addRandomizeColumn(plan, randomize_seed.value()));
+      ARROW_ASSIGN_OR_RAISE(top_node, addRandomizeColumn(plan, top_node, randomize_seed.value()));
    }
 
-   ARROW_ASSIGN_OR_RAISE(plan.top_node, addSortNode(plan, getOutputSchema(), ordering));
+   ARROW_ASSIGN_OR_RAISE(top_node, addSortNode(plan, top_node, getOutputSchema(), ordering));
 
    if (randomize_seed.has_value()) {
-      ARROW_ASSIGN_OR_RAISE(plan.top_node, removeRandomizeColumn(plan));
+      ARROW_ASSIGN_OR_RAISE(top_node, removeRandomizeColumn(plan, top_node));
    }
 
-   return plan;
+   return top_node;
 }
 
 nlohmann::json OrderByNode::toJson() const {

--- a/src/silo/query_engine/operators/order_by_node.h
+++ b/src/silo/query_engine/operators/order_by_node.h
@@ -30,7 +30,8 @@ class OrderByNode final : public QueryNode {
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/operators/phylo_subtree_node.cpp
+++ b/src/silo/query_engine/operators/phylo_subtree_node.cpp
@@ -84,7 +84,8 @@ std::vector<schema::ColumnIdentifier> PhyloSubtreeNode::getOutputSchema() const 
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-arrow::Result<PartialArrowPlan> PhyloSubtreeNode::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> PhyloSubtreeNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& /*tables*/,
    const config::QueryOptions& /*query_options*/
 ) const {
@@ -159,18 +160,12 @@ arrow::Result<PartialArrowPlan> PhyloSubtreeNode::toQueryPlan(
       return arrow::Future{result};
    };
 
-   ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
-
    const arrow::acero::SourceNodeOptions options{
       exec_node::columnsToArrowSchema(output_fields),
       std::move(producer),
       arrow::Ordering::Implicit()
    };
-   ARROW_ASSIGN_OR_RAISE(
-      auto node, arrow::acero::MakeExecNode("source", arrow_plan.get(), {}, options)
-   );
-
-   return PartialArrowPlan{.top_node = node, .plan = arrow_plan};
+   return arrow::acero::MakeExecNode("source", &plan, {}, options);
 }
 
 nlohmann::json PhyloSubtreeNode::toJson() const {

--- a/src/silo/query_engine/operators/phylo_subtree_node.h
+++ b/src/silo/query_engine/operators/phylo_subtree_node.h
@@ -35,7 +35,8 @@ class PhyloSubtreeNode final : public QueryNode {
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/operators/project_node.cpp
+++ b/src/silo/query_engine/operators/project_node.cpp
@@ -15,11 +15,12 @@ std::vector<schema::ColumnIdentifier> ProjectNode::getOutputSchema() const {
    return fields;
 }
 
-arrow::Result<PartialArrowPlan> ProjectNode::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> ProjectNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
    const config::QueryOptions& query_options
 ) const {
-   ARROW_ASSIGN_OR_RAISE(auto plan, child->toQueryPlan(tables, query_options));
+   ARROW_ASSIGN_OR_RAISE(auto* child_node, child->addToExecPlan(plan, tables, query_options));
 
    std::vector<arrow::Expression> expressions;
    std::vector<std::string> names;
@@ -31,11 +32,7 @@ arrow::Result<PartialArrowPlan> ProjectNode::toQueryPlan(
    }
 
    const arrow::acero::ProjectNodeOptions options{std::move(expressions), std::move(names)};
-   ARROW_ASSIGN_OR_RAISE(
-      plan.top_node,
-      arrow::acero::MakeExecNode("project", plan.plan.get(), {plan.top_node}, options)
-   );
-   return plan;
+   return arrow::acero::MakeExecNode("project", &plan, {child_node}, options);
 }
 
 nlohmann::json ProjectNode::toJson() const {

--- a/src/silo/query_engine/operators/project_node.h
+++ b/src/silo/query_engine/operators/project_node.h
@@ -23,7 +23,8 @@ class ProjectNode final : public QueryNode {
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/operators/query_node.cpp
+++ b/src/silo/query_engine/operators/query_node.cpp
@@ -54,6 +54,8 @@ std::string_view nodeKindToString(NodeKind kind) {
          return "ZstdDecompress";
       case NodeKind::MAP:
          return "Map";
+      case NodeKind::UNION_ALL:
+         return "UnionAll";
    }
    SILO_UNREACHABLE();
 }

--- a/src/silo/query_engine/operators/query_node.h
+++ b/src/silo/query_engine/operators/query_node.h
@@ -37,6 +37,7 @@ enum class NodeKind : uint8_t {
    TABLE_SCAN,
    COUNT_FILTER,
    ZSTD_DECOMPRESS,
+   UNION_ALL,
 };
 
 struct PartialArrowPlan {

--- a/src/silo/query_engine/operators/query_node.h
+++ b/src/silo/query_engine/operators/query_node.h
@@ -44,8 +44,8 @@ class QueryNode {
   public:
    virtual ~QueryNode() = default;
 
-   /// Add this node's exec nodes to an existing Arrow ExecPlan.
-   /// Returns the top ExecNode* within that plan.
+   /// Translate this node (including its sub-nodes) to `arrow::acero` nodes and add them to an
+   /// existing `ExecPlan`. Returns the top `ExecNode*` within that plan.
    [[nodiscard]] virtual arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
       arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,

--- a/src/silo/query_engine/operators/query_node.h
+++ b/src/silo/query_engine/operators/query_node.h
@@ -40,16 +40,14 @@ enum class NodeKind : uint8_t {
    UNION_ALL,
 };
 
-struct PartialArrowPlan {
-   arrow::acero::ExecNode* top_node;
-   std::shared_ptr<arrow::acero::ExecPlan> plan;
-};
-
 class QueryNode {
   public:
    virtual ~QueryNode() = default;
 
-   [[nodiscard]] virtual arrow::Result<PartialArrowPlan> toQueryPlan(
+   /// Add this node's exec nodes to an existing Arrow ExecPlan.
+   /// Returns the top ExecNode* within that plan.
+   [[nodiscard]] virtual arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const = 0;

--- a/src/silo/query_engine/operators/table_scan_node.cpp
+++ b/src/silo/query_engine/operators/table_scan_node.cpp
@@ -20,26 +20,16 @@ std::vector<schema::ColumnIdentifier> TableScanNode::getOutputSchema() const {
    return fields;
 }
 
-arrow::Result<PartialArrowPlan> TableScanNode::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> TableScanNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& /*tables*/,
    const config::QueryOptions& query_options
 ) const {
    auto bitmap_filter = computeFilter(filter, *table);
 
-   ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
-
-   ARROW_ASSIGN_OR_RAISE(
-      arrow::acero::ExecNode * node,
-      exec_node::makeTableScan(
-         arrow_plan.get(),
-         fields,
-         std::move(bitmap_filter),
-         table,
-         query_options.materialization_cutoff
-      )
+   return exec_node::makeTableScan(
+      &plan, fields, std::move(bitmap_filter), table, query_options.materialization_cutoff
    );
-
-   return PartialArrowPlan{.top_node = node, .plan = arrow_plan};
 }
 
 nlohmann::json TableScanNode::toJson() const {

--- a/src/silo/query_engine/operators/table_scan_node.h
+++ b/src/silo/query_engine/operators/table_scan_node.h
@@ -29,7 +29,8 @@ class TableScanNode final : public QueryNode {
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/operators/union_all_node.cpp
+++ b/src/silo/query_engine/operators/union_all_node.cpp
@@ -10,6 +10,7 @@
 #include <nlohmann/json.hpp>
 
 #include "silo/common/panic.h"
+#include "silo/common/size_constants.h"
 #include "silo/query_engine/exec_node/arrow_util.h"
 
 namespace silo::query_engine::operators {
@@ -36,7 +37,13 @@ struct StreamState {
 
       arrow::acero::BackpressureMonitor* backpressure_monitor = nullptr;
       const arrow::acero::SinkNodeOptions sink_options{
-         &current_generator, arrow::acero::BackpressureOptions{}, &backpressure_monitor, true
+         &current_generator,
+         arrow::acero::BackpressureOptions{
+            /*.resume_if_below =*/silo::common::S_16_KB,
+            /*.pause_if_above =*/silo::common::S_64_MB
+         },
+         &backpressure_monitor,
+         true
       };
       ARROW_ASSIGN_OR_RAISE(
          auto sink_node,
@@ -75,6 +82,9 @@ struct StreamState {
 
 /// Pull the next batch from the streaming union.
 /// Starts child plans on demand, drains them one at a time, then advances.
+/// Note: blocks synchronously on the child generator. This is intentional — the child
+/// plan runs on the same shared Arrow thread pool, so async continuations would deadlock.
+/// This matches the pattern used by QueryPlan::executeAndWriteImpl.
 arrow::Future<std::optional<arrow::ExecBatch>> pullNext(const std::shared_ptr<StreamState>& state) {
    while (true) {
       if (state->child_idx >= state->child_plans.size()) {
@@ -92,15 +102,8 @@ arrow::Future<std::optional<arrow::ExecBatch>> pullNext(const std::shared_ptr<St
       auto result = future.result();
 
       if (!result.ok()) {
-         if (result.status().IsCancelled()) {
-            SPDLOG_WARN(
-               "UnionAll: child {} generator returned Cancelled, advancing to next child",
-               state->child_idx
-            );
-            state->stopCurrentChild();
-            ++state->child_idx;
-            continue;
-         }
+         // Propagate all errors (including Cancelled) to the caller.
+         state->stopCurrentChild();
          return arrow::Future{arrow::Result<std::optional<arrow::ExecBatch>>{result.status()}};
       }
 

--- a/src/silo/query_engine/operators/union_all_node.cpp
+++ b/src/silo/query_engine/operators/union_all_node.cpp
@@ -27,6 +27,8 @@ struct StreamState {
    arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> current_generator;
    bool generator_active = false;
 
+   ~StreamState() { stopCurrentChild(); }
+
    /// Attach a sink to the current child plan and start producing.
    arrow::Status startCurrentChild() {
       SILO_ASSERT(child_idx < child_plans.size());

--- a/src/silo/query_engine/operators/union_all_node.cpp
+++ b/src/silo/query_engine/operators/union_all_node.cpp
@@ -53,13 +53,20 @@ struct StreamState {
 
    /// Tear down the current child plan.
    void stopCurrentChild() {
+      constexpr double GRACE_SHUTDOWN_SECONDS = 5.0;
       if (!current_plan) {
          return;
       }
       auto finished_future = current_plan->finished();
       if (!finished_future.is_finished()) {
          current_plan->StopProducing();
-         finished_future.Wait();
+         const bool drained = finished_future.Wait(GRACE_SHUTDOWN_SECONDS);
+         if (!drained) {
+            SPDLOG_WARN(
+               "UnionAll: child plan cleanup exceeded {} s grace; continuing.",
+               GRACE_SHUTDOWN_SECONDS
+            );
+         }
       }
       current_plan.reset();
       generator_active = false;

--- a/src/silo/query_engine/operators/union_all_node.cpp
+++ b/src/silo/query_engine/operators/union_all_node.cpp
@@ -6,8 +6,8 @@
 #include <arrow/acero/exec_plan.h>
 #include <arrow/acero/options.h>
 #include <arrow/util/async_generator.h>
-#include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
 
 #include "silo/common/panic.h"
 #include "silo/query_engine/exec_node/arrow_util.h"
@@ -71,17 +71,13 @@ struct StreamState {
 // NOLINTNEXTLINE(misc-no-recursion)
 arrow::Future<std::optional<arrow::ExecBatch>> pullNext(const std::shared_ptr<StreamState>& state) {
    if (state->child_idx >= state->child_plans.size()) {
-      return arrow::Future{
-         std::optional<arrow::ExecBatch>{std::nullopt}
-      };
+      return arrow::Future{std::optional<arrow::ExecBatch>{std::nullopt}};
    }
 
    if (!state->generator_active) {
       auto status = state->startCurrentChild();
       if (!status.ok()) {
-         return arrow::Future{
-            arrow::Result<std::optional<arrow::ExecBatch>>{status}
-         };
+         return arrow::Future{arrow::Result<std::optional<arrow::ExecBatch>>{status}};
       }
    }
 
@@ -98,9 +94,7 @@ arrow::Future<std::optional<arrow::ExecBatch>> pullNext(const std::shared_ptr<St
          ++state->child_idx;
          return pullNext(state);
       }
-      return arrow::Future{
-         arrow::Result<std::optional<arrow::ExecBatch>>{result.status()}
-      };
+      return arrow::Future{arrow::Result<std::optional<arrow::ExecBatch>>{result.status()}};
    }
 
    if (!result->has_value()) {
@@ -137,8 +131,9 @@ arrow::Result<PartialArrowPlan> UnionAllNode::toQueryPlan(
       state->child_plans.push_back(std::move(child_plan));
    }
 
-   std::function<arrow::Future<std::optional<arrow::ExecBatch>>()> producer =
-      [state]() { return pullNext(state); };
+   std::function<arrow::Future<std::optional<arrow::ExecBatch>>()> producer = [state]() {
+      return pullNext(state);
+   };
 
    ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
 
@@ -148,8 +143,7 @@ arrow::Result<PartialArrowPlan> UnionAllNode::toQueryPlan(
       arrow::Ordering::Implicit()
    };
    ARROW_ASSIGN_OR_RAISE(
-      auto source_node,
-      arrow::acero::MakeExecNode("source", arrow_plan.get(), {}, source_options)
+      auto source_node, arrow::acero::MakeExecNode("source", arrow_plan.get(), {}, source_options)
    );
 
    return PartialArrowPlan{.top_node = source_node, .plan = arrow_plan};

--- a/src/silo/query_engine/operators/union_all_node.cpp
+++ b/src/silo/query_engine/operators/union_all_node.cpp
@@ -1,0 +1,141 @@
+#include "silo/query_engine/operators/union_all_node.h"
+
+#include <functional>
+#include <optional>
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/acero/options.h>
+#include <arrow/util/async_generator.h>
+#include <nlohmann/json.hpp>
+
+#include "silo/common/panic.h"
+#include "silo/query_engine/exec_node/arrow_util.h"
+
+namespace silo::query_engine::operators {
+
+namespace {
+
+/// Execute a child plan to completion and collect all output batches.
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+arrow::Result<std::vector<arrow::ExecBatch>> drainChildPlan(PartialArrowPlan& child_plan) {
+   arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> generator;
+   arrow::acero::BackpressureMonitor* backpressure_monitor;
+   const arrow::acero::SinkNodeOptions sink_options{
+      &generator, arrow::acero::BackpressureOptions{}, &backpressure_monitor, true
+   };
+   ARROW_ASSIGN_OR_RAISE(
+      auto sink_node,
+      arrow::acero::MakeExecNode("sink", child_plan.plan.get(), {child_plan.top_node}, sink_options)
+   );
+   (void)sink_node;
+   (void)backpressure_monitor;
+
+   ARROW_RETURN_NOT_OK(child_plan.plan->Validate());
+   child_plan.plan->StartProducing();
+
+   std::vector<arrow::ExecBatch> batches;
+   while (true) {
+      auto future = generator();
+      auto result = future.result();
+      if (!result.ok()) {
+         // The plan may report Cancelled when torn down after all data was produced.
+         if (result.status().IsCancelled()) {
+            break;
+         }
+         return result.status();
+      }
+      if (!result->has_value()) {
+         break;
+      }
+      batches.push_back(std::move(result->value()));
+   }
+
+   // Ensure the plan is fully wound down before returning.
+   auto finished_future = child_plan.plan->finished();
+   if (!finished_future.is_finished()) {
+      child_plan.plan->StopProducing();
+      finished_future.Wait();
+   }
+
+   return batches;
+}
+
+arrow::Result<arrow::acero::ExecNode*> makeUnionSource(
+   arrow::acero::ExecPlan* plan,
+   const std::vector<schema::ColumnIdentifier>& output_schema,
+   std::shared_ptr<std::vector<std::vector<arrow::ExecBatch>>> shared_batches
+) {
+   std::function<arrow::Future<std::optional<arrow::ExecBatch>>()> producer =
+      [shared_batches = std::move(shared_batches), child_idx = size_t{0},
+       batch_idx = size_t{0}]() mutable -> arrow::Future<std::optional<arrow::ExecBatch>> {
+      while (child_idx < shared_batches->size()) {
+         auto& child_batches = (*shared_batches)[child_idx];
+         if (batch_idx < child_batches.size()) {
+            auto batch = std::move(child_batches[batch_idx]);
+            ++batch_idx;
+            return arrow::Future<std::optional<arrow::ExecBatch>>{
+               std::optional<arrow::ExecBatch>{std::move(batch)}
+            };
+         }
+         ++child_idx;
+         batch_idx = 0;
+      }
+      return arrow::Future<std::optional<arrow::ExecBatch>>{
+         std::optional<arrow::ExecBatch>{std::nullopt}
+      };
+   };
+
+   const arrow::acero::SourceNodeOptions source_options{
+      exec_node::columnsToArrowSchema(output_schema),
+      std::move(producer),
+      arrow::Ordering::Implicit()
+   };
+   return arrow::acero::MakeExecNode("source", plan, {}, source_options);
+}
+
+}  // namespace
+
+UnionAllNode::UnionAllNode(std::vector<QueryNodePtr> children)
+    : children(std::move(children)) {
+   SILO_ASSERT(this->children.size() >= 2);
+}
+
+std::vector<schema::ColumnIdentifier> UnionAllNode::getOutputSchema() const {
+   return children.front()->getOutputSchema();
+}
+
+arrow::Result<PartialArrowPlan> UnionAllNode::toQueryPlan(
+   const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
+   const config::QueryOptions& query_options
+) const {
+   auto all_batches = std::make_shared<std::vector<std::vector<arrow::ExecBatch>>>();
+   all_batches->reserve(children.size());
+
+   for (const auto& child : children) {
+      ARROW_ASSIGN_OR_RAISE(auto child_plan, child->toQueryPlan(tables, query_options));
+      ARROW_ASSIGN_OR_RAISE(auto batches, drainChildPlan(child_plan));
+      all_batches->push_back(std::move(batches));
+   }
+
+   ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
+
+   ARROW_ASSIGN_OR_RAISE(
+      auto source_node,
+      makeUnionSource(arrow_plan.get(), getOutputSchema(), std::move(all_batches))
+   );
+
+   return PartialArrowPlan{.top_node = source_node, .plan = arrow_plan};
+}
+
+nlohmann::json UnionAllNode::toJson() const {
+   nlohmann::json children_json = nlohmann::json::array();
+   for (const auto& child : children) {
+      children_json.push_back(child->toJson());
+   }
+   return {
+      {"type", nodeKindToString(kind())},
+      {"children", std::move(children_json)},
+   };
+}
+
+}  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/union_all_node.cpp
+++ b/src/silo/query_engine/operators/union_all_node.cpp
@@ -68,42 +68,43 @@ struct StreamState {
 
 /// Pull the next batch from the streaming union.
 /// Starts child plans on demand, drains them one at a time, then advances.
-// NOLINTNEXTLINE(misc-no-recursion)
 arrow::Future<std::optional<arrow::ExecBatch>> pullNext(const std::shared_ptr<StreamState>& state) {
-   if (state->child_idx >= state->child_plans.size()) {
-      return arrow::Future{std::optional<arrow::ExecBatch>{std::nullopt}};
-   }
-
-   if (!state->generator_active) {
-      auto status = state->startCurrentChild();
-      if (!status.ok()) {
-         return arrow::Future{arrow::Result<std::optional<arrow::ExecBatch>>{status}};
+   while (true) {
+      if (state->child_idx >= state->child_plans.size()) {
+         return arrow::Future{std::optional<arrow::ExecBatch>{std::nullopt}};
       }
-   }
 
-   auto future = state->current_generator();
-   auto result = future.result();
+      if (!state->generator_active) {
+         auto status = state->startCurrentChild();
+         if (!status.ok()) {
+            return arrow::Future{arrow::Result<std::optional<arrow::ExecBatch>>{status}};
+         }
+      }
 
-   if (!result.ok()) {
-      if (result.status().IsCancelled()) {
-         SPDLOG_WARN(
-            "UnionAll: child {} generator returned Cancelled, advancing to next child",
-            state->child_idx
-         );
+      auto future = state->current_generator();
+      auto result = future.result();
+
+      if (!result.ok()) {
+         if (result.status().IsCancelled()) {
+            SPDLOG_WARN(
+               "UnionAll: child {} generator returned Cancelled, advancing to next child",
+               state->child_idx
+            );
+            state->stopCurrentChild();
+            ++state->child_idx;
+            continue;
+         }
+         return arrow::Future{arrow::Result<std::optional<arrow::ExecBatch>>{result.status()}};
+      }
+
+      if (!result->has_value()) {
          state->stopCurrentChild();
          ++state->child_idx;
-         return pullNext(state);
+         continue;
       }
-      return arrow::Future{arrow::Result<std::optional<arrow::ExecBatch>>{result.status()}};
-   }
 
-   if (!result->has_value()) {
-      state->stopCurrentChild();
-      ++state->child_idx;
-      return pullNext(state);
+      return arrow::Future{std::move(result.ValueUnsafe())};
    }
-
-   return arrow::Future{std::move(result.ValueUnsafe())};
 }
 
 }  // namespace

--- a/src/silo/query_engine/operators/union_all_node.cpp
+++ b/src/silo/query_engine/operators/union_all_node.cpp
@@ -116,13 +116,12 @@ arrow::Future<std::optional<arrow::ExecBatch>> pullNext(const std::shared_ptr<St
 
 }  // namespace
 
-UnionAllNode::UnionAllNode(std::vector<QueryNodePtr> children)
-    : children(std::move(children)) {
-   SILO_ASSERT(this->children.size() == 2);
-}
+UnionAllNode::UnionAllNode(QueryNodePtr left, QueryNodePtr right)
+    : left(std::move(left)),
+      right(std::move(right)) {}
 
 std::vector<schema::ColumnIdentifier> UnionAllNode::getOutputSchema() const {
-   return children.front()->getOutputSchema();
+   return left->getOutputSchema();
 }
 
 arrow::Result<PartialArrowPlan> UnionAllNode::toQueryPlan(
@@ -133,13 +132,13 @@ arrow::Result<PartialArrowPlan> UnionAllNode::toQueryPlan(
    // Actual data production is deferred — each child is started and drained lazily
    // by the streaming producer, so only one child's batches are in flight at a time.
    auto state = std::make_shared<StreamState>();
-   state->child_plans.reserve(children.size());
-   for (const auto& child : children) {
-      ARROW_ASSIGN_OR_RAISE(auto child_plan, child->toQueryPlan(tables, query_options));
-      state->child_plans.push_back(std::move(child_plan));
-   }
+   state->child_plans.reserve(2);
+   ARROW_ASSIGN_OR_RAISE(auto left_plan, left->toQueryPlan(tables, query_options));
+   state->child_plans.push_back(std::move(left_plan));
+   ARROW_ASSIGN_OR_RAISE(auto right_plan, right->toQueryPlan(tables, query_options));
+   state->child_plans.push_back(std::move(right_plan));
 
-   std::function<arrow::Future<std::optional<arrow::ExecBatch>>()> producer = [state]() {
+   std::function<arrow::Future<std::optional<arrow::ExecBatch>>()> producer = [state] {
       return pullNext(state);
    };
 
@@ -158,13 +157,10 @@ arrow::Result<PartialArrowPlan> UnionAllNode::toQueryPlan(
 }
 
 nlohmann::json UnionAllNode::toJson() const {
-   nlohmann::json children_json = nlohmann::json::array();
-   for (const auto& child : children) {
-      children_json.push_back(child->toJson());
-   }
    return {
       {"type", nodeKindToString(kind())},
-      {"children", std::move(children_json)},
+      {"left", left->toJson()},
+      {"right", right->toJson()},
    };
 }
 

--- a/src/silo/query_engine/operators/union_all_node.cpp
+++ b/src/silo/query_engine/operators/union_all_node.cpp
@@ -1,125 +1,10 @@
 #include "silo/query_engine/operators/union_all_node.h"
 
-#include <functional>
-#include <optional>
-
 #include <arrow/acero/exec_plan.h>
 #include <arrow/acero/options.h>
-#include <arrow/util/async_generator.h>
-#include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
 
-#include "silo/common/panic.h"
-#include "silo/common/size_constants.h"
-#include "silo/query_engine/exec_node/arrow_util.h"
-
 namespace silo::query_engine::operators {
-
-namespace {
-
-/// Mutable state for the streaming union producer.
-/// Owns the pre-built child plans and drains them lazily one at a time.
-struct StreamState {
-   std::vector<PartialArrowPlan> child_plans;
-
-   size_t child_idx = 0;
-   std::shared_ptr<arrow::acero::ExecPlan> current_plan;
-   arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> current_generator;
-   bool generator_active = false;
-
-   ~StreamState() { stopCurrentChild(); }
-
-   /// Attach a sink to the current child plan and start producing.
-   arrow::Status startCurrentChild() {
-      SILO_ASSERT(child_idx < child_plans.size());
-      SILO_ASSERT(!generator_active);
-
-      auto& partial = child_plans[child_idx];
-      current_plan = partial.plan;
-
-      arrow::acero::BackpressureMonitor* backpressure_monitor = nullptr;
-      const arrow::acero::SinkNodeOptions sink_options{
-         &current_generator,
-         arrow::acero::BackpressureOptions{
-            /*.resume_if_below =*/silo::common::S_16_KB,
-            /*.pause_if_above =*/silo::common::S_64_MB
-         },
-         &backpressure_monitor,
-         true
-      };
-      ARROW_ASSIGN_OR_RAISE(
-         auto sink_node,
-         arrow::acero::MakeExecNode("sink", current_plan.get(), {partial.top_node}, sink_options)
-      );
-      (void)sink_node;
-      (void)backpressure_monitor;
-
-      ARROW_RETURN_NOT_OK(current_plan->Validate());
-      current_plan->StartProducing();
-      generator_active = true;
-      return arrow::Status::OK();
-   }
-
-   /// Tear down the current child plan.
-   void stopCurrentChild() {
-      constexpr double GRACE_SHUTDOWN_SECONDS = 5.0;
-      if (!current_plan) {
-         return;
-      }
-      auto finished_future = current_plan->finished();
-      if (!finished_future.is_finished()) {
-         current_plan->StopProducing();
-         const bool drained = finished_future.Wait(GRACE_SHUTDOWN_SECONDS);
-         if (!drained) {
-            SPDLOG_WARN(
-               "UnionAll: child plan cleanup exceeded {} s grace; continuing.",
-               GRACE_SHUTDOWN_SECONDS
-            );
-         }
-      }
-      current_plan.reset();
-      generator_active = false;
-   }
-};
-
-/// Pull the next batch from the streaming union.
-/// Starts child plans on demand, drains them one at a time, then advances.
-/// Note: blocks synchronously on the child generator. This is intentional — the child
-/// plan runs on the same shared Arrow thread pool, so async continuations would deadlock.
-/// This matches the pattern used by QueryPlan::executeAndWriteImpl.
-arrow::Future<std::optional<arrow::ExecBatch>> pullNext(const std::shared_ptr<StreamState>& state) {
-   while (true) {
-      if (state->child_idx >= state->child_plans.size()) {
-         return arrow::Future{std::optional<arrow::ExecBatch>{std::nullopt}};
-      }
-
-      if (!state->generator_active) {
-         auto status = state->startCurrentChild();
-         if (!status.ok()) {
-            return arrow::Future{arrow::Result<std::optional<arrow::ExecBatch>>{status}};
-         }
-      }
-
-      auto future = state->current_generator();
-      auto result = future.result();
-
-      if (!result.ok()) {
-         // Propagate all errors (including Cancelled) to the caller.
-         state->stopCurrentChild();
-         return arrow::Future{arrow::Result<std::optional<arrow::ExecBatch>>{result.status()}};
-      }
-
-      if (!result->has_value()) {
-         state->stopCurrentChild();
-         ++state->child_idx;
-         continue;
-      }
-
-      return arrow::Future{std::move(result.ValueUnsafe())};
-   }
-}
-
-}  // namespace
 
 UnionAllNode::UnionAllNode(QueryNodePtr left, QueryNodePtr right)
     : left(std::move(left)),
@@ -129,36 +14,14 @@ std::vector<schema::ColumnIdentifier> UnionAllNode::getOutputSchema() const {
    return left->getOutputSchema();
 }
 
-arrow::Result<PartialArrowPlan> UnionAllNode::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> UnionAllNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
    const config::QueryOptions& query_options
 ) const {
-   // Build child plans eagerly (cheap: creates Arrow nodes + compiles bitmap filters).
-   // Actual data production is deferred — each child is started and drained lazily
-   // by the streaming producer, so only one child's batches are in flight at a time.
-   auto state = std::make_shared<StreamState>();
-   state->child_plans.reserve(2);
-   ARROW_ASSIGN_OR_RAISE(auto left_plan, left->toQueryPlan(tables, query_options));
-   state->child_plans.push_back(std::move(left_plan));
-   ARROW_ASSIGN_OR_RAISE(auto right_plan, right->toQueryPlan(tables, query_options));
-   state->child_plans.push_back(std::move(right_plan));
-
-   std::function<arrow::Future<std::optional<arrow::ExecBatch>>()> producer = [state] {
-      return pullNext(state);
-   };
-
-   ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
-
-   const arrow::acero::SourceNodeOptions source_options{
-      exec_node::columnsToArrowSchema(getOutputSchema()),
-      std::move(producer),
-      arrow::Ordering::Implicit()
-   };
-   ARROW_ASSIGN_OR_RAISE(
-      auto source_node, arrow::acero::MakeExecNode("source", arrow_plan.get(), {}, source_options)
-   );
-
-   return PartialArrowPlan{.top_node = source_node, .plan = arrow_plan};
+   ARROW_ASSIGN_OR_RAISE(auto* left_node, left->addToExecPlan(plan, tables, query_options));
+   ARROW_ASSIGN_OR_RAISE(auto* right_node, right->addToExecPlan(plan, tables, query_options));
+   return arrow::acero::MakeExecNode("union", &plan, {left_node, right_node}, {});
 }
 
 nlohmann::json UnionAllNode::toJson() const {

--- a/src/silo/query_engine/operators/union_all_node.cpp
+++ b/src/silo/query_engine/operators/union_all_node.cpp
@@ -8,6 +8,8 @@
 #include <arrow/util/async_generator.h>
 #include <nlohmann/json.hpp>
 
+#include <spdlog/spdlog.h>
+
 #include "silo/common/panic.h"
 #include "silo/query_engine/exec_node/arrow_util.h"
 
@@ -19,7 +21,7 @@ namespace {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 arrow::Result<std::vector<arrow::ExecBatch>> drainChildPlan(PartialArrowPlan& child_plan) {
    arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> generator;
-   arrow::acero::BackpressureMonitor* backpressure_monitor;
+   arrow::acero::BackpressureMonitor* backpressure_monitor = nullptr;
    const arrow::acero::SinkNodeOptions sink_options{
       &generator, arrow::acero::BackpressureOptions{}, &backpressure_monitor, true
    };
@@ -38,8 +40,13 @@ arrow::Result<std::vector<arrow::ExecBatch>> drainChildPlan(PartialArrowPlan& ch
       auto future = generator();
       auto result = future.result();
       if (!result.ok()) {
-         // The plan may report Cancelled when torn down after all data was produced.
+         // The plan may report Cancelled when torn down after all data was produced
+         // due to Arrow Acero's internal threading. This is expected and not an error.
          if (result.status().IsCancelled()) {
+            SPDLOG_WARN(
+               "UnionAll child plan generator returned Cancelled after {} batches",
+               batches.size()
+            );
             break;
          }
          return result.status();
@@ -97,7 +104,7 @@ arrow::Result<arrow::acero::ExecNode*> makeUnionSource(
 
 UnionAllNode::UnionAllNode(std::vector<QueryNodePtr> children)
     : children(std::move(children)) {
-   SILO_ASSERT(this->children.size() >= 2);
+   SILO_ASSERT(this->children.size() == 2);
 }
 
 std::vector<schema::ColumnIdentifier> UnionAllNode::getOutputSchema() const {
@@ -108,6 +115,9 @@ arrow::Result<PartialArrowPlan> UnionAllNode::toQueryPlan(
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
    const config::QueryOptions& query_options
 ) const {
+   // NOTE: This eagerly materializes ALL child batches into memory before producing output.
+   // For large datasets both child results are buffered simultaneously. A future optimization
+   // could stream batches lazily, draining the second child only after the first is consumed.
    auto all_batches = std::make_shared<std::vector<std::vector<arrow::ExecBatch>>>();
    all_batches->reserve(children.size());
 

--- a/src/silo/query_engine/operators/union_all_node.cpp
+++ b/src/silo/query_engine/operators/union_all_node.cpp
@@ -6,8 +6,8 @@
 #include <arrow/acero/exec_plan.h>
 #include <arrow/acero/options.h>
 #include <arrow/util/async_generator.h>
-#include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
 
 #include "silo/common/panic.h"
 #include "silo/query_engine/exec_node/arrow_util.h"

--- a/src/silo/query_engine/operators/union_all_node.cpp
+++ b/src/silo/query_engine/operators/union_all_node.cpp
@@ -7,7 +7,6 @@
 #include <arrow/acero/options.h>
 #include <arrow/util/async_generator.h>
 #include <nlohmann/json.hpp>
-
 #include <spdlog/spdlog.h>
 
 #include "silo/common/panic.h"
@@ -17,87 +16,100 @@ namespace silo::query_engine::operators {
 
 namespace {
 
-/// Execute a child plan to completion and collect all output batches.
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
-arrow::Result<std::vector<arrow::ExecBatch>> drainChildPlan(PartialArrowPlan& child_plan) {
-   arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> generator;
-   arrow::acero::BackpressureMonitor* backpressure_monitor = nullptr;
-   const arrow::acero::SinkNodeOptions sink_options{
-      &generator, arrow::acero::BackpressureOptions{}, &backpressure_monitor, true
-   };
-   ARROW_ASSIGN_OR_RAISE(
-      auto sink_node,
-      arrow::acero::MakeExecNode("sink", child_plan.plan.get(), {child_plan.top_node}, sink_options)
-   );
-   (void)sink_node;
-   (void)backpressure_monitor;
+/// Mutable state for the streaming union producer.
+/// Owns the pre-built child plans and drains them lazily one at a time.
+struct StreamState {
+   std::vector<PartialArrowPlan> child_plans;
 
-   ARROW_RETURN_NOT_OK(child_plan.plan->Validate());
-   child_plan.plan->StartProducing();
+   size_t child_idx = 0;
+   std::shared_ptr<arrow::acero::ExecPlan> current_plan;
+   arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> current_generator;
+   bool generator_active = false;
 
-   std::vector<arrow::ExecBatch> batches;
-   while (true) {
-      auto future = generator();
-      auto result = future.result();
-      if (!result.ok()) {
-         // The plan may report Cancelled when torn down after all data was produced
-         // due to Arrow Acero's internal threading. This is expected and not an error.
-         if (result.status().IsCancelled()) {
-            SPDLOG_WARN(
-               "UnionAll child plan generator returned Cancelled after {} batches",
-               batches.size()
-            );
-            break;
-         }
-         return result.status();
-      }
-      if (!result->has_value()) {
-         break;
-      }
-      batches.push_back(std::move(result->value()));
+   /// Attach a sink to the current child plan and start producing.
+   arrow::Status startCurrentChild() {
+      SILO_ASSERT(child_idx < child_plans.size());
+      SILO_ASSERT(!generator_active);
+
+      auto& partial = child_plans[child_idx];
+      current_plan = partial.plan;
+
+      arrow::acero::BackpressureMonitor* backpressure_monitor = nullptr;
+      const arrow::acero::SinkNodeOptions sink_options{
+         &current_generator, arrow::acero::BackpressureOptions{}, &backpressure_monitor, true
+      };
+      ARROW_ASSIGN_OR_RAISE(
+         auto sink_node,
+         arrow::acero::MakeExecNode("sink", current_plan.get(), {partial.top_node}, sink_options)
+      );
+      (void)sink_node;
+      (void)backpressure_monitor;
+
+      ARROW_RETURN_NOT_OK(current_plan->Validate());
+      current_plan->StartProducing();
+      generator_active = true;
+      return arrow::Status::OK();
    }
 
-   // Ensure the plan is fully wound down before returning.
-   auto finished_future = child_plan.plan->finished();
-   if (!finished_future.is_finished()) {
-      child_plan.plan->StopProducing();
-      finished_future.Wait();
-   }
-
-   return batches;
-}
-
-arrow::Result<arrow::acero::ExecNode*> makeUnionSource(
-   arrow::acero::ExecPlan* plan,
-   const std::vector<schema::ColumnIdentifier>& output_schema,
-   std::shared_ptr<std::vector<std::vector<arrow::ExecBatch>>> shared_batches
-) {
-   std::function<arrow::Future<std::optional<arrow::ExecBatch>>()> producer =
-      [shared_batches = std::move(shared_batches), child_idx = size_t{0},
-       batch_idx = size_t{0}]() mutable -> arrow::Future<std::optional<arrow::ExecBatch>> {
-      while (child_idx < shared_batches->size()) {
-         auto& child_batches = (*shared_batches)[child_idx];
-         if (batch_idx < child_batches.size()) {
-            auto batch = std::move(child_batches[batch_idx]);
-            ++batch_idx;
-            return arrow::Future<std::optional<arrow::ExecBatch>>{
-               std::optional<arrow::ExecBatch>{std::move(batch)}
-            };
-         }
-         ++child_idx;
-         batch_idx = 0;
+   /// Tear down the current child plan.
+   void stopCurrentChild() {
+      if (!current_plan) {
+         return;
       }
-      return arrow::Future<std::optional<arrow::ExecBatch>>{
+      auto finished_future = current_plan->finished();
+      if (!finished_future.is_finished()) {
+         current_plan->StopProducing();
+         finished_future.Wait();
+      }
+      current_plan.reset();
+      generator_active = false;
+   }
+};
+
+/// Pull the next batch from the streaming union.
+/// Starts child plans on demand, drains them one at a time, then advances.
+// NOLINTNEXTLINE(misc-no-recursion)
+arrow::Future<std::optional<arrow::ExecBatch>> pullNext(const std::shared_ptr<StreamState>& state) {
+   if (state->child_idx >= state->child_plans.size()) {
+      return arrow::Future{
          std::optional<arrow::ExecBatch>{std::nullopt}
       };
-   };
+   }
 
-   const arrow::acero::SourceNodeOptions source_options{
-      exec_node::columnsToArrowSchema(output_schema),
-      std::move(producer),
-      arrow::Ordering::Implicit()
-   };
-   return arrow::acero::MakeExecNode("source", plan, {}, source_options);
+   if (!state->generator_active) {
+      auto status = state->startCurrentChild();
+      if (!status.ok()) {
+         return arrow::Future{
+            arrow::Result<std::optional<arrow::ExecBatch>>{status}
+         };
+      }
+   }
+
+   auto future = state->current_generator();
+   auto result = future.result();
+
+   if (!result.ok()) {
+      if (result.status().IsCancelled()) {
+         SPDLOG_WARN(
+            "UnionAll: child {} generator returned Cancelled, advancing to next child",
+            state->child_idx
+         );
+         state->stopCurrentChild();
+         ++state->child_idx;
+         return pullNext(state);
+      }
+      return arrow::Future{
+         arrow::Result<std::optional<arrow::ExecBatch>>{result.status()}
+      };
+   }
+
+   if (!result->has_value()) {
+      state->stopCurrentChild();
+      ++state->child_idx;
+      return pullNext(state);
+   }
+
+   return arrow::Future{std::move(result.ValueUnsafe())};
 }
 
 }  // namespace
@@ -115,23 +127,29 @@ arrow::Result<PartialArrowPlan> UnionAllNode::toQueryPlan(
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
    const config::QueryOptions& query_options
 ) const {
-   // NOTE: This eagerly materializes ALL child batches into memory before producing output.
-   // For large datasets both child results are buffered simultaneously. A future optimization
-   // could stream batches lazily, draining the second child only after the first is consumed.
-   auto all_batches = std::make_shared<std::vector<std::vector<arrow::ExecBatch>>>();
-   all_batches->reserve(children.size());
-
+   // Build child plans eagerly (cheap: creates Arrow nodes + compiles bitmap filters).
+   // Actual data production is deferred — each child is started and drained lazily
+   // by the streaming producer, so only one child's batches are in flight at a time.
+   auto state = std::make_shared<StreamState>();
+   state->child_plans.reserve(children.size());
    for (const auto& child : children) {
       ARROW_ASSIGN_OR_RAISE(auto child_plan, child->toQueryPlan(tables, query_options));
-      ARROW_ASSIGN_OR_RAISE(auto batches, drainChildPlan(child_plan));
-      all_batches->push_back(std::move(batches));
+      state->child_plans.push_back(std::move(child_plan));
    }
+
+   std::function<arrow::Future<std::optional<arrow::ExecBatch>>()> producer =
+      [state]() { return pullNext(state); };
 
    ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
 
+   const arrow::acero::SourceNodeOptions source_options{
+      exec_node::columnsToArrowSchema(getOutputSchema()),
+      std::move(producer),
+      arrow::Ordering::Implicit()
+   };
    ARROW_ASSIGN_OR_RAISE(
       auto source_node,
-      makeUnionSource(arrow_plan.get(), getOutputSchema(), std::move(all_batches))
+      arrow::acero::MakeExecNode("source", arrow_plan.get(), {}, source_options)
    );
 
    return PartialArrowPlan{.top_node = source_node, .plan = arrow_plan};

--- a/src/silo/query_engine/operators/union_all_node.cpp
+++ b/src/silo/query_engine/operators/union_all_node.cpp
@@ -6,8 +6,8 @@
 #include <arrow/acero/exec_plan.h>
 #include <arrow/acero/options.h>
 #include <arrow/util/async_generator.h>
-#include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
 
 #include "silo/common/panic.h"
 #include "silo/query_engine/exec_node/arrow_util.h"

--- a/src/silo/query_engine/operators/union_all_node.h
+++ b/src/silo/query_engine/operators/union_all_node.h
@@ -2,7 +2,6 @@
 
 #include <map>
 #include <memory>
-#include <vector>
 
 #include <arrow/result.h>
 
@@ -16,9 +15,10 @@ namespace silo::query_engine::operators {
 /// Both children must produce compatible output schemas (same column names and types).
 class UnionAllNode final : public QueryNode {
   public:
-   std::vector<QueryNodePtr> children;
+   QueryNodePtr left;
+   QueryNodePtr right;
 
-   explicit UnionAllNode(std::vector<QueryNodePtr> children);
+   UnionAllNode(QueryNodePtr left, QueryNodePtr right);
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 

--- a/src/silo/query_engine/operators/union_all_node.h
+++ b/src/silo/query_engine/operators/union_all_node.h
@@ -22,7 +22,8 @@ class UnionAllNode final : public QueryNode {
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/operators/union_all_node.h
+++ b/src/silo/query_engine/operators/union_all_node.h
@@ -12,8 +12,8 @@
 
 namespace silo::query_engine::operators {
 
-/// Concatenates the output of multiple child pipelines (UNION ALL semantics).
-/// All children must produce compatible output schemas (same column names and types).
+/// Concatenates the output of two child pipelines (UNION ALL semantics).
+/// Both children must produce compatible output schemas (same column names and types).
 class UnionAllNode final : public QueryNode {
   public:
    std::vector<QueryNodePtr> children;

--- a/src/silo/query_engine/operators/union_all_node.h
+++ b/src/silo/query_engine/operators/union_all_node.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include <arrow/result.h>
+
+#include "silo/query_engine/operators/query_node.h"
+#include "silo/schema/database_schema.h"
+#include "silo/storage/table.h"
+
+namespace silo::query_engine::operators {
+
+/// Concatenates the output of multiple child pipelines (UNION ALL semantics).
+/// All children must produce compatible output schemas (same column names and types).
+class UnionAllNode final : public QueryNode {
+  public:
+   std::vector<QueryNodePtr> children;
+
+   explicit UnionAllNode(std::vector<QueryNodePtr> children);
+
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
+
+   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+      const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
+      const config::QueryOptions& query_options
+   ) const override;
+
+   [[nodiscard]] NodeKind kind() const override { return NodeKind::UNION_ALL; }
+
+   [[nodiscard]] nlohmann::json toJson() const override;
+};
+
+}  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -153,6 +153,31 @@ const QueryTestScenario UNION_ALL_DIFFERENT_COLUMN_ORDER_SCENARIO = {
    )
 };
 
+// Nested unionAll: unionAll of two unionAlls
+const QueryTestScenario UNION_ALL_NESTED_SCENARIO = {
+   .name = "UNION_ALL_NESTED",
+   .query = R"(unionAll(
+      unionAll(
+         default.filter(country='CH').project({primaryKey}),
+         default.filter(country='DE').project({primaryKey})
+      ),
+      unionAll(
+         default.filter(country='CH').project({primaryKey}),
+         default.filter(country='DE').project({primaryKey})
+      )
+   ))",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}},
+       {{"primaryKey", "id_2"}},
+       {{"primaryKey", "id_1"}},
+       {{"primaryKey", "id_3"}},
+       {{"primaryKey", "id_0"}},
+       {{"primaryKey", "id_2"}},
+       {{"primaryKey", "id_1"}},
+       {{"primaryKey", "id_3"}}}
+   )
+};
+
 // Downstream filter above unionAll should be rejected (not silently dropped)
 const QueryTestScenario UNION_ALL_DOWNSTREAM_FILTER_SCENARIO = {
    .name = "UNION_ALL_DOWNSTREAM_FILTER",
@@ -178,6 +203,7 @@ QUERY_TEST(
       UNION_ALL_SCHEMA_MISMATCH_SCENARIO,
       UNION_ALL_TYPE_MISMATCH_SCENARIO,
       UNION_ALL_DIFFERENT_COLUMN_ORDER_SCENARIO,
+      UNION_ALL_NESTED_SCENARIO,
       UNION_ALL_DOWNSTREAM_FILTER_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -119,7 +119,20 @@ const QueryTestScenario UNION_ALL_SCHEMA_MISMATCH_SCENARIO = {
    .expected_error_message =
       "unionAll requires both inputs to have the same schema "
       "(same column names and types). "
-      "Left schema: [primaryKey], right schema: [country]."
+      "Left schema: [primaryKey:STRING], right schema: [country:STRING]."
+};
+
+// Downstream filter above unionAll should be rejected (not silently dropped)
+const QueryTestScenario UNION_ALL_DOWNSTREAM_FILTER_SCENARIO = {
+   .name = "UNION_ALL_DOWNSTREAM_FILTER",
+   .query = R"(unionAll(
+      default.project({primaryKey, country}),
+      default.project({primaryKey, country})
+   ).filter(country='CH'))",
+   .expected_query_result = {},
+   .expected_error_message =
+      "filter above unionAll is not supported. "
+      "Apply the filter inside each child of the unionAll instead."
 };
 }  // namespace
 
@@ -131,6 +144,7 @@ QUERY_TEST(
       UNION_ALL_DUPLICATES_SCENARIO,
       UNION_ALL_WITH_GROUPBY_SCENARIO,
       UNION_ALL_EMPTY_CHILD_SCENARIO,
-      UNION_ALL_SCHEMA_MISMATCH_SCENARIO
+      UNION_ALL_SCHEMA_MISMATCH_SCENARIO,
+      UNION_ALL_DOWNSTREAM_FILTER_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -247,9 +247,7 @@ const QueryTestScenario UNION_ALL_COMBINED_FILTERS_SCENARIO = {
       default.filter(country='CH').project({primaryKey, country}),
       default.filter(country='DE').project({primaryKey, country})
    ).filter(primaryKey='id_0'))",
-   .expected_query_result = nlohmann::json(
-      {{{"primaryKey", "id_0"}, {"country", "CH"}}}
-   )
+   .expected_query_result = nlohmann::json({{{"primaryKey", "id_0"}, {"country", "CH"}}})
 };
 }  // namespace
 

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -196,6 +196,36 @@ const QueryTestScenario UNION_ALL_OF_MUTATIONS_SCENARIO = {
    )
 };
 
+// Piped syntax: left.unionAll(right) instead of unionAll(left, right)
+const QueryTestScenario UNION_ALL_PIPED_SYNTAX_SCENARIO = {
+   .name = "UNION_ALL_PIPED_SYNTAX",
+   .query = R"(
+      default.filter(country='CH').project({primaryKey, country})
+         .unionAll(default.filter(country='DE').project({primaryKey, country}))
+   )",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"country", "CH"}},
+       {{"primaryKey", "id_2"}, {"country", "CH"}},
+       {{"primaryKey", "id_1"}, {"country", "DE"}},
+       {{"primaryKey", "id_3"}, {"country", "DE"}}}
+   )
+};
+
+// Named arguments: unionAll(left:=..., right:=...)
+const QueryTestScenario UNION_ALL_NAMED_ARGS_SCENARIO = {
+   .name = "UNION_ALL_NAMED_ARGS",
+   .query = R"(unionAll(
+      left:=default.filter(country='CH').project({primaryKey, country}),
+      right:=default.filter(country='DE').project({primaryKey, country})
+   ))",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"country", "CH"}},
+       {{"primaryKey", "id_2"}, {"country", "CH"}},
+       {{"primaryKey", "id_1"}, {"country", "DE"}},
+       {{"primaryKey", "id_3"}, {"country", "DE"}}}
+   )
+};
+
 // Downstream filter above unionAll should be rejected (not silently dropped)
 const QueryTestScenario UNION_ALL_DOWNSTREAM_FILTER_SCENARIO = {
    .name = "UNION_ALL_DOWNSTREAM_FILTER",
@@ -224,6 +254,8 @@ QUERY_TEST(
       UNION_ALL_NESTED_SCENARIO,
       UNION_ALL_MUTATIONS_ON_UNION_SCENARIO,
       UNION_ALL_OF_MUTATIONS_SCENARIO,
+      UNION_ALL_PIPED_SYNTAX_SCENARIO,
+      UNION_ALL_NAMED_ARGS_SCENARIO,
       UNION_ALL_DOWNSTREAM_FILTER_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -121,10 +121,6 @@ const QueryTestScenario UNION_ALL_SCHEMA_MISMATCH_SCENARIO = {
       "(same column names and types). "
       "Left schema: [primaryKey], right schema: [country]."
 };
-
-// TODO(#1221): Add multi-table test once the QUERY_TEST fixture supports multiple tables.
-// That is the primary use case for unionAll (see issue description).
-
 }  // namespace
 
 QUERY_TEST(

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -240,6 +240,17 @@ const QueryTestScenario UNION_ALL_DOWNSTREAM_FILTER_SCENARIO = {
        {{"primaryKey", "id_2"}, {"country", "CH"}}}
    )
 };
+// Filter on child AND filter above unionAll both apply
+const QueryTestScenario UNION_ALL_COMBINED_FILTERS_SCENARIO = {
+   .name = "UNION_ALL_COMBINED_FILTERS",
+   .query = R"(unionAll(
+      default.filter(country='CH').project({primaryKey, country}),
+      default.filter(country='DE').project({primaryKey, country})
+   ).filter(primaryKey='id_0'))",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"country", "CH"}}}
+   )
+};
 }  // namespace
 
 QUERY_TEST(
@@ -258,6 +269,7 @@ QUERY_TEST(
       UNION_ALL_OF_MUTATIONS_SCENARIO,
       UNION_ALL_PIPED_SYNTAX_SCENARIO,
       UNION_ALL_NAMED_ARGS_SCENARIO,
-      UNION_ALL_DOWNSTREAM_FILTER_SCENARIO
+      UNION_ALL_DOWNSTREAM_FILTER_SCENARIO,
+      UNION_ALL_COMBINED_FILTERS_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -11,7 +11,7 @@ nlohmann::json createData(const std::string& primaryKey, const std::string& coun
    return {
       {"primaryKey", primaryKey},
       {"country", country},
-      {"segment1", nullptr},
+      {"segment1", {{"sequence", "T"}, {"insertions", nlohmann::json::array()}}},
       {"gene1", nullptr},
       {"unaligned_segment1", nullptr}
    };
@@ -178,6 +178,28 @@ const QueryTestScenario UNION_ALL_NESTED_SCENARIO = {
    )
 };
 
+const QueryTestScenario UNION_ALL_MUTATIONS_ON_UNION_SCENARIO = {
+   .name = "UNION_ALL_MUTATIONS_ON_UNION",
+   .query = R"(unionAll(
+      default.project({primaryKey}),
+      default.project({primaryKey})
+   ).mutations(minProportion:=0.0))",
+   .expected_query_result = {},
+   .expected_error_message = "mutations() must be applied to a table scan"
+};
+
+const QueryTestScenario UNION_ALL_OF_MUTATIONS_SCENARIO = {
+   .name = "UNION_ALL_OF_MUTATIONS",
+   .query = R"(unionAll(
+      default.filter(country='CH').mutations(minProportion:=0.0, fields:={mutation, proportion}),
+      default.filter(country='DE').mutations(minProportion:=0.0, fields:={mutation, proportion})
+   ))",
+   .expected_query_result = nlohmann::json(
+      {{{"mutation", "A1T"}, {"proportion", 1.0}},
+       {{"mutation", "A1T"}, {"proportion", 1.0}}}
+   )
+};
+
 // Downstream filter above unionAll should be rejected (not silently dropped)
 const QueryTestScenario UNION_ALL_DOWNSTREAM_FILTER_SCENARIO = {
    .name = "UNION_ALL_DOWNSTREAM_FILTER",
@@ -204,6 +226,8 @@ QUERY_TEST(
       UNION_ALL_TYPE_MISMATCH_SCENARIO,
       UNION_ALL_DIFFERENT_COLUMN_ORDER_SCENARIO,
       UNION_ALL_NESTED_SCENARIO,
+      UNION_ALL_MUTATIONS_ON_UNION_SCENARIO,
+      UNION_ALL_OF_MUTATIONS_SCENARIO,
       UNION_ALL_DOWNSTREAM_FILTER_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -226,17 +226,19 @@ const QueryTestScenario UNION_ALL_NAMED_ARGS_SCENARIO = {
    )
 };
 
-// Downstream filter above unionAll should be rejected (not silently dropped)
+// Filter above unionAll is pushed into both children
 const QueryTestScenario UNION_ALL_DOWNSTREAM_FILTER_SCENARIO = {
    .name = "UNION_ALL_DOWNSTREAM_FILTER",
    .query = R"(unionAll(
       default.project({primaryKey, country}),
       default.project({primaryKey, country})
    ).filter(country='CH'))",
-   .expected_query_result = {},
-   .expected_error_message =
-      "filter above unionAll is not supported. "
-      "Apply the filter inside each child of the unionAll instead."
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"country", "CH"}},
+       {{"primaryKey", "id_2"}, {"country", "CH"}},
+       {{"primaryKey", "id_0"}, {"country", "CH"}},
+       {{"primaryKey", "id_2"}, {"country", "CH"}}}
+   )
 };
 }  // namespace
 

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -1,0 +1,126 @@
+#include <nlohmann/json.hpp>
+
+#include "silo/test/query_fixture.test.h"
+
+namespace {
+using silo::ReferenceGenomes;
+using silo::test::QueryTestData;
+using silo::test::QueryTestScenario;
+
+nlohmann::json createData(const std::string& primaryKey, const std::string& country, int value) {
+   return {
+      {"primaryKey", primaryKey},
+      {"country", country},
+      {"int_value", value},
+      {"segment1", nullptr},
+      {"gene1", nullptr},
+      {"unaligned_segment1", nullptr}
+   };
+}
+
+const std::vector<nlohmann::json> DATA = {
+   createData("id_0", "CH", 10),
+   createData("id_1", "DE", 20),
+   createData("id_2", "CH", 30),
+   createData("id_3", "DE", 40),
+};
+
+const auto DATABASE_CONFIG =
+   R"(
+defaultNucleotideSequence: "segment1"
+schema:
+  instanceName: "dummy name"
+  metadata:
+    - name: "primaryKey"
+      type: "string"
+    - name: "country"
+      type: "string"
+    - name: "int_value"
+      type: "int"
+  primaryKey: "primaryKey"
+)";
+
+const auto REFERENCE_GENOMES = ReferenceGenomes{
+   {{"segment1", "A"}},
+   {{"gene1", "*"}},
+};
+
+const QueryTestData TEST_DATA{
+   .ndjson_input_data = DATA,
+   .database_config = DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES
+};
+
+// Basic unionAll of two filtered pipelines from the same table
+const QueryTestScenario UNION_ALL_BASIC_SCENARIO = {
+   .name = "UNION_ALL_BASIC",
+   .query = R"(unionAll(
+      default.filter(country='CH').project({primaryKey, country}),
+      default.filter(country='DE').project({primaryKey, country})
+   ))",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"country", "CH"}},
+       {{"primaryKey", "id_2"}, {"country", "CH"}},
+       {{"primaryKey", "id_1"}, {"country", "DE"}},
+       {{"primaryKey", "id_3"}, {"country", "DE"}}}
+   )
+};
+
+// UnionAll produces duplicates (all rows from both sides)
+const QueryTestScenario UNION_ALL_DUPLICATES_SCENARIO = {
+   .name = "UNION_ALL_DUPLICATES",
+   .query = R"(unionAll(
+      default.project({primaryKey}),
+      default.project({primaryKey})
+   ))",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}},
+       {{"primaryKey", "id_1"}},
+       {{"primaryKey", "id_2"}},
+       {{"primaryKey", "id_3"}},
+       {{"primaryKey", "id_0"}},
+       {{"primaryKey", "id_1"}},
+       {{"primaryKey", "id_2"}},
+       {{"primaryKey", "id_3"}}}
+   )
+};
+
+// UnionAll with downstream operations (groupBy on the result)
+const QueryTestScenario UNION_ALL_WITH_GROUPBY_SCENARIO = {
+   .name = "UNION_ALL_WITH_GROUPBY",
+   .query = R"(unionAll(
+      default.filter(country='CH').project({country}),
+      default.filter(country='DE').project({country})
+   ).groupBy({count := count()}, {country}).orderBy({asc(country)}))",
+   .expected_query_result = nlohmann::json(
+      {{{"country", "CH"}, {"count", 2}},
+       {{"country", "DE"}, {"count", 2}}}
+   )
+};
+
+// UnionAll with schema mismatch should error
+const QueryTestScenario UNION_ALL_SCHEMA_MISMATCH_SCENARIO = {
+   .name = "UNION_ALL_SCHEMA_MISMATCH",
+   .query = R"(unionAll(
+      default.project({primaryKey}),
+      default.project({country})
+   ))",
+   .expected_query_result = {},
+   .expected_error_message =
+      "unionAll requires both inputs to have the same schema "
+      "(same column names and types). "
+      "Left schema: [primaryKey], right schema: [country]."
+};
+
+}  // namespace
+
+QUERY_TEST(
+   UnionAllTest,
+   TEST_DATA,
+   ::testing::Values(
+      UNION_ALL_BASIC_SCENARIO,
+      UNION_ALL_DUPLICATES_SCENARIO,
+      UNION_ALL_WITH_GROUPBY_SCENARIO,
+      UNION_ALL_SCHEMA_MISMATCH_SCENARIO
+   )
+);

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -54,11 +54,11 @@ const QueryTestScenario UNION_ALL_BASIC_SCENARIO = {
    .query = R"(unionAll(
       default.filter(country='CH').project({primaryKey, country}),
       default.filter(country='DE').project({primaryKey, country})
-   ))",
+   ).orderBy({asc(primaryKey)}))",
    .expected_query_result = nlohmann::json(
       {{{"primaryKey", "id_0"}, {"country", "CH"}},
-       {{"primaryKey", "id_2"}, {"country", "CH"}},
        {{"primaryKey", "id_1"}, {"country", "DE"}},
+       {{"primaryKey", "id_2"}, {"country", "CH"}},
        {{"primaryKey", "id_3"}, {"country", "DE"}}}
    )
 };
@@ -69,15 +69,15 @@ const QueryTestScenario UNION_ALL_DUPLICATES_SCENARIO = {
    .query = R"(unionAll(
       default.project({primaryKey}),
       default.project({primaryKey})
-   ))",
+   ).orderBy({asc(primaryKey)}))",
    .expected_query_result = nlohmann::json(
       {{{"primaryKey", "id_0"}},
-       {{"primaryKey", "id_1"}},
-       {{"primaryKey", "id_2"}},
-       {{"primaryKey", "id_3"}},
        {{"primaryKey", "id_0"}},
        {{"primaryKey", "id_1"}},
+       {{"primaryKey", "id_1"}},
        {{"primaryKey", "id_2"}},
+       {{"primaryKey", "id_2"}},
+       {{"primaryKey", "id_3"}},
        {{"primaryKey", "id_3"}}}
    )
 };
@@ -99,7 +99,7 @@ const QueryTestScenario UNION_ALL_EMPTY_CHILD_SCENARIO = {
    .query = R"(unionAll(
       default.filter(country='CH').project({primaryKey, country}),
       default.filter(country='XX').project({primaryKey, country})
-   ))",
+   ).orderBy({asc(primaryKey)}))",
    .expected_query_result = nlohmann::json(
       {{{"primaryKey", "id_0"}, {"country", "CH"}}, {{"primaryKey", "id_2"}, {"country", "CH"}}}
    )
@@ -137,15 +137,15 @@ const QueryTestScenario UNION_ALL_DIFFERENT_COLUMN_ORDER_SCENARIO = {
    .query = R"(unionAll(
       default.project({primaryKey, country}),
       default.project({country, primaryKey})
-   ))",
+   ).orderBy({asc(primaryKey)}))",
    .expected_query_result = nlohmann::json(
       {{{"primaryKey", "id_0"}, {"country", "CH"}},
-       {{"primaryKey", "id_1"}, {"country", "DE"}},
-       {{"primaryKey", "id_2"}, {"country", "CH"}},
-       {{"primaryKey", "id_3"}, {"country", "DE"}},
        {{"primaryKey", "id_0"}, {"country", "CH"}},
        {{"primaryKey", "id_1"}, {"country", "DE"}},
+       {{"primaryKey", "id_1"}, {"country", "DE"}},
        {{"primaryKey", "id_2"}, {"country", "CH"}},
+       {{"primaryKey", "id_2"}, {"country", "CH"}},
+       {{"primaryKey", "id_3"}, {"country", "DE"}},
        {{"primaryKey", "id_3"}, {"country", "DE"}}}
    )
 };
@@ -162,15 +162,15 @@ const QueryTestScenario UNION_ALL_NESTED_SCENARIO = {
          default.filter(country='CH').project({primaryKey}),
          default.filter(country='DE').project({primaryKey})
       )
-   ))",
+   ).orderBy({asc(primaryKey)}))",
    .expected_query_result = nlohmann::json(
       {{{"primaryKey", "id_0"}},
-       {{"primaryKey", "id_2"}},
-       {{"primaryKey", "id_1"}},
-       {{"primaryKey", "id_3"}},
        {{"primaryKey", "id_0"}},
-       {{"primaryKey", "id_2"}},
        {{"primaryKey", "id_1"}},
+       {{"primaryKey", "id_1"}},
+       {{"primaryKey", "id_2"}},
+       {{"primaryKey", "id_2"}},
+       {{"primaryKey", "id_3"}},
        {{"primaryKey", "id_3"}}}
    )
 };
@@ -190,7 +190,7 @@ const QueryTestScenario UNION_ALL_OF_MUTATIONS_SCENARIO = {
    .query = R"(unionAll(
       default.filter(country='CH').mutations(minProportion:=0.0, fields:={mutation, proportion}),
       default.filter(country='DE').mutations(minProportion:=0.0, fields:={mutation, proportion})
-   ))",
+   ).orderBy({asc(mutation)}))",
    .expected_query_result = nlohmann::json(
       {{{"mutation", "A1T"}, {"proportion", 1.0}}, {{"mutation", "A1T"}, {"proportion", 1.0}}}
    )
@@ -202,11 +202,12 @@ const QueryTestScenario UNION_ALL_PIPED_SYNTAX_SCENARIO = {
    .query = R"(
       default.filter(country='CH').project({primaryKey, country})
          .unionAll(default.filter(country='DE').project({primaryKey, country}))
+         .orderBy({asc(primaryKey)})
    )",
    .expected_query_result = nlohmann::json(
       {{{"primaryKey", "id_0"}, {"country", "CH"}},
-       {{"primaryKey", "id_2"}, {"country", "CH"}},
        {{"primaryKey", "id_1"}, {"country", "DE"}},
+       {{"primaryKey", "id_2"}, {"country", "CH"}},
        {{"primaryKey", "id_3"}, {"country", "DE"}}}
    )
 };
@@ -217,11 +218,11 @@ const QueryTestScenario UNION_ALL_NAMED_ARGS_SCENARIO = {
    .query = R"(unionAll(
       left:=default.filter(country='CH').project({primaryKey, country}),
       right:=default.filter(country='DE').project({primaryKey, country})
-   ))",
+   ).orderBy({asc(primaryKey)}))",
    .expected_query_result = nlohmann::json(
       {{{"primaryKey", "id_0"}, {"country", "CH"}},
-       {{"primaryKey", "id_2"}, {"country", "CH"}},
        {{"primaryKey", "id_1"}, {"country", "DE"}},
+       {{"primaryKey", "id_2"}, {"country", "CH"}},
        {{"primaryKey", "id_3"}, {"country", "DE"}}}
    )
 };
@@ -232,11 +233,11 @@ const QueryTestScenario UNION_ALL_DOWNSTREAM_FILTER_SCENARIO = {
    .query = R"(unionAll(
       default.project({primaryKey, country}),
       default.project({primaryKey, country})
-   ).filter(country='CH'))",
+   ).filter(country='CH').orderBy({asc(primaryKey)}))",
    .expected_query_result = nlohmann::json(
       {{{"primaryKey", "id_0"}, {"country", "CH"}},
-       {{"primaryKey", "id_2"}, {"country", "CH"}},
        {{"primaryKey", "id_0"}, {"country", "CH"}},
+       {{"primaryKey", "id_2"}, {"country", "CH"}},
        {{"primaryKey", "id_2"}, {"country", "CH"}}}
    )
 };

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -89,10 +89,8 @@ const QueryTestScenario UNION_ALL_WITH_GROUPBY_SCENARIO = {
       default.filter(country='CH').project({country}),
       default.filter(country='DE').project({country})
    ).groupBy({count := count()}, {country}).orderBy({asc(country)}))",
-   .expected_query_result = nlohmann::json(
-      {{{"country", "CH"}, {"count", 2}},
-       {{"country", "DE"}, {"count", 2}}}
-   )
+   .expected_query_result =
+      nlohmann::json({{{"country", "CH"}, {"count", 2}}, {{"country", "DE"}, {"count", 2}}})
 };
 
 // UnionAll where one child produces empty results
@@ -103,8 +101,7 @@ const QueryTestScenario UNION_ALL_EMPTY_CHILD_SCENARIO = {
       default.filter(country='XX').project({primaryKey, country})
    ))",
    .expected_query_result = nlohmann::json(
-      {{{"primaryKey", "id_0"}, {"country", "CH"}},
-       {{"primaryKey", "id_2"}, {"country", "CH"}}}
+      {{{"primaryKey", "id_0"}, {"country", "CH"}}, {{"primaryKey", "id_2"}, {"country", "CH"}}}
    )
 };
 
@@ -195,8 +192,7 @@ const QueryTestScenario UNION_ALL_OF_MUTATIONS_SCENARIO = {
       default.filter(country='DE').mutations(minProportion:=0.0, fields:={mutation, proportion})
    ))",
    .expected_query_result = nlohmann::json(
-      {{{"mutation", "A1T"}, {"proportion", 1.0}},
-       {{"mutation", "A1T"}, {"proportion", 1.0}}}
+      {{{"mutation", "A1T"}, {"proportion", 1.0}}, {{"mutation", "A1T"}, {"proportion", 1.0}}}
    )
 };
 

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -122,6 +122,37 @@ const QueryTestScenario UNION_ALL_SCHEMA_MISMATCH_SCENARIO = {
       "Left schema: [primaryKey:STRING], right schema: [country:STRING]."
 };
 
+// Same column name but different types from map
+const QueryTestScenario UNION_ALL_TYPE_MISMATCH_SCENARIO = {
+   .name = "UNION_ALL_TYPE_MISMATCH",
+   .query = R"(unionAll(
+      default.map({x := 42}).project({primaryKey, x}),
+      default.map({x := 'hello'}).project({primaryKey, x})
+   ))",
+   .expected_query_result = {},
+   .expected_error_message =
+      "unionAll requires both inputs to have the same schema (same column names and types). "
+      "Left schema: [primaryKey:STRING, x:INT64], right schema: [primaryKey:STRING, x:STRING]."
+};
+
+const QueryTestScenario UNION_ALL_DIFFERENT_COLUMN_ORDER_SCENARIO = {
+   .name = "UNION_ALL_DIFFERENT_COLUMN_ORDER",
+   .query = R"(unionAll(
+      default.project({primaryKey, country}),
+      default.project({country, primaryKey})
+   ))",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"country", "CH"}},
+       {{"primaryKey", "id_1"}, {"country", "DE"}},
+       {{"primaryKey", "id_2"}, {"country", "CH"}},
+       {{"primaryKey", "id_3"}, {"country", "DE"}},
+       {{"primaryKey", "id_0"}, {"country", "CH"}},
+       {{"primaryKey", "id_1"}, {"country", "DE"}},
+       {{"primaryKey", "id_2"}, {"country", "CH"}},
+       {{"primaryKey", "id_3"}, {"country", "DE"}}}
+   )
+};
+
 // Downstream filter above unionAll should be rejected (not silently dropped)
 const QueryTestScenario UNION_ALL_DOWNSTREAM_FILTER_SCENARIO = {
    .name = "UNION_ALL_DOWNSTREAM_FILTER",
@@ -145,6 +176,8 @@ QUERY_TEST(
       UNION_ALL_WITH_GROUPBY_SCENARIO,
       UNION_ALL_EMPTY_CHILD_SCENARIO,
       UNION_ALL_SCHEMA_MISMATCH_SCENARIO,
+      UNION_ALL_TYPE_MISMATCH_SCENARIO,
+      UNION_ALL_DIFFERENT_COLUMN_ORDER_SCENARIO,
       UNION_ALL_DOWNSTREAM_FILTER_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -7,11 +7,10 @@ using silo::ReferenceGenomes;
 using silo::test::QueryTestData;
 using silo::test::QueryTestScenario;
 
-nlohmann::json createData(const std::string& primaryKey, const std::string& country, int value) {
+nlohmann::json createData(const std::string& primaryKey, const std::string& country) {
    return {
       {"primaryKey", primaryKey},
       {"country", country},
-      {"int_value", value},
       {"segment1", nullptr},
       {"gene1", nullptr},
       {"unaligned_segment1", nullptr}
@@ -19,10 +18,10 @@ nlohmann::json createData(const std::string& primaryKey, const std::string& coun
 }
 
 const std::vector<nlohmann::json> DATA = {
-   createData("id_0", "CH", 10),
-   createData("id_1", "DE", 20),
-   createData("id_2", "CH", 30),
-   createData("id_3", "DE", 40),
+   createData("id_0", "CH"),
+   createData("id_1", "DE"),
+   createData("id_2", "CH"),
+   createData("id_3", "DE"),
 };
 
 const auto DATABASE_CONFIG =
@@ -35,8 +34,6 @@ schema:
       type: "string"
     - name: "country"
       type: "string"
-    - name: "int_value"
-      type: "int"
   primaryKey: "primaryKey"
 )";
 
@@ -98,6 +95,19 @@ const QueryTestScenario UNION_ALL_WITH_GROUPBY_SCENARIO = {
    )
 };
 
+// UnionAll where one child produces empty results
+const QueryTestScenario UNION_ALL_EMPTY_CHILD_SCENARIO = {
+   .name = "UNION_ALL_EMPTY_CHILD",
+   .query = R"(unionAll(
+      default.filter(country='CH').project({primaryKey, country}),
+      default.filter(country='XX').project({primaryKey, country})
+   ))",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"country", "CH"}},
+       {{"primaryKey", "id_2"}, {"country", "CH"}}}
+   )
+};
+
 // UnionAll with schema mismatch should error
 const QueryTestScenario UNION_ALL_SCHEMA_MISMATCH_SCENARIO = {
    .name = "UNION_ALL_SCHEMA_MISMATCH",
@@ -112,6 +122,9 @@ const QueryTestScenario UNION_ALL_SCHEMA_MISMATCH_SCENARIO = {
       "Left schema: [primaryKey], right schema: [country]."
 };
 
+// TODO(#1221): Add multi-table test once the QUERY_TEST fixture supports multiple tables.
+// That is the primary use case for unionAll (see issue description).
+
 }  // namespace
 
 QUERY_TEST(
@@ -121,6 +134,7 @@ QUERY_TEST(
       UNION_ALL_BASIC_SCENARIO,
       UNION_ALL_DUPLICATES_SCENARIO,
       UNION_ALL_WITH_GROUPBY_SCENARIO,
+      UNION_ALL_EMPTY_CHILD_SCENARIO,
       UNION_ALL_SCHEMA_MISMATCH_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -115,7 +115,7 @@ const QueryTestScenario UNION_ALL_SCHEMA_MISMATCH_SCENARIO = {
    .expected_query_result = {},
    .expected_error_message =
       "unionAll requires both inputs to have the same schema "
-      "(same column names and types). "
+      "(same column names, types, and order). "
       "Left schema: [primaryKey:STRING], right schema: [country:STRING]."
 };
 
@@ -128,7 +128,8 @@ const QueryTestScenario UNION_ALL_TYPE_MISMATCH_SCENARIO = {
    ))",
    .expected_query_result = {},
    .expected_error_message =
-      "unionAll requires both inputs to have the same schema (same column names and types). "
+      "unionAll requires both inputs to have the same schema "
+      "(same column names, types, and order). "
       "Left schema: [primaryKey:STRING, x:INT64], right schema: [primaryKey:STRING, x:STRING]."
 };
 
@@ -137,17 +138,13 @@ const QueryTestScenario UNION_ALL_DIFFERENT_COLUMN_ORDER_SCENARIO = {
    .query = R"(unionAll(
       default.project({primaryKey, country}),
       default.project({country, primaryKey})
-   ).orderBy({asc(primaryKey)}))",
-   .expected_query_result = nlohmann::json(
-      {{{"primaryKey", "id_0"}, {"country", "CH"}},
-       {{"primaryKey", "id_0"}, {"country", "CH"}},
-       {{"primaryKey", "id_1"}, {"country", "DE"}},
-       {{"primaryKey", "id_1"}, {"country", "DE"}},
-       {{"primaryKey", "id_2"}, {"country", "CH"}},
-       {{"primaryKey", "id_2"}, {"country", "CH"}},
-       {{"primaryKey", "id_3"}, {"country", "DE"}},
-       {{"primaryKey", "id_3"}, {"country", "DE"}}}
-   )
+   ))",
+   .expected_query_result = {},
+   .expected_error_message =
+      "unionAll requires both inputs to have the same schema "
+      "(same column names, types, and order). "
+      "Left schema: [primaryKey:STRING, country:STRING], "
+      "right schema: [country:STRING, primaryKey:STRING]."
 };
 
 // Nested unionAll: unionAll of two unionAlls

--- a/src/silo/query_engine/operators/unresolved_insertions_node.h
+++ b/src/silo/query_engine/operators/unresolved_insertions_node.h
@@ -35,7 +35,8 @@ class UnresolvedInsertionsNode final : public QueryNode {
       };
    }
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& /*plan*/,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& /*tables*/,
       const config::QueryOptions& /*query_options*/
    ) const override {

--- a/src/silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h
+++ b/src/silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h
@@ -36,7 +36,8 @@ class UnresolvedMostRecentCommonAncestorNode final : public QueryNode {
       return output_fields;
    }
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& /*plan*/,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& /*tables*/,
       const config::QueryOptions& /*query_options*/
    ) const override {

--- a/src/silo/query_engine/operators/unresolved_mutations_node.h
+++ b/src/silo/query_engine/operators/unresolved_mutations_node.h
@@ -67,7 +67,8 @@ class UnresolvedMutationsNode final : public QueryNode {
       return output_fields;
    }
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& /*plan*/,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& /*tables*/,
       const config::QueryOptions& /*query_options*/
    ) const override {

--- a/src/silo/query_engine/operators/unresolved_phylo_subtree_node.h
+++ b/src/silo/query_engine/operators/unresolved_phylo_subtree_node.h
@@ -38,7 +38,8 @@ class UnresolvedPhyloSubtreeNode final : public QueryNode {
       return output_fields;
    }
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& /*plan*/,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& /*tables*/,
       const config::QueryOptions& /*query_options*/
    ) const override {

--- a/src/silo/query_engine/operators/zstd_decompress_node.cpp
+++ b/src/silo/query_engine/operators/zstd_decompress_node.cpp
@@ -134,12 +134,13 @@ std::vector<ColumnIdentifier> ZstdDecompressNode::getOutputSchema() const {
    return output;
 }
 
-arrow::Result<PartialArrowPlan> ZstdDecompressNode::toQueryPlan(
+arrow::Result<arrow::acero::ExecNode*> ZstdDecompressNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
    const std::map<TableName, std::shared_ptr<storage::Table>>& tables,
    const config::QueryOptions& query_options
 ) const {
-   ARROW_ASSIGN_OR_RAISE(auto plan, child->toQueryPlan(tables, query_options));
-   const auto& input_ordering = plan.top_node->ordering();
+   ARROW_ASSIGN_OR_RAISE(auto* top_node, child->addToExecPlan(plan, tables, query_options));
+   const auto& input_ordering = top_node->ordering();
 
    size_t sum_of_reference_genome_sizes = 0;
 
@@ -165,23 +166,20 @@ arrow::Result<PartialArrowPlan> ZstdDecompressNode::toQueryPlan(
    arrow::acero::BackpressureMonitor* backpressure_monitor;
    std::shared_ptr<arrow::Schema> schema_of_sequence_batches;
    ARROW_ASSIGN_OR_RAISE(
-      plan.top_node,
+      top_node,
       arrow::acero::MakeExecNode(
          "sink",
-         plan.plan.get(),
-         {plan.top_node},
+         &plan,
+         {top_node},
          arrow::acero::SinkNodeOptions{
             &batch_generator,
             &schema_of_sequence_batches,
-            arrow::acero::BackpressureOptions{
-               /*.resume_if_below =*/silo::common::S_16_KB,
-               /*.pause_if_above =*/silo::common::S_64_MB
-            },
+            arrow::acero::BackpressureOptions{silo::common::S_16_KB, silo::common::S_64_MB},
             &backpressure_monitor
          }
       )
    );
-   plan.top_node->SetLabel(
+   top_node->SetLabel(
       "additional sink node to help backpressure application before zstd decompression"
    );
 
@@ -193,10 +191,10 @@ arrow::Result<PartialArrowPlan> ZstdDecompressNode::toQueryPlan(
    constexpr std::chrono::milliseconds TARGET_BATCH_RATE{667};
 
    ARROW_ASSIGN_OR_RAISE(
-      plan.top_node,
+      top_node,
       arrow::acero::MakeExecNode(
          "source",
-         plan.plan.get(),
+         &plan,
          {},
          arrow::acero::SourceNodeOptions{
             schema_of_sequence_batches,
@@ -207,19 +205,12 @@ arrow::Result<PartialArrowPlan> ZstdDecompressNode::toQueryPlan(
          }
       )
    );
-   plan.top_node->SetLabel(
+   top_node->SetLabel(
       "additional source node to help backpressure application before zstd decompression"
    );
 
    const arrow::acero::ProjectNodeOptions project_options{column_expressions, column_names};
-   ARROW_ASSIGN_OR_RAISE(
-      plan.top_node,
-      arrow::acero::MakeExecNode(
-         std::string{"project"}, plan.plan.get(), {plan.top_node}, project_options
-      )
-   );
-
-   return plan;
+   return arrow::acero::MakeExecNode(std::string{"project"}, &plan, {top_node}, project_options);
 }
 
 nlohmann::json ZstdDecompressNode::toJson() const {

--- a/src/silo/query_engine/operators/zstd_decompress_node.h
+++ b/src/silo/query_engine/operators/zstd_decompress_node.h
@@ -29,7 +29,8 @@ class ZstdDecompressNode : public QueryNode {
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 
-   [[nodiscard]] arrow::Result<PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
       const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
       const config::QueryOptions& query_options
    ) const override;

--- a/src/silo/query_engine/planner.cpp
+++ b/src/silo/query_engine/planner.cpp
@@ -2,6 +2,7 @@
 
 #include <stdexcept>
 
+#include <arrow/acero/exec_plan.h>
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
@@ -23,10 +24,9 @@ arrow::Result<QueryPlan> planQueryOrError(
    const config::QueryOptions& query_options,
    std::string_view request_id
 ) {
-   ARROW_ASSIGN_OR_RAISE(auto partial_query_plan, node.toQueryPlan(tables, query_options));
-   return QueryPlan::makeQueryPlan(
-      partial_query_plan.plan, partial_query_plan.top_node, request_id
-   );
+   ARROW_ASSIGN_OR_RAISE(auto arrow_plan, arrow::acero::ExecPlan::Make());
+   ARROW_ASSIGN_OR_RAISE(auto* top_node, node.addToExecPlan(*arrow_plan, tables, query_options));
+   return QueryPlan::makeQueryPlan(std::move(arrow_plan), top_node, request_id);
 }
 
 }  // namespace

--- a/src/silo/query_engine/planner.test.cpp
+++ b/src/silo/query_engine/planner.test.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <stdexcept>
 
+#include <arrow/acero/exec_plan.h>
 #include <arrow/result.h>
 #include <arrow/status.h>
 #include <gmock/gmock.h>
@@ -26,7 +27,8 @@ class ErrorQueryNode final : public operators::QueryNode {
       return {};
    }
 
-   [[nodiscard]] arrow::Result<operators::PartialArrowPlan> toQueryPlan(
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& /*plan*/,
       const std::map<silo::schema::TableName, std::shared_ptr<silo::storage::Table>>& /*tables*/,
       const silo::config::QueryOptions& /*query_options*/
    ) const override {

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -1118,18 +1118,25 @@ operators::QueryNodePtr handleUnionAll(
    auto left = convert_child(args.at("left"), tables);
    auto right = convert_child(args.at("right"), tables);
 
-   // Schema matching is name-based (not positional): both children must produce
-   // the same columns in the same order with the same types. This is stricter than
-   // SQL's positional UNION ALL, but avoids subtle bugs from column reordering.
+   // both children must have the same set of columns (same names and types).
    auto left_schema = left->getOutputSchema();
    auto right_schema = right->getOutputSchema();
+   auto left_sorted = left_schema;
+   auto right_sorted = right_schema;
+   std::ranges::sort(left_sorted, {}, &schema::ColumnIdentifier::name);
+   std::ranges::sort(right_sorted, {}, &schema::ColumnIdentifier::name);
    CHECK_SILO_QUERY(
-      left_schema == right_schema,
+      left_sorted == right_sorted,
       "unionAll requires both inputs to have the same schema (same column names and types). "
       "Left schema: [{}], right schema: [{}].",
-      fmt::join(namesWithTypes(left_schema), ", "),
-      fmt::join(namesWithTypes(right_schema), ", ")
+      fmt::join(namesWithTypes(left_sorted), ", "),
+      fmt::join(namesWithTypes(right_sorted), ", ")
    );
+
+   // If the right child has different column order, wrap it in a ProjectNode to reorder columns
+   if (left_schema != right_schema) {
+      right = std::make_unique<operators::ProjectNode>(std::move(right), left_schema);
+   }
 
    std::vector<operators::QueryNodePtr> children;
    children.push_back(std::move(left));

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -52,6 +52,7 @@
 #include "silo/query_engine/operators/unresolved_insertions_node.h"
 #include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/unresolved_mutations_node.h"
+#include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/unresolved_phylo_subtree_node.h"
 #include "silo/query_engine/operators/zstd_decompress_node.h"
 #include "silo/query_engine/order_by_field.h"
@@ -1099,6 +1100,31 @@ operators::QueryNodePtr handlePhyloSubtree(
    );
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr handleUnionAll(
+   const BoundArguments& args,
+   const Tables& tables,
+   const ChildConverter& convert_child
+) {
+   auto left = convert_child(args.at("left"), tables);
+   auto right = convert_child(args.at("right"), tables);
+
+   auto left_schema = left->getOutputSchema();
+   auto right_schema = right->getOutputSchema();
+   CHECK_SILO_QUERY(
+      left_schema == right_schema,
+      "unionAll requires both inputs to have the same schema (same column names and types). "
+      "Left schema: [{}], right schema: [{}].",
+      fmt::join(names(left_schema), ", "),
+      fmt::join(names(right_schema), ", ")
+   );
+
+   std::vector<operators::QueryNodePtr> children;
+   children.push_back(std::move(left));
+   children.push_back(std::move(right));
+   return std::make_unique<operators::UnionAllNode>(std::move(children));
+}
+
 }  // namespace
 
 // NOLINTNEXTLINE(misc-no-recursion)
@@ -1218,6 +1244,8 @@ FunctionRegistry::FunctionRegistry() {
         named("contractUnaryNodes", false)}},
       handlePhyloSubtree
    );
+
+   registerFunction("unionAll", {{pos("left"), pos("right")}}, handleUnionAll);
 }
 
 FunctionRegistry& FunctionRegistry::instance() {

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -49,10 +49,10 @@
 #include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
+#include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/unresolved_insertions_node.h"
 #include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/unresolved_mutations_node.h"
-#include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/unresolved_phylo_subtree_node.h"
 #include "silo/query_engine/operators/zstd_decompress_node.h"
 #include "silo/query_engine/order_by_field.h"
@@ -1304,8 +1304,12 @@ ScalarFunctionRegistry::ScalarFunctionRegistry() {
 
    auto insertion_contains_sig =
       FunctionSignature{{named("position"), named("value"), named("sequenceName", false)}};
-   registerFunction("insertionContains", insertion_contains_sig, handleInsertionContains<Nucleotide>);
-   registerFunction("aminoAcidInsertionContains", insertion_contains_sig, handleInsertionContains<AminoAcid>);
+   registerFunction(
+      "insertionContains", insertion_contains_sig, handleInsertionContains<Nucleotide>
+   );
+   registerFunction(
+      "aminoAcidInsertionContains", insertion_contains_sig, handleInsertionContains<AminoAcid>
+   );
 
    registerFunction("exact", {{pos("child")}}, handleExact);
    registerFunction("maybe", {{pos("child")}}, handleMaybe);
@@ -1321,8 +1325,12 @@ ScalarFunctionRegistry::ScalarFunctionRegistry() {
       named("sequenceId", false),
       named("mutations", false),
    }};
-   registerFunction("nucleotideMutationProfile", mutation_profile_sig, handleMutationProfile<Nucleotide>);
-   registerFunction("aminoAcidMutationProfile", mutation_profile_sig, handleMutationProfile<AminoAcid>);
+   registerFunction(
+      "nucleotideMutationProfile", mutation_profile_sig, handleMutationProfile<Nucleotide>
+   );
+   registerFunction(
+      "aminoAcidMutationProfile", mutation_profile_sig, handleMutationProfile<AminoAcid>
+   );
 }
 
 ScalarFunctionRegistry& ScalarFunctionRegistry::instance() {

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -683,12 +683,12 @@ GroupByArgs parseGroupBySpecs(
 }
 
 std::vector<std::string> names(const std::vector<schema::ColumnIdentifier>& schema) {
-   std::vector<std::string> result;
-   result.reserve(schema.size());
+   std::vector<std::string> names;
+   names.reserve(schema.size());
    for (const auto& col : schema) {
-      result.push_back(col.name);
+      names.push_back(col.name);
    }
-   return result;
+   return names;
 }
 
 std::vector<std::string> namesWithTypes(const std::vector<schema::ColumnIdentifier>& schema) {

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -1304,12 +1304,8 @@ ScalarFunctionRegistry::ScalarFunctionRegistry() {
 
    auto insertion_contains_sig =
       FunctionSignature{{named("position"), named("value"), named("sequenceName", false)}};
-   registerFunction(
-      "insertionContains", insertion_contains_sig, handleInsertionContains<Nucleotide>
-   );
-   registerFunction(
-      "aminoAcidInsertionContains", insertion_contains_sig, handleInsertionContains<AminoAcid>
-   );
+   registerFunction("insertionContains", insertion_contains_sig, handleInsertionContains<Nucleotide>);
+   registerFunction("aminoAcidInsertionContains", insertion_contains_sig, handleInsertionContains<AminoAcid>);
 
    registerFunction("exact", {{pos("child")}}, handleExact);
    registerFunction("maybe", {{pos("child")}}, handleMaybe);
@@ -1325,12 +1321,8 @@ ScalarFunctionRegistry::ScalarFunctionRegistry() {
       named("sequenceId", false),
       named("mutations", false),
    }};
-   registerFunction(
-      "nucleotideMutationProfile", mutation_profile_sig, handleMutationProfile<Nucleotide>
-   );
-   registerFunction(
-      "aminoAcidMutationProfile", mutation_profile_sig, handleMutationProfile<AminoAcid>
-   );
+   registerFunction("nucleotideMutationProfile", mutation_profile_sig, handleMutationProfile<Nucleotide>);
+   registerFunction("aminoAcidMutationProfile", mutation_profile_sig, handleMutationProfile<AminoAcid>);
 }
 
 ScalarFunctionRegistry& ScalarFunctionRegistry::instance() {

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -1138,10 +1138,7 @@ operators::QueryNodePtr handleUnionAll(
       right = std::make_unique<operators::ProjectNode>(std::move(right), left_schema);
    }
 
-   std::vector<operators::QueryNodePtr> children;
-   children.push_back(std::move(left));
-   children.push_back(std::move(right));
-   return std::make_unique<operators::UnionAllNode>(std::move(children));
+   return std::make_unique<operators::UnionAllNode>(std::move(left), std::move(right));
 }
 
 }  // namespace

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -1118,7 +1118,7 @@ operators::QueryNodePtr handleUnionAll(
    auto left = convert_child(args.at("left"), tables);
    auto right = convert_child(args.at("right"), tables);
 
-   // both children must have the same set of columns (same names and types).
+   // Both children must have the same set of columns (same names and types).
    auto left_schema = left->getOutputSchema();
    auto right_schema = right->getOutputSchema();
    auto left_sorted = left_schema;

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -683,12 +683,21 @@ GroupByArgs parseGroupBySpecs(
 }
 
 std::vector<std::string> names(const std::vector<schema::ColumnIdentifier>& schema) {
-   std::vector<std::string> names;
-   names.reserve(schema.size());
+   std::vector<std::string> result;
+   result.reserve(schema.size());
    for (const auto& col : schema) {
-      names.push_back(col.name);
+      result.push_back(col.name);
    }
-   return names;
+   return result;
+}
+
+std::vector<std::string> namesWithTypes(const std::vector<schema::ColumnIdentifier>& schema) {
+   std::vector<std::string> result;
+   result.reserve(schema.size());
+   for (const auto& col : schema) {
+      result.push_back(fmt::format("{}:{}", col.name, schema::columnTypeToString(col.type)));
+   }
+   return result;
 }
 
 OrderByField parseOrderByField(
@@ -1118,8 +1127,8 @@ operators::QueryNodePtr handleUnionAll(
       left_schema == right_schema,
       "unionAll requires both inputs to have the same schema (same column names and types). "
       "Left schema: [{}], right schema: [{}].",
-      fmt::join(names(left_schema), ", "),
-      fmt::join(names(right_schema), ", ")
+      fmt::join(namesWithTypes(left_schema), ", "),
+      fmt::join(namesWithTypes(right_schema), ", ")
    );
 
    std::vector<operators::QueryNodePtr> children;

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -1109,6 +1109,9 @@ operators::QueryNodePtr handleUnionAll(
    auto left = convert_child(args.at("left"), tables);
    auto right = convert_child(args.at("right"), tables);
 
+   // Schema matching is name-based (not positional): both children must produce
+   // the same columns in the same order with the same types. This is stricter than
+   // SQL's positional UNION ALL, but avoids subtle bugs from column reordering.
    auto left_schema = left->getOutputSchema();
    auto right_schema = right->getOutputSchema();
    CHECK_SILO_QUERY(

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -1118,25 +1118,16 @@ operators::QueryNodePtr handleUnionAll(
    auto left = convert_child(args.at("left"), tables);
    auto right = convert_child(args.at("right"), tables);
 
-   // Both children must have the same set of columns (same names and types).
    auto left_schema = left->getOutputSchema();
    auto right_schema = right->getOutputSchema();
-   auto left_sorted = left_schema;
-   auto right_sorted = right_schema;
-   std::ranges::sort(left_sorted, {}, &schema::ColumnIdentifier::name);
-   std::ranges::sort(right_sorted, {}, &schema::ColumnIdentifier::name);
    CHECK_SILO_QUERY(
-      left_sorted == right_sorted,
-      "unionAll requires both inputs to have the same schema (same column names and types). "
+      left_schema == right_schema,
+      "unionAll requires both inputs to have the same schema "
+      "(same column names, types, and order). "
       "Left schema: [{}], right schema: [{}].",
-      fmt::join(namesWithTypes(left_sorted), ", "),
-      fmt::join(namesWithTypes(right_sorted), ", ")
+      fmt::join(namesWithTypes(left_schema), ", "),
+      fmt::join(namesWithTypes(right_schema), ", ")
    );
-
-   // If the right child has different column order, wrap it in a ProjectNode to reorder columns
-   if (left_schema != right_schema) {
-      right = std::make_unique<operators::ProjectNode>(std::move(right), left_schema);
-   }
 
    return std::make_unique<operators::UnionAllNode>(std::move(left), std::move(right));
 }


### PR DESCRIPTION
resolves #1221

### Summary

Adds a `unionAll` operator to the SaneQL interface.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
