### PR TITLE
feat(silo): add an at expression

### DIFF
--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -128,10 +128,11 @@ Sequence data columns use the naming convention `<sequenceName>` for aligned seq
 
 ### `map(expressions)`
 
-Adds columns to the table. `expressions` is a record of `name := value` assignments. For now only field references and the following literal values are supported: integers, floats, strings (single-quoted), and booleans.
+Adds columns to the table. `expressions` is a record of `name := value` assignments. Each value may be a literal (integers, floats, single-quoted strings, or booleans), a field reference, or a call to a non-boolean [scalar function](#scalar-functions) such as [`at`](#atcolumn-position).
 
 ```
 default.map({x := 3, label := 'cohort A', active := true, copy := country})
+default.map({second_char := primary_key.at(2)})
 ```
 
 All input columns are passed through unchanged and the new columns are appended. An assignment whose name matches an existing column replaces that column in place.
@@ -359,7 +360,15 @@ unionAll(
 
 ## Scalar Functions
 
-These are used inside `.filter(...)` predicates. For now, only boolean scalar functions exist.
+Most scalar functions are boolean predicates used inside `.filter(...)`. Functions that return a non-boolean value (currently [`at`](#atcolumn-position)) cannot be used as a filter predicate and are instead used as `map()` assignments.
+
+### `at(column, position)`
+
+Extracts the single character of a string `column` at the 1-based `position`, returning it as a string. `position` must be greater than 0. If `position` is past the end of the value, the result is an empty string `""` (a `null` value yields `null`). This is not a boolean predicate, so it cannot be used in `.filter(...)`; use it inside [`map()`](#mapexpressions).
+
+```
+default.map({second_char := primary_key.at(2)})
+```
 
 ### `between(column, from, to)`
 

--- a/src/silo/database.cpp
+++ b/src/silo/database.cpp
@@ -264,7 +264,8 @@ roaring::Roaring Database::getFilteredBitmap(
 
    query_engine::saneql::Parser parser(filter);
    auto ast = parser.parse();
-   auto filter_expression = query_engine::saneql::convertToFilter(*ast);
+   auto filter_expression =
+      query_engine::saneql::convertToFilter(*ast, table->schema->getColumnIdentifiers());
 
    auto rewritten_filter_expression =
       filter_expression->rewrite(*table, Expression::AmbiguityMode::NONE);

--- a/src/silo/query_engine/expressions/at.cpp
+++ b/src/silo/query_engine/expressions/at.cpp
@@ -1,0 +1,37 @@
+#include "silo/query_engine/expressions/at.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "silo/common/panic.h"
+#include "silo/query_engine/filter/operators/operator.h"
+
+namespace silo::query_engine::expressions {
+
+At::At(schema::ColumnIdentifier input_column, uint32_t position)
+    : input_column(std::move(input_column)),
+      position(position) {}
+
+std::string At::toString() const {
+   return fmt::format("{}.at({})", input_column.name, position);
+}
+
+std::vector<schema::ColumnIdentifier> At::freeIUs() const {
+   return {input_column};
+}
+
+std::unique_ptr<Expression> At::rewrite(const storage::Table& /*table*/, AmbiguityMode /*mode*/)
+   const {
+   return std::make_unique<At>(input_column, position);
+}
+
+std::unique_ptr<filter::operators::Operator> At::compile(const storage::Table& /*table*/) const {
+   // `at` yields a string scalar value, not a filter predicate.
+   SILO_UNIMPLEMENTED();
+}
+
+}  // namespace silo::query_engine::expressions

--- a/src/silo/query_engine/expressions/at.h
+++ b/src/silo/query_engine/expressions/at.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "silo/query_engine/expressions/expression.h"
+#include "silo/query_engine/filter/operators/operator.h"
+#include "silo/schema/database_schema.h"
+
+namespace silo::query_engine::expressions {
+
+/// A scalar expression that evaluates to the single character of a string-valued
+/// column at a given 1-indexed position, e.g. `seq.at(3)`. Its value is a string
+/// (the character), so it is not a filter predicate; compile() is unimplemented and
+/// it is only meaningful as a scalar expression (e.g. in a map() assignment).
+class At : public Expression {
+  public:
+   schema::ColumnIdentifier input_column;
+   /// 1-indexed position of the character to extract.
+   uint32_t position;
+
+   At(schema::ColumnIdentifier input_column, uint32_t position);
+
+   [[nodiscard]] schema::ColumnType type() const override { return schema::ColumnType::STRING; }
+
+   static constexpr Kind KIND = Kind::AT;
+   [[nodiscard]] Kind kind() const override { return KIND; }
+
+   [[nodiscard]] std::string toString() const override;
+
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
+   [[nodiscard]] std::unique_ptr<Expression> rewrite(
+      const storage::Table& table,
+      AmbiguityMode mode
+   ) const override;
+
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<At>(input_column, position);
+   }
+
+   [[nodiscard]] std::unique_ptr<filter::operators::Operator> compile(const storage::Table& table
+   ) const override;
+};
+
+}  // namespace silo::query_engine::expressions

--- a/src/silo/query_engine/expressions/expression.h
+++ b/src/silo/query_engine/expressions/expression.h
@@ -27,6 +27,7 @@ class Expression {
    enum class Kind : uint8_t {
       AND,
       OR,
+      AT,
       N_OF,
       NEGATION,
       MAYBE,

--- a/src/silo/query_engine/operators/map_node.cpp
+++ b/src/silo/query_engine/operators/map_node.cpp
@@ -9,6 +9,7 @@
 #include <arrow/datum.h>
 #include <nlohmann/json_fwd.hpp>
 
+#include "silo/query_engine/expressions/at.h"
 #include "silo/query_engine/expressions/field_ref.h"
 #include "silo/query_engine/expressions/literal.h"
 
@@ -37,8 +38,21 @@ arrow::Result<arrow::compute::Expression> scalarToArrowExpression(
    if (const auto* field_ref = dynamic_cast<const expressions::FieldRef*>(&expression)) {
       return arrow::compute::field_ref(field_ref->column.name);
    }
+   if (const auto* at_function = dynamic_cast<const expressions::At*>(&expression)) {
+      // `at` is 1-indexed; utf8_slice_codeunits takes a 0-indexed, half-open
+      // [start, stop) range of code units, so extract the single character at
+      // position-1.
+      const int64_t start = static_cast<int64_t>(at_function->position) - 1;
+      const auto stop = static_cast<int64_t>(at_function->position);
+      return arrow::compute::call(
+         "utf8_slice_codeunits",
+         {arrow::compute::field_ref(at_function->input_column.name)},
+         arrow::compute::SliceOptions(start, stop)
+      );
+   }
    return arrow::Status::NotImplemented(
-      "non-literal scalar expressions are not yet supported in map() assignments"
+      "unsupported scalar expression in map() assignments (supported: literals, column references, "
+      "and at())"
    );
 }
 

--- a/src/silo/query_engine/operators/map_node.test.cpp
+++ b/src/silo/query_engine/operators/map_node.test.cpp
@@ -7,17 +7,34 @@ using silo::ReferenceGenomes;
 using silo::test::QueryTestData;
 using silo::test::QueryTestScenario;
 
-nlohmann::json createData(const std::string& primaryKey, int value) {
+nlohmann::json createData(
+   const std::string& primaryKey,
+   int value,
+   const std::string& str_value,
+   const nlohmann::json& segment1 = nullptr
+) {
    return {
       {"primaryKey", primaryKey},
       {"int_value", value},
-      {"segment1", nullptr},
+      {"str_value", str_value},
+      {"segment1", segment1},
       {"gene1", nullptr},
       {"unaligned_segment1", nullptr}
    };
 }
 
-const std::vector<nlohmann::json> DATA = {createData("id_0", 1), createData("id_1", 2)};
+nlohmann::json alignedSequence(const std::string& sequence) {
+   return {{"sequence", sequence}, {"insertions", nlohmann::json::array()}};
+}
+
+// id_0 carries an aligned sequence, id_1 has no sequence (null) so that `at` on a
+// sequence column can be checked for both a present and an absent value. The
+// str_value column holds strings of differing lengths so that `at` can be checked
+// for a position that is out of bounds for one value but in bounds for the other.
+const std::vector<nlohmann::json> DATA = {
+   createData("id_0", 1, "short", alignedSequence("ACGT")),
+   createData("id_1", 2, "longlonglong")
+};
 
 const auto DATABASE_CONFIG =
    R"(
@@ -29,11 +46,13 @@ schema:
       type: "string"
     - name: "int_value"
       type: "int"
+    - name: "str_value"
+      type: "string"
   primaryKey: "primaryKey"
 )";
 
 const auto REFERENCE_GENOMES = ReferenceGenomes{
-   {{"segment1", "A"}},
+   {{"segment1", "ACGT"}},
    {{"gene1", "*"}},
 };
 
@@ -80,6 +99,45 @@ const QueryTestScenario MAP_FIELD_REF_SCENARIO = {
    )
 };
 
+// `at` extracts the (1-indexed) character of a string column at a position.
+const QueryTestScenario MAP_AT_SCENARIO = {
+   .name = "MAP_AT",
+   .query = "default.map({second := primaryKey.at(4)}).project({primaryKey, second})",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"second", "0"}}, {{"primaryKey", "id_1"}, {"second", "1"}}}
+   )
+};
+
+// When the position is past the end of the string, `at` yields an empty string
+// rather than failing. id_0's str_value "short" has only 5 characters, so at(8) is
+// out of bounds and produces ""; id_1's "longlonglong" has a character at 8 ("g").
+const QueryTestScenario MAP_AT_OUT_OF_BOUNDS_SCENARIO = {
+   .name = "MAP_AT_OUT_OF_BOUNDS",
+   .query = "default.map({eighth := str_value.at(8)}).project({primaryKey, eighth})",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"eighth", ""}}, {{"primaryKey", "id_1"}, {"eighth", "g"}}}
+   )
+};
+
+// `at` works on a (zstd-compressed) nucleotide sequence column: the sequence is
+// decompressed and the (1-indexed) character at the position is extracted. id_0's
+// aligned sequence is "ACGT"; id_1 has no sequence, so the value is null.
+const QueryTestScenario MAP_AT_SEQUENCE_FIRST_SCENARIO = {
+   .name = "MAP_AT_SEQUENCE_FIRST",
+   .query = "default.map({base := segment1.at(1)}).project({primaryKey, base})",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"base", "A"}}, {{"primaryKey", "id_1"}, {"base", nullptr}}}
+   )
+};
+
+const QueryTestScenario MAP_AT_SEQUENCE_INNER_SCENARIO = {
+   .name = "MAP_AT_SEQUENCE_INNER",
+   .query = "default.map({base := segment1.at(3)}).project({primaryKey, base})",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"base", "G"}}, {{"primaryKey", "id_1"}, {"base", nullptr}}}
+   )
+};
+
 // All projected columns are produced by the map; none are passed through from
 // the child. The table scan must still emit one row per input record (a prior
 // bug narrowed the scan to zero fields and returned no rows).
@@ -99,6 +157,10 @@ QUERY_TEST(
       MAP_OVERRIDE_SCENARIO,
       MAP_INT64_SCENARIO,
       MAP_FIELD_REF_SCENARIO,
+      MAP_AT_SCENARIO,
+      MAP_AT_OUT_OF_BOUNDS_SCENARIO,
+      MAP_AT_SEQUENCE_FIRST_SCENARIO,
+      MAP_AT_SEQUENCE_INNER_SCENARIO,
       MAP_ONLY_MAPPED_COLUMN_SCENARIO
    )
 );

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -16,6 +16,7 @@
 #include "silo/common/lineage_tree.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/query_engine/expressions/and.h"
+#include "silo/query_engine/expressions/at.h"
 #include "silo/query_engine/expressions/bool_equals.h"
 #include "silo/query_engine/expressions/date_between.h"
 #include "silo/query_engine/expressions/date_equals.h"
@@ -64,7 +65,10 @@ namespace silo::query_engine::saneql {
 
 namespace {
 
-FilterPtr convertEqualsToFilter(const std::string& column_name, const ast::Expression& value_expr) {
+ScalarExpressionPtr convertEqualsToFilter(
+   const std::string& column_name,
+   const ast::Expression& value_expr
+) {
    if (isNullLiteral(value_expr)) {
       return std::make_unique<expressions::IsNull>(column_name);
    }
@@ -96,7 +100,7 @@ FilterPtr convertEqualsToFilter(const std::string& column_name, const ast::Expre
    );
 }
 
-FilterPtr convertIntComparison(
+ScalarExpressionPtr convertIntComparison(
    const std::string& column_name,
    ast::BinaryOp binary_op,
    uint32_t value
@@ -115,7 +119,7 @@ FilterPtr convertIntComparison(
    }
 }
 
-FilterPtr convertFloatComparison(
+ScalarExpressionPtr convertFloatComparison(
    const std::string& column_name,
    ast::BinaryOp binary_op,
    double value
@@ -134,7 +138,7 @@ FilterPtr convertFloatComparison(
    }
 }
 
-FilterPtr convertDateComparison(
+ScalarExpressionPtr convertDateComparison(
    const std::string& column_name,
    ast::BinaryOp binary_op,
    const ast::Expression& value_expr
@@ -154,7 +158,7 @@ FilterPtr convertDateComparison(
    }
 }
 
-FilterPtr convertComparisonToFilter(
+ScalarExpressionPtr convertComparisonToFilter(
    const std::string& column_name,
    ast::BinaryOp binary_op,
    const ast::Expression& value_expr
@@ -177,18 +181,21 @@ FilterPtr convertComparisonToFilter(
    );
 }
 
-FilterPtr convertBinaryExprToFilter(const ast::BinaryExpr& bin_expr) {
+ScalarExpressionPtr convertBinaryExprToFilter(
+   const ast::BinaryExpr& bin_expr,
+   const std::vector<schema::ColumnIdentifier>& schema
+) {
    switch (bin_expr.op) {
       case ast::BinaryOp::AND: {
          expressions::ExpressionVector children;
-         children.push_back(convertToFilter(*bin_expr.left));
-         children.push_back(convertToFilter(*bin_expr.right));
+         children.push_back(convertToFilter(*bin_expr.left, schema));
+         children.push_back(convertToFilter(*bin_expr.right, schema));
          return std::make_unique<expressions::And>(std::move(children));
       }
       case ast::BinaryOp::OR: {
          expressions::ExpressionVector children;
-         children.push_back(convertToFilter(*bin_expr.left));
-         children.push_back(convertToFilter(*bin_expr.right));
+         children.push_back(convertToFilter(*bin_expr.left, schema));
+         children.push_back(convertToFilter(*bin_expr.right, schema));
          return std::make_unique<expressions::Or>(std::move(children));
       }
       case ast::BinaryOp::EQUALS: {
@@ -243,7 +250,10 @@ FilterPtr convertBinaryExprToFilter(const ast::BinaryExpr& bin_expr) {
 // Scalar function handlers (registered in ScalarFunctionRegistry)
 // ========================================================================
 
-FilterPtr handleBetween(const BoundArguments& args) {
+ScalarExpressionPtr handleBetween(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& /*schema*/
+) {
    auto column_name = extractIdentifierName(args.at("column"));
    const auto& from_expr = args.at("from");
    const auto& to_expr = args.at("to");
@@ -283,7 +293,10 @@ FilterPtr handleBetween(const BoundArguments& args) {
    );
 }
 
-FilterPtr handleIn(const BoundArguments& args) {
+ScalarExpressionPtr handleIn(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& /*schema*/
+) {
    auto column_name = extractIdentifierName(args.at("column"));
    const auto& set_expr = args.at("values");
    CHECK_SILO_QUERY(
@@ -300,17 +313,26 @@ FilterPtr handleIn(const BoundArguments& args) {
    return std::make_unique<expressions::StringInSet>(column_name, std::move(values));
 }
 
-FilterPtr handleIsNull(const BoundArguments& args) {
+ScalarExpressionPtr handleIsNull(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& /*schema*/
+) {
    return std::make_unique<expressions::IsNull>(extractIdentifierName(args.at("column")));
 }
 
-FilterPtr handleIsNotNull(const BoundArguments& args) {
+ScalarExpressionPtr handleIsNotNull(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& /*schema*/
+) {
    return std::make_unique<expressions::Negation>(
       std::make_unique<expressions::IsNull>(extractIdentifierName(args.at("column")))
    );
 }
 
-FilterPtr handleLineage(const BoundArguments& args) {
+ScalarExpressionPtr handleLineage(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& /*schema*/
+) {
    auto column_name = extractIdentifierName(args.at("column"));
    const auto& value_expr = args.at("value");
    std::optional<std::string> lineage_value;
@@ -344,13 +366,19 @@ FilterPtr handleLineage(const BoundArguments& args) {
    return std::make_unique<expressions::LineageFilter>(column_name, lineage_value, sublineage_mode);
 }
 
-FilterPtr handlePhyloDescendantOf(const BoundArguments& args) {
+ScalarExpressionPtr handlePhyloDescendantOf(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& /*schema*/
+) {
    return std::make_unique<expressions::PhyloChildFilter>(
       extractIdentifierName(args.at("column")), extractStringLiteral(args.at("node"))
    );
 }
 
-FilterPtr handleLike(const BoundArguments& args) {
+ScalarExpressionPtr handleLike(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& /*schema*/
+) {
    auto column_name = extractIdentifierName(args.at("column"));
    auto pattern = extractStringLiteral(args.at("pattern"));
    auto regex = std::make_unique<re2::RE2>(pattern);
@@ -364,7 +392,10 @@ FilterPtr handleLike(const BoundArguments& args) {
 }
 
 template <typename SymbolType>
-FilterPtr handleSymbolEquals(const BoundArguments& args) {
+ScalarExpressionPtr handleSymbolEquals(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& /*schema*/
+) {
    const uint32_t position = extractUint32Literal(args.at("position"));
    CHECK_SILO_QUERY(position > 0, "The field 'position' is 1-indexed. Value of 0 not allowed.");
    const uint32_t position_idx = position - 1;
@@ -389,7 +420,10 @@ FilterPtr handleSymbolEquals(const BoundArguments& args) {
 }
 
 template <typename SymbolType>
-FilterPtr handleHasMutation(const BoundArguments& args) {
+ScalarExpressionPtr handleHasMutation(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& /*schema*/
+) {
    const uint32_t position = extractUint32Literal(args.at("position"));
    CHECK_SILO_QUERY(position > 0, "The field 'position' is 1-indexed. Value of 0 not allowed.");
    auto sequence_name = args.getOptionalString("sequenceName");
@@ -399,7 +433,10 @@ FilterPtr handleHasMutation(const BoundArguments& args) {
 }
 
 template <typename SymbolType>
-FilterPtr handleInsertionContains(const BoundArguments& args) {
+ScalarExpressionPtr handleInsertionContains(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& /*schema*/
+) {
    auto position = extractUint32Literal(args.at("position"));
    auto value = extractStringLiteral(args.at("value"));
    CHECK_SILO_QUERY(
@@ -412,16 +449,47 @@ FilterPtr handleInsertionContains(const BoundArguments& args) {
    );
 }
 
-FilterPtr handleExact(const BoundArguments& args) {
-   return std::make_unique<expressions::Exact>(convertToFilter(args.at("child")));
-}
-
-FilterPtr handleMaybe(const BoundArguments& args) {
-   return std::make_unique<expressions::Maybe>(convertToFilter(args.at("child")));
+ScalarExpressionPtr handleAt(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& schema
+) {
+   auto input_column = extractIdentifierName(args.at("input"));
+   const uint32_t position = extractUint32Literal(args.at("position"));
+   CHECK_SILO_QUERY(
+      position > 0, "at(): the field 'position' is 1-indexed. Value of 0 not allowed."
+   );
+   // Resolve the referenced column against the available schema so the At carries the
+   // column's actual {name, type}. If it is unknown the column is kept with a
+   // placeholder type; the caller reports the (contextual) unknown-column error.
+   const auto found =
+      std::ranges::find_if(schema, [&](const auto& col) { return col.name == input_column; });
+   CHECK_SILO_QUERY(
+      found != schema.end(), "at(): the field {} is not found in the current context", input_column
+   );
+   return std::make_unique<expressions::At>(*found, position);
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-FilterPtr handleNOf(const BoundArguments& args) {
+ScalarExpressionPtr handleExact(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& schema
+) {
+   return std::make_unique<expressions::Exact>(convertToFilter(args.at("child"), schema));
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+ScalarExpressionPtr handleMaybe(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& schema
+) {
+   return std::make_unique<expressions::Maybe>(convertToFilter(args.at("child"), schema));
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+ScalarExpressionPtr handleNOf(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& schema
+) {
    const int32_t number_of_matchers = extractInt32Literal(args.at("count"));
    bool match_exactly = false;
    if (const auto* expr = args.get("matchExactly")) {
@@ -430,7 +498,7 @@ FilterPtr handleNOf(const BoundArguments& args) {
    const auto& children_set = extractSetLiteral(args.at("children"));
    expressions::ExpressionVector children;
    for (const auto& child_expr : children_set.elements) {
-      children.push_back(convertToFilter(*child_expr));
+      children.push_back(convertToFilter(*child_expr, schema));
    }
    return std::make_unique<expressions::NOf>(
       std::move(children), number_of_matchers, match_exactly
@@ -510,7 +578,10 @@ std::vector<typename expressions::MutationProfile<SymbolType>::Mutation> parseMu
 }
 
 template <typename SymbolType>
-FilterPtr handleMutationProfile(const BoundArguments& args) {
+ScalarExpressionPtr handleMutationProfile(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& /*schema*/
+) {
    const uint32_t distance = extractUint32Literal(args.at("distance"));
    auto sequence_name = args.getOptionalString("sequenceName");
 
@@ -559,15 +630,18 @@ FilterPtr handleMutationProfile(const BoundArguments& args) {
 
 }  // namespace
 
-std::unique_ptr<expressions::Expression> convertToFilter(const ast::Expression& ast) {
+std::unique_ptr<expressions::Expression> convertToFilter(
+   const ast::Expression& ast,
+   const std::vector<schema::ColumnIdentifier>& schema
+) {
    return std::visit(
-      [&](const auto& node) -> FilterPtr {
+      [&](const auto& node) -> ScalarExpressionPtr {
          using T = std::decay_t<decltype(node)>;
 
          if constexpr (std::is_same_v<T, ast::BinaryExpr>) {
-            return convertBinaryExprToFilter(node);
+            return convertBinaryExprToFilter(node, schema);
          } else if constexpr (std::is_same_v<T, ast::UnaryNotExpr>) {
-            return std::make_unique<expressions::Negation>(convertToFilter(*node.operand));
+            return std::make_unique<expressions::Negation>(convertToFilter(*node.operand, schema));
          } else if constexpr (std::is_same_v<T, ast::BoolLiteral>) {
             return std::make_unique<expressions::BoolLiteral>(node.value);
          } else if constexpr (std::is_same_v<T, ast::FunctionCall>) {
@@ -576,7 +650,20 @@ std::unique_ptr<expressions::Expression> convertToFilter(const ast::Expression& 
             auto bound = bindArguments(
                node.function_name, entry->signature, node.positional_arguments, node.named_arguments
             );
-            return entry->handler(bound);
+            auto expression = entry->handler(bound, schema);
+            // The registry also holds value-producing scalar functions (e.g. `at`),
+            // which are not filter predicates. Reject them here rather than letting a
+            // non-boolean expression reach compile().
+            CHECK_SILO_QUERY(
+               expression->type() == schema::ColumnType::BOOL,
+               "scalar function '{}' produces a {} value and cannot be used as a filter "
+               "predicate at {}:{}",
+               node.function_name,
+               schema::columnTypeToString(expression->type()),
+               ast.location.line,
+               ast.location.column
+            );
+            return expression;
          } else {
             throw IllegalQueryException(
                "unsupported expression type in filter context at {}:{}",
@@ -811,7 +898,7 @@ operators::QueryNodePtr handleFilter(
    const ChildConverter& convert_child
 ) {
    auto child = convert_child(args.at("input"), tables);
-   auto filter_expr = convertToFilter(args.at("predicate"));
+   auto filter_expr = convertToFilter(args.at("predicate"), child->getOutputSchema());
    return std::make_unique<operators::FilterNode>(std::move(child), std::move(filter_expr));
 }
 
@@ -862,11 +949,52 @@ namespace {
 
 using operators::MapNode;
 
+/// Builds a scalar Expression from a function call (e.g. `seq.at(3)`) appearing in
+/// a scalar position. The handler resolves referenced columns against `schema`;
+/// this additionally validates that every referenced column exists so a missing
+/// column produces a diagnostic with the call's context and location.
+std::unique_ptr<expressions::Expression> convertScalarFunctionCall(
+   const ast::FunctionCall& call,
+   const SourceLocation& location,
+   const std::vector<schema::ColumnIdentifier>& schema,
+   std::string_view error_context
+) {
+   const auto* entry = ScalarFunctionRegistry::instance().findFunction(call.function_name);
+   CHECK_SILO_QUERY(
+      entry != nullptr,
+      "{} references unknown scalar function '{}' at {}:{}",
+      error_context,
+      call.function_name,
+      location.line,
+      location.column
+   );
+   auto bound = bindArguments(
+      call.function_name, entry->signature, call.positional_arguments, call.named_arguments
+   );
+   auto expression = entry->handler(bound, schema);
+   // Validate that every referenced column actually exists, mirroring the check for
+   // a bare column reference.
+   for (const auto& referenced : expression->freeIUs()) {
+      const bool exists =
+         std::ranges::any_of(schema, [&](const auto& col) { return col.name == referenced.name; });
+      CHECK_SILO_QUERY(
+         exists,
+         "{} references unknown column '{}' at {}:{}",
+         error_context,
+         referenced.name,
+         location.line,
+         location.column
+      );
+   }
+   return expression;
+}
+
 /// Converts a saneql expression into a SILO scalar Expression: a value-producing
 /// expression (as opposed to convertToFilter, which yields a boolean predicate).
-/// Supported forms are literals (int, float, string, bool) and references to an
-/// existing column of `schema` (resolved to that column's type). `error_context`
-/// prefixes diagnostics so callers can describe where the expression appears
+/// Supported forms are literals (int, float, string, bool), references to an
+/// existing column of `schema` (resolved to that column's type), and scalar
+/// function calls (see convertScalarFunctionCall). `error_context` prefixes
+/// diagnostics so callers can describe where the expression appears
 /// (e.g. "map() field 'x'").
 std::unique_ptr<expressions::Expression> convertToScalar(
    const ast::Expression& ast,
@@ -901,9 +1029,15 @@ std::unique_ptr<expressions::Expression> convertToScalar(
    if (std::holds_alternative<ast::BoolLiteral>(value)) {
       return std::make_unique<expressions::BoolLiteral>(std::get<ast::BoolLiteral>(value).value);
    }
+   if (std::holds_alternative<ast::FunctionCall>(value)) {
+      return convertScalarFunctionCall(
+         std::get<ast::FunctionCall>(value), location, schema, error_context
+      );
+   }
 
    throw IllegalQueryException(
-      "{} must be assigned a literal value (int, float, string, or bool) or a column reference at "
+      "{} must be assigned a literal value (int, float, string, or bool), a column reference, or a "
+      "scalar function call at "
       "{}:{}",
       error_context,
       location.line,
@@ -1280,6 +1414,8 @@ ScalarFunctionRegistry::ScalarFunctionRegistry() {
    registerFunction("phyloDescendantOf", {{pos("column"), pos("node")}}, handlePhyloDescendantOf);
 
    registerFunction("like", {{pos("column"), pos("pattern")}}, handleLike);
+
+   registerFunction("at", {{pos("input"), pos("position")}}, handleAt);
 
    auto symbol_equals_sig =
       FunctionSignature{{named("position"), named("symbol"), named("sequenceName", false)}};

--- a/src/silo/query_engine/saneql/ast_to_query.h
+++ b/src/silo/query_engine/saneql/ast_to_query.h
@@ -27,6 +27,12 @@ operators::QueryNodePtr convertExpression(
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables
 );
 
-std::unique_ptr<expressions::Expression> convertToFilter(const ast::Expression& ast);
+/// Converts a saneql expression into a boolean filter predicate. `schema` lists the
+/// columns available where the predicate appears (the input table or child node's
+/// output), used to resolve referenced columns to their full {name, type}.
+std::unique_ptr<expressions::Expression> convertToFilter(
+   const ast::Expression& ast,
+   const std::vector<schema::ColumnIdentifier>& schema
+);
 
 }  // namespace silo::query_engine::saneql

--- a/src/silo/query_engine/saneql/ast_to_query.test.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.test.cpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include <string_view>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -22,8 +23,11 @@ namespace ast = silo::query_engine::saneql::ast;
 
 namespace {
 
-auto parseFilter(std::string_view query) {
-   return convertToFilter(*Parser(query).parse());
+auto parseFilter(
+   std::string_view query,
+   const std::vector<silo::schema::ColumnIdentifier>& schema = {}
+) {
+   return convertToFilter(*Parser(query).parse(), schema);
 }
 
 using Tables = std::map<silo::schema::TableName, std::shared_ptr<silo::storage::Table>>;
@@ -296,7 +300,7 @@ TEST(AstToQueryBinaryExpr, unhandledBinaryOpThrows) {
       {}
    );
    EXPECT_THAT(
-      [&]() { (void)convertToFilter(*expr); },
+      [&]() { (void)convertToFilter(*expr, {}); },
       ThrowsMessage<IllegalQueryException>(::testing::HasSubstr("unhandled binary operator"))
    );
 }
@@ -397,7 +401,32 @@ TEST(AstToQueryMap, unsupportedValueThrows) {
    EXPECT_THAT(
       [&tables]() { (void)parseAndConvertToQueryTree("default.map({x := count()})", tables); },
       ThrowsMessage<IllegalQueryException>(
-         ::testing::HasSubstr("map() field 'x' must be assigned a literal value")
+         ::testing::HasSubstr("map() field 'x' references unknown scalar function 'count'")
+      )
+   );
+}
+
+TEST(AstToQueryMap, atResolvesToCharacterOfColumn) {
+   auto tables = makeTablesWithDefault();
+   EXPECT_NO_THROW((void)parseAndConvertToQueryTree("default.map({c := id.at(2)})", tables));
+}
+
+TEST(AstToQueryMap, atOnUnknownColumnThrows) {
+   auto tables = makeTablesWithDefault();
+   EXPECT_THAT(
+      [&tables]() { (void)parseAndConvertToQueryTree("default.map({c := nope.at(2)})", tables); },
+      ThrowsMessage<IllegalQueryException>(
+         ::testing::HasSubstr("at(): the field nope is not found in the current context")
+      )
+   );
+}
+
+TEST(AstToQueryMap, atWithPositionZeroThrows) {
+   auto tables = makeTablesWithDefault();
+   EXPECT_THAT(
+      [&tables]() { (void)parseAndConvertToQueryTree("default.map({c := id.at(0)})", tables); },
+      ThrowsMessage<IllegalQueryException>(
+         ::testing::HasSubstr("at(): the field 'position' is 1-indexed. Value of 0 not allowed.")
       )
    );
 }

--- a/src/silo/query_engine/saneql/function_registry.h
+++ b/src/silo/query_engine/saneql/function_registry.h
@@ -92,12 +92,12 @@ class FunctionRegistry {
 
 // --- Scalar function registry ---
 
-// Currently every scalar function produces a boolean filter predicate. As other
-// scalar expressions (e.g. for use in a MapNode) are added, the registry will be
-// extended to produce them as well.
-using FilterPtr = std::unique_ptr<query_engine::expressions::Expression>;
+using ScalarExpressionPtr = std::unique_ptr<expressions::Expression>;
 
-using ScalarFunctionHandler = std::function<FilterPtr(const BoundArguments& args)>;
+using ScalarFunctionHandler = std::function<ScalarExpressionPtr(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& schema
+)>;
 
 class ScalarFunctionRegistry {
   public:


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1292

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This adds an `at` expression that works on strings (1-indexed) and returns the character at a given position in the string. This can be used to get a character symbol from a sequence

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
