### PR TITLE
refactor: extract generic pipeline optimizer base class

### DIFF
--- a/src/silo/query_engine/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/column_narrowing_pass.cpp
@@ -19,9 +19,9 @@ namespace silo::query_engine {
 
 namespace {
 // NOLINTNEXTLINE(misc-no-recursion)
-void applyToNode(operators::QueryNodePtr& child, ColumnNarrowingPass& pass) {
-   if (auto new_child = operators::visit(*child, pass)) {
-      child = std::move(new_child);
+void applyToNode(operators::QueryNodePtr& node, ColumnNarrowingPass& pass) {
+   if (auto new_node = operators::visit(*node, pass)) {
+      node = std::move(new_node);
    }
 }
 }  // namespace

--- a/src/silo/query_engine/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/column_narrowing_pass.cpp
@@ -1,35 +1,17 @@
 #include "silo/query_engine/column_narrowing_pass.h"
 
-#include "silo/query_engine/operator_visitor.h"
 #include "silo/query_engine/operators/aggregate_node.h"
-#include "silo/query_engine/operators/fetch_node.h"
-#include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
-#include "silo/query_engine/operators/unresolved_insertions_node.h"
-#include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
-#include "silo/query_engine/operators/unresolved_mutations_node.h"
-#include "silo/query_engine/operators/unresolved_phylo_subtree_node.h"
 #include "silo/query_engine/operators/zstd_decompress_node.h"
 
 namespace silo::query_engine {
 
-namespace {
-// NOLINTNEXTLINE(misc-no-recursion)
-void applyToNode(operators::QueryNodePtr& node, ColumnNarrowingPass& pass) {
-   if (auto new_node = operators::visit(*node, pass)) {
-      node = std::move(new_node);
-   }
-}
-}  // namespace
-
-operators::QueryNodePtr ColumnNarrowingPass::run(operators::QueryNodePtr node) {
-   ColumnNarrowingPass pass{node->getOutputSchema()};
-   applyToNode(node, pass);
-   return node;
+ColumnNarrowingPass ColumnNarrowingPass::makePass(const operators::QueryNodePtr& node) {
+   return ColumnNarrowingPass{node->getOutputSchema()};
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static,misc-no-recursion)
@@ -65,7 +47,7 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::AggregateNode
    } else {
       required = std::move(child_required);
    }
-   applyToNode(node.child, *this);
+   propagateToNode(node.child);
    return nullptr;
 }
 
@@ -80,7 +62,7 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::ProjectNode& 
    node.fields = narrowed_fields;
 
    required = node.fields;
-   applyToNode(node.child, *this);
+   propagateToNode(node.child);
    if (node.child->getOutputSchema() == node.fields) {
       return std::move(node.child);
    }
@@ -104,7 +86,7 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::ZstdDecompres
       }
    }
    required = std::move(child_required);
-   applyToNode(node.child, *this);
+   propagateToNode(node.child);
 
    if (new_column_mapping.empty()) {
       return std::move(node.child);
@@ -143,7 +125,7 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::MapNode& node
       child_required.push_back(child_schema.front());
    }
    required = std::move(child_required);
-   applyToNode(node.child, *this);
+   propagateToNode(node.child);
    return nullptr;
 }
 
@@ -154,72 +136,20 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::OrderByNode& 
          required.push_back(field.field);
       }
    }
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::FetchNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::FilterNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-template <typename SymbolType>
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr ColumnNarrowingPass::operator()(
-   operators::UnresolvedMutationsNode<SymbolType>& node
-) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-template <typename SymbolType>
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr ColumnNarrowingPass::operator()(
-   operators::UnresolvedInsertionsNode<SymbolType>& node
-) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr ColumnNarrowingPass::operator()(
-   operators::UnresolvedMostRecentCommonAncestorNode& node
-) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedPhyloSubtreeNode& node
-) {
-   applyToNode(node.child, *this);
+   propagateToNode(node.child);
    return nullptr;
 }
 
 // NOLINTNEXTLINE(misc-no-recursion,readability-make-member-function-const)
 operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnionAllNode& node) {
-   // Narrow columns in each child independently using the same required set.
+   // Narrow columns in each child independently using the same required set. Each branch needs
+   // its own pass instance because `required` is mutated while walking, so the base default
+   // (which shares a single instance across both branches) is not correct here.
    ColumnNarrowingPass left_pass(required);
-   applyToNode(node.left, left_pass);
+   left_pass.propagateToNode(node.left);
    ColumnNarrowingPass right_pass(required);
-   applyToNode(node.right, right_pass);
+   right_pass.propagateToNode(node.right);
    return nullptr;
 }
-
-template operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedMutationsNode<
-                                                                 silo::Nucleotide>&);
-template operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedMutationsNode<
-                                                                 silo::AminoAcid>&);
-template operators::QueryNodePtr ColumnNarrowingPass::
-operator()(operators::UnresolvedInsertionsNode<silo::Nucleotide>&);
-template operators::QueryNodePtr ColumnNarrowingPass::
-operator()(operators::UnresolvedInsertionsNode<silo::AminoAcid>&);
 
 }  // namespace silo::query_engine

--- a/src/silo/query_engine/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/column_narrowing_pass.cpp
@@ -19,12 +19,18 @@ namespace silo::query_engine {
 
 namespace {
 // NOLINTNEXTLINE(misc-no-recursion)
-void applyToChild(operators::QueryNodePtr& child, ColumnNarrowingPass& pass) {
+void applyToNode(operators::QueryNodePtr& child, ColumnNarrowingPass& pass) {
    if (auto new_child = operators::visit(*child, pass)) {
       child = std::move(new_child);
    }
 }
 }  // namespace
+
+operators::QueryNodePtr ColumnNarrowingPass::run(operators::QueryNodePtr node) {
+   ColumnNarrowingPass pass{node->getOutputSchema()};
+   applyToNode(node, pass);
+   return node;
+}
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static,misc-no-recursion)
 operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::TableScanNode& node) {
@@ -59,7 +65,7 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::AggregateNode
    } else {
       required = std::move(child_required);
    }
-   applyToChild(node.child, *this);
+   applyToNode(node.child, *this);
    return nullptr;
 }
 
@@ -74,7 +80,7 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::ProjectNode& 
    node.fields = narrowed_fields;
 
    required = node.fields;
-   applyToChild(node.child, *this);
+   applyToNode(node.child, *this);
    if (node.child->getOutputSchema() == node.fields) {
       return std::move(node.child);
    }
@@ -98,7 +104,7 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::ZstdDecompres
       }
    }
    required = std::move(child_required);
-   applyToChild(node.child, *this);
+   applyToNode(node.child, *this);
 
    if (new_column_mapping.empty()) {
       return std::move(node.child);
@@ -137,7 +143,7 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::MapNode& node
       child_required.push_back(child_schema.front());
    }
    required = std::move(child_required);
-   applyToChild(node.child, *this);
+   applyToNode(node.child, *this);
    return nullptr;
 }
 
@@ -148,19 +154,19 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::OrderByNode& 
          required.push_back(field.field);
       }
    }
-   applyToChild(node.child, *this);
+   applyToNode(node.child, *this);
    return nullptr;
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::FetchNode& node) {
-   applyToChild(node.child, *this);
+   applyToNode(node.child, *this);
    return nullptr;
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::FilterNode& node) {
-   applyToChild(node.child, *this);
+   applyToNode(node.child, *this);
    return nullptr;
 }
 
@@ -169,7 +175,7 @@ template <typename SymbolType>
 operators::QueryNodePtr ColumnNarrowingPass::operator()(
    operators::UnresolvedMutationsNode<SymbolType>& node
 ) {
-   applyToChild(node.child, *this);
+   applyToNode(node.child, *this);
    return nullptr;
 }
 
@@ -178,7 +184,7 @@ template <typename SymbolType>
 operators::QueryNodePtr ColumnNarrowingPass::operator()(
    operators::UnresolvedInsertionsNode<SymbolType>& node
 ) {
-   applyToChild(node.child, *this);
+   applyToNode(node.child, *this);
    return nullptr;
 }
 
@@ -186,14 +192,14 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(
 operators::QueryNodePtr ColumnNarrowingPass::operator()(
    operators::UnresolvedMostRecentCommonAncestorNode& node
 ) {
-   applyToChild(node.child, *this);
+   applyToNode(node.child, *this);
    return nullptr;
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedPhyloSubtreeNode& node
 ) {
-   applyToChild(node.child, *this);
+   applyToNode(node.child, *this);
    return nullptr;
 }
 
@@ -201,9 +207,9 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnresolvedPhy
 operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnionAllNode& node) {
    // Narrow columns in each child independently using the same required set.
    ColumnNarrowingPass left_pass(required);
-   applyToChild(node.left, left_pass);
+   applyToNode(node.left, left_pass);
    ColumnNarrowingPass right_pass(required);
-   applyToChild(node.right, right_pass);
+   applyToNode(node.right, right_pass);
    return nullptr;
 }
 

--- a/src/silo/query_engine/column_narrowing_pass.h
+++ b/src/silo/query_engine/column_narrowing_pass.h
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "silo/query_engine/operators/query_node.h"
+#include "silo/query_engine/pipeline_pass_base.h"
 #include "silo/schema/database_schema.h"
 
 namespace silo::query_engine::operators {
@@ -12,20 +13,17 @@ class ProjectNode;
 class MapNode;
 class ZstdDecompressNode;
 class OrderByNode;
-class FetchNode;
-class FilterNode;
-template <typename SymbolType>
-class UnresolvedMutationsNode;
-template <typename SymbolType>
-class UnresolvedInsertionsNode;
 class UnionAllNode;
-class UnresolvedMostRecentCommonAncestorNode;
-class UnresolvedPhyloSubtreeNode;
 }  // namespace silo::query_engine::operators
 
 namespace silo::query_engine {
 
-class ColumnNarrowingPass {
+/// Optimization pass that narrows the set of columns produced by each node down to those
+/// actually required by its parent, pruning unneeded columns from scans and collapsing
+/// redundant Project/ZstdDecompress nodes.
+///
+/// Carries state (`required`) that is mutated while walking the nodes.
+class ColumnNarrowingPass : public PipelinePassBase<ColumnNarrowingPass> {
   public:
    using RequiredColumns = std::vector<schema::ColumnIdentifier>;
 
@@ -34,9 +32,9 @@ class ColumnNarrowingPass {
    explicit ColumnNarrowingPass(RequiredColumns required)
        : required(std::move(required)) {}
 
-   /// Runs the pass on `node`, seeding the required columns from the node's output
-   /// schema (the query result keeps exactly those columns).
-   static operators::QueryNodePtr run(operators::QueryNodePtr node);
+   static ColumnNarrowingPass makePass(const operators::QueryNodePtr& node);
+
+   using PipelinePassBase<ColumnNarrowingPass>::operator();
 
    operators::QueryNodePtr operator()(operators::TableScanNode& node);
    operators::QueryNodePtr operator()(operators::AggregateNode& node);
@@ -44,21 +42,7 @@ class ColumnNarrowingPass {
    operators::QueryNodePtr operator()(operators::ZstdDecompressNode& node);
    operators::QueryNodePtr operator()(operators::MapNode& node);
    operators::QueryNodePtr operator()(operators::OrderByNode& node);
-   operators::QueryNodePtr operator()(operators::FetchNode& node);
-   operators::QueryNodePtr operator()(operators::FilterNode& node);
-   template <typename SymbolType>
-   operators::QueryNodePtr operator()(operators::UnresolvedMutationsNode<SymbolType>& node);
-   template <typename SymbolType>
-   operators::QueryNodePtr operator()(operators::UnresolvedInsertionsNode<SymbolType>& node);
-   operators::QueryNodePtr operator()(operators::UnresolvedMostRecentCommonAncestorNode& node);
-   operators::QueryNodePtr operator()(operators::UnresolvedPhyloSubtreeNode& node);
    operators::QueryNodePtr operator()(operators::UnionAllNode& node);
-
-   // Post-pushdown nodes are leaves that don't participate in column narrowing.
-   template <typename T>
-   operators::QueryNodePtr operator()(T& /*node*/) {
-      return nullptr;
-   }
 };
 
 }  // namespace silo::query_engine

--- a/src/silo/query_engine/column_narrowing_pass.h
+++ b/src/silo/query_engine/column_narrowing_pass.h
@@ -34,6 +34,10 @@ class ColumnNarrowingPass {
    explicit ColumnNarrowingPass(RequiredColumns required)
        : required(std::move(required)) {}
 
+   /// Runs the pass on `node`, seeding the required columns from the node's output
+   /// schema (the query result keeps exactly those columns).
+   static operators::QueryNodePtr run(operators::QueryNodePtr node);
+
    operators::QueryNodePtr operator()(operators::TableScanNode& node);
    operators::QueryNodePtr operator()(operators::AggregateNode& node);
    operators::QueryNodePtr operator()(operators::ProjectNode& node);

--- a/src/silo/query_engine/column_narrowing_pass.test.cpp
+++ b/src/silo/query_engine/column_narrowing_pass.test.cpp
@@ -9,13 +9,16 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "silo/query_engine/expressions/field_ref.h"
 #include "silo/query_engine/expressions/literal.h"
 #include "silo/query_engine/operators/aggregate_node.h"
 #include "silo/query_engine/operators/fetch_node.h"
 #include "silo/query_engine/operators/filter_node.h"
+#include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
+#include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/zstd_decompress_node.h"
 #include "silo/query_engine/order_by_field.h"
 #include "silo/schema/database_schema.h"
@@ -92,6 +95,9 @@ operators::TableScanNode& leafScan(operators::QueryNode& node) {
    }
    if (auto* zstd = dynamic_cast<operators::ZstdDecompressNode*>(&node)) {
       return leafScan(*zstd->child);
+   }
+   if (auto* map = dynamic_cast<operators::MapNode*>(&node)) {
+      return leafScan(*map->child);
    }
    throw std::logic_error("unexpected node type in leafScan");
 }
@@ -318,6 +324,56 @@ TEST(ColumnNarrowingPassFetch, propagatesRequiredThroughFetch) {
    pass(*fetch);
 
    EXPECT_THAT(scanSchema(leafScan(*fetch)), ::testing::ElementsAre(col("b")));
+}
+
+// --- FilterNode -> TableScanNode ---
+TEST(ColumnNarrowingPassFilter, propagatesRequiredThroughFilter) {
+   auto scan = makeScan({col("a"), col("b"), col("c")});
+   auto filter = std::make_unique<operators::FilterNode>(
+      std::move(scan), std::make_unique<silo::query_engine::expressions::BoolLiteral>(true)
+   );
+
+   silo::query_engine::ColumnNarrowingPass pass({col("b")});
+   pass(*filter);
+
+   EXPECT_THAT(scanSchema(leafScan(*filter)), ::testing::ElementsAre(col("b")));
+}
+
+// --- MapNode -> TableScanNode ---
+
+// A map produces "x := b". Only "x" is required from above, so the child does not need to provide
+// "x" (the map produces it), but it must provide "b" (referenced by the assignment). "a" and "c"
+// are pruned from the scan.
+TEST(ColumnNarrowingPassMap, keepsReferencedColumnAndPrunesOthers) {
+   auto scan = makeScan({col("a"), col("b"), col("c")});
+   std::vector<operators::MapNode::Assignment> assignments;
+   assignments.push_back(
+      {.output_column = col("x"),
+       .expression = std::make_unique<silo::query_engine::expressions::FieldRef>(col("b"))}
+   );
+   auto map = std::make_unique<operators::MapNode>(std::move(scan), std::move(assignments));
+
+   silo::query_engine::ColumnNarrowingPass pass({col("x")});
+   pass(*map);
+
+   EXPECT_THAT(scanSchema(leafScan(*map)), ::testing::ElementsAre(col("b")));
+}
+
+// --- UnionAllNode -> TableScanNode (both branches) ---
+
+// UnionAll narrows each branch independently using the same required set. A custom override is
+// kept (instead of the stateless base default) because `required` is mutated while walking, so
+// each branch needs its own pass instance.
+TEST(ColumnNarrowingPassUnionAll, narrowsBothBranchesIndependently) {
+   auto left = makeScan({col("a"), col("b"), col("c")});
+   auto right = makeScan({col("a"), col("b"), col("c")});
+   const auto union_all = std::make_unique<operators::UnionAllNode>(std::move(left), std::move(right));
+
+   silo::query_engine::ColumnNarrowingPass pass({col("a")});
+   pass(*union_all);
+
+   EXPECT_THAT(scanSchema(leafScan(*union_all->left)), ::testing::ElementsAre(col("a")));
+   EXPECT_THAT(scanSchema(leafScan(*union_all->right)), ::testing::ElementsAre(col("a")));
 }
 
 }  // namespace

--- a/src/silo/query_engine/column_narrowing_pass.test.cpp
+++ b/src/silo/query_engine/column_narrowing_pass.test.cpp
@@ -367,7 +367,8 @@ TEST(ColumnNarrowingPassMap, keepsReferencedColumnAndPrunesOthers) {
 TEST(ColumnNarrowingPassUnionAll, narrowsBothBranchesIndependently) {
    auto left = makeScan({col("a"), col("b"), col("c")});
    auto right = makeScan({col("a"), col("b"), col("c")});
-   const auto union_all = std::make_unique<operators::UnionAllNode>(std::move(left), std::move(right));
+   const auto union_all =
+      std::make_unique<operators::UnionAllNode>(std::move(left), std::move(right));
 
    silo::query_engine::ColumnNarrowingPass pass({col("a")});
    pass(*union_all);

--- a/src/silo/query_engine/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.cpp
@@ -17,7 +17,7 @@ namespace silo::query_engine {
 operators::QueryNodePtr FilterPushdownPass::operator()(operators::FilterNode& node) {
    current_filters.push_back(std::move(node.filter));
    auto child = std::move(node.child);
-   propagateToChild(child);
+   propagateToNode(child);
    return child;
 }
 
@@ -78,8 +78,8 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& 
    FilterPushdownPass left_pass;
    left_pass.current_filters = std::move(current_filters);
 
-   left_pass.propagateToChild(node.left);
-   right_pass.propagateToChild(node.right);
+   left_pass.propagateToNode(node.left);
+   right_pass.propagateToNode(node.right);
    return nullptr;
 }
 

--- a/src/silo/query_engine/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.cpp
@@ -3,45 +3,21 @@
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/query_engine/expressions/and.h"
-#include "silo/query_engine/operator_visitor.h"
-#include "silo/query_engine/operators/aggregate_node.h"
-#include "silo/query_engine/operators/fetch_node.h"
 #include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/insertions_node.h"
-#include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/mutations_node.h"
-#include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/phylo_subtree_node.h"
-#include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
-#include "silo/query_engine/operators/zstd_decompress_node.h"
 
 namespace silo::query_engine {
-
-namespace {
-
-// NOLINTNEXTLINE(misc-no-recursion)
-void applyToNode(operators::QueryNodePtr& node, FilterPushdownPass& pass) {
-   while (auto replacement = operators::visit(*node, pass)) {
-      node = std::move(replacement);
-   }
-}
-
-}  // namespace
-
-operators::QueryNodePtr FilterPushdownPass::run(operators::QueryNodePtr node) {
-   FilterPushdownPass pass;
-   applyToNode(node, pass);
-   return node;
-}
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr FilterPushdownPass::operator()(operators::FilterNode& node) {
    current_filters.push_back(std::move(node.filter));
    auto child = std::move(node.child);
-   applyToNode(child, *this);
+   applyToNode(child, *this);  // NOLINT(*-static-accessed-through-instance)
    return child;
 }
 
@@ -93,75 +69,6 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::MostRecentComm
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(operators::AggregateNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(operators::OrderByNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(operators::FetchNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(operators::ProjectNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(operators::MapNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(operators::ZstdDecompressNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-template <typename SymbolType>
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(
-   operators::UnresolvedMutationsNode<SymbolType>& node
-) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-template <typename SymbolType>
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(
-   operators::UnresolvedInsertionsNode<SymbolType>& node
-) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(
-   operators::UnresolvedMostRecentCommonAncestorNode& node
-) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedPhyloSubtreeNode& node
-) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& node) {
    // Push parent filters into both children. Clone for right, move originals into left.
    FilterPushdownPass right_pass;
@@ -175,14 +82,5 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& 
    applyToNode(node.right, right_pass);
    return nullptr;
 }
-
-template operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedMutationsNode<
-                                                                silo::Nucleotide>&);
-template operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedMutationsNode<
-                                                                silo::AminoAcid>&);
-template operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedInsertionsNode<
-                                                                silo::Nucleotide>&);
-template operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnresolvedInsertionsNode<
-                                                                silo::AminoAcid>&);
 
 }  // namespace silo::query_engine

--- a/src/silo/query_engine/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.cpp
@@ -17,7 +17,7 @@ namespace silo::query_engine {
 operators::QueryNodePtr FilterPushdownPass::operator()(operators::FilterNode& node) {
    current_filters.push_back(std::move(node.filter));
    auto child = std::move(node.child);
-   applyToNode(child, *this);  // NOLINT(*-static-accessed-through-instance)
+   propagateToChild(child);
    return child;
 }
 
@@ -78,8 +78,8 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& 
    FilterPushdownPass left_pass;
    left_pass.current_filters = std::move(current_filters);
 
-   applyToNode(node.left, left_pass);
-   applyToNode(node.right, right_pass);
+   left_pass.propagateToChild(node.left);
+   right_pass.propagateToChild(node.right);
    return nullptr;
 }
 

--- a/src/silo/query_engine/filter_pushdown_pass.h
+++ b/src/silo/query_engine/filter_pushdown_pass.h
@@ -2,14 +2,10 @@
 
 #include "silo/query_engine/expressions/expression.h"
 #include "silo/query_engine/operators/query_node.h"
+#include "silo/query_engine/pipeline_pass_base.h"
 
 namespace silo::query_engine::operators {
-class AggregateNode;
-class FetchNode;
 class FilterNode;
-class MapNode;
-class OrderByNode;
-class ProjectNode;
 class TableScanNode;
 template <typename SymbolType>
 class MutationsNode;
@@ -17,34 +13,20 @@ template <typename SymbolType>
 class InsertionsNode;
 class PhyloSubtreeNode;
 class MostRecentCommonAncestorNode;
-template <typename SymbolType>
-class UnresolvedMutationsNode;
-template <typename SymbolType>
-class UnresolvedInsertionsNode;
-class UnresolvedPhyloSubtreeNode;
-class UnresolvedMostRecentCommonAncestorNode;
 class UnionAllNode;
-class ZstdDecompressNode;
-
 }  // namespace silo::query_engine::operators
 
 namespace silo::query_engine {
 
 /// Optimization pass that eliminates FilterNodes by pushing their filter expression
 /// into the child node's filter field
-class FilterPushdownPass {
+class FilterPushdownPass : public PipelinePassBase<FilterPushdownPass> {
    std::vector<std::unique_ptr<expressions::Expression>> current_filters;
 
   public:
-   static operators::QueryNodePtr run(operators::QueryNodePtr node);
+   using PipelinePassBase<FilterPushdownPass>::operator();
 
    operators::QueryNodePtr operator()(operators::FilterNode& node);
-   operators::QueryNodePtr operator()(operators::AggregateNode& node);
-   operators::QueryNodePtr operator()(operators::OrderByNode& node);
-   operators::QueryNodePtr operator()(operators::FetchNode& node);
-   operators::QueryNodePtr operator()(operators::ProjectNode& node);
-   operators::QueryNodePtr operator()(operators::MapNode& node);
-   operators::QueryNodePtr operator()(operators::ZstdDecompressNode& node);
 
    operators::QueryNodePtr operator()(operators::TableScanNode& node);
    operators::QueryNodePtr operator()(operators::MutationsNode<Nucleotide>& node);
@@ -54,19 +36,7 @@ class FilterPushdownPass {
    operators::QueryNodePtr operator()(operators::PhyloSubtreeNode& node);
    operators::QueryNodePtr operator()(operators::MostRecentCommonAncestorNode& node);
 
-   template <typename SymbolType>
-   operators::QueryNodePtr operator()(operators::UnresolvedMutationsNode<SymbolType>& node);
-   template <typename SymbolType>
-   operators::QueryNodePtr operator()(operators::UnresolvedInsertionsNode<SymbolType>& node);
-   operators::QueryNodePtr operator()(operators::UnresolvedPhyloSubtreeNode& node);
-   operators::QueryNodePtr operator()(operators::UnresolvedMostRecentCommonAncestorNode& node);
    operators::QueryNodePtr operator()(operators::UnionAllNode& node);
-
-   // All other nodes (TableScanNode, MutationsNode, etc.) are leaves here.
-   template <typename T>
-   operators::QueryNodePtr operator()(T& /*node*/) {
-      return nullptr;
-   }
 };
 
 }  // namespace silo::query_engine

--- a/src/silo/query_engine/filter_pushdown_pass.h
+++ b/src/silo/query_engine/filter_pushdown_pass.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <string_view>
-
 #include "silo/query_engine/expressions/expression.h"
 #include "silo/query_engine/operators/query_node.h"
 #include "silo/query_engine/pipeline_pass_base.h"
@@ -26,8 +24,6 @@ class FilterPushdownPass : public PipelinePassBase<FilterPushdownPass> {
    std::vector<std::unique_ptr<expressions::Expression>> current_filters;
 
   public:
-   static constexpr std::string_view NAME = "FilterPushdownPass";
-
    using PipelinePassBase<FilterPushdownPass>::operator();
 
    operators::QueryNodePtr operator()(operators::FilterNode& node);

--- a/src/silo/query_engine/filter_pushdown_pass.h
+++ b/src/silo/query_engine/filter_pushdown_pass.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 #include "silo/query_engine/expressions/expression.h"
 #include "silo/query_engine/operators/query_node.h"
 #include "silo/query_engine/pipeline_pass_base.h"
@@ -24,6 +26,8 @@ class FilterPushdownPass : public PipelinePassBase<FilterPushdownPass> {
    std::vector<std::unique_ptr<expressions::Expression>> current_filters;
 
   public:
+   static constexpr std::string_view NAME = "FilterPushdownPass";
+
    using PipelinePassBase<FilterPushdownPass>::operator();
 
    operators::QueryNodePtr operator()(operators::FilterNode& node);

--- a/src/silo/query_engine/filter_pushdown_pass.test.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.test.cpp
@@ -9,7 +9,9 @@
 #include "silo/query_engine/expressions/literal.h"
 #include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/map_node.h"
+#include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
+#include "silo/query_engine/operators/union_all_node.h"
 #include "silo/schema/database_schema.h"
 #include "silo/storage/column/string_column.h"
 #include "silo/storage/table.h"
@@ -38,6 +40,18 @@ std::unique_ptr<expressions::Expression> makeDummyFilter() {
    return std::make_unique<expressions::BoolLiteral>(true);
 }
 
+operators::QueryNodePtr makeScan() {
+   return std::make_unique<operators::TableScanNode>(
+      makeTable(), makeDummyFilter(), std::vector<silo::schema::ColumnIdentifier>{}
+   );
+}
+
+operators::QueryNodePtr makeFilteredScan(bool filter_value) {
+   return std::make_unique<operators::FilterNode>(
+      makeScan(), std::make_unique<expressions::BoolLiteral>(filter_value)
+   );
+}
+
 // --- FilterNode(TableScanNode) ---
 
 TEST(FilterPushdownPass, eliminatesFilterNodeAboveTableScan) {
@@ -53,6 +67,20 @@ TEST(FilterPushdownPass, eliminatesFilterNodeAboveTableScan) {
    EXPECT_EQ(result->kind(), operators::NodeKind::TABLE_SCAN);
    auto* table_scan = dynamic_cast<operators::TableScanNode*>(result.get());
    EXPECT_EQ(table_scan->filter->toString(), "And(And(true & true))");
+}
+
+// --- FilterNode(FilterNode(TableScanNode)) ---
+TEST(FilterPushdownPass, eliminatesStackedFilterNodesAboveTableScan) {
+   auto inner_filter = makeFilteredScan(false);
+   auto outer_filter =
+      std::make_unique<operators::FilterNode>(std::move(inner_filter), makeDummyFilter());
+
+   auto result = FilterPushdownPass::run(std::move(outer_filter));
+
+   // Both FilterNodes are gone; result is the TableScanNode with all three filters merged.
+   EXPECT_EQ(result->kind(), operators::NodeKind::TABLE_SCAN);
+   auto* table_scan = dynamic_cast<operators::TableScanNode*>(result.get());
+   EXPECT_EQ(table_scan->filter->toString(), "And(And(And(true & false & true)))");
 }
 
 // --- MapNode(FilterNode(TableScanNode)) ---
@@ -80,6 +108,58 @@ TEST(FilterPushdownPass, pushesFilterThroughMapIntoTableScan) {
    ASSERT_EQ(map->child->kind(), operators::NodeKind::TABLE_SCAN);
    auto* table_scan = dynamic_cast<operators::TableScanNode*>(map->child.get());
    EXPECT_EQ(table_scan->filter->toString(), "And(And(true & true))");
+}
+
+// --- FilterNode(ProjectNode(MapNode(FilterNode(TableScanNode)))) ---
+TEST(FilterPushdownPass, pushesFilterThroughProjectAndMapIntoTableScan) {
+   auto inner_filter = makeFilteredScan(false);
+
+   std::vector<operators::MapNode::Assignment> assignments;
+   assignments.push_back(
+      {.output_column = {.name = "x", .type = silo::schema::ColumnType::INT64},
+       .expression = std::make_unique<expressions::Int64Literal>(3)}
+   );
+   auto map_node =
+      std::make_unique<operators::MapNode>(std::move(inner_filter), std::move(assignments));
+   auto project_node = std::make_unique<operators::ProjectNode>(
+      std::move(map_node),
+      std::vector<silo::schema::ColumnIdentifier>{
+         {.name = "x", .type = silo::schema::ColumnType::INT64}
+      }
+   );
+   auto outer_filter =
+      std::make_unique<operators::FilterNode>(std::move(project_node), makeDummyFilter());
+
+   auto result = FilterPushdownPass::run(std::move(outer_filter));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::PROJECT);
+   auto* project = dynamic_cast<operators::ProjectNode*>(result.get());
+   ASSERT_EQ(project->child->kind(), operators::NodeKind::MAP);
+   auto* map = dynamic_cast<operators::MapNode*>(project->child.get());
+   ASSERT_EQ(map->child->kind(), operators::NodeKind::TABLE_SCAN);
+   auto* table_scan = dynamic_cast<operators::TableScanNode*>(map->child.get());
+   EXPECT_EQ(table_scan->filter->toString(), "And(And(And(true & false & true)))");
+}
+
+// --- FilterNode(UnionAllNode(FilterNode(TableScanNode), FilterNode(TableScanNode))) ---
+TEST(FilterPushdownPass, pushesFilterIntoBothUnionAllBranches) {
+   // left branch: Filter(false, Scan), right branch: Filter(true, Scan)
+   auto union_all = std::make_unique<operators::UnionAllNode>(
+      makeFilteredScan(false), makeFilteredScan(true)
+   );
+   auto filter_node = std::make_unique<operators::FilterNode>(std::move(union_all), makeDummyFilter());
+
+   auto result = FilterPushdownPass::run(std::move(filter_node));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::UNION_ALL);
+   auto* union_node = dynamic_cast<operators::UnionAllNode*>(result.get());
+   ASSERT_EQ(union_node->left->kind(), operators::NodeKind::TABLE_SCAN);
+   ASSERT_EQ(union_node->right->kind(), operators::NodeKind::TABLE_SCAN);
+   auto* left_scan = dynamic_cast<operators::TableScanNode*>(union_node->left.get());
+   auto* right_scan = dynamic_cast<operators::TableScanNode*>(union_node->right.get());
+   // outer filter (true) + branch filter (false/true) + scan filter (true)
+   EXPECT_EQ(left_scan->filter->toString(), "And(And(And(true & false & true)))");
+   EXPECT_EQ(right_scan->filter->toString(), "And(And(And(true & true & true)))");
 }
 
 }  // namespace

--- a/src/silo/query_engine/filter_pushdown_pass.test.cpp
+++ b/src/silo/query_engine/filter_pushdown_pass.test.cpp
@@ -66,7 +66,7 @@ TEST(FilterPushdownPass, eliminatesFilterNodeAboveTableScan) {
    // The FilterNode is gone; result is the TableScanNode directly.
    EXPECT_EQ(result->kind(), operators::NodeKind::TABLE_SCAN);
    auto* table_scan = dynamic_cast<operators::TableScanNode*>(result.get());
-   EXPECT_EQ(table_scan->filter->toString(), "And(And(true & true))");
+   EXPECT_EQ(table_scan->filter->toString(), "And(true & true)");
 }
 
 // --- FilterNode(FilterNode(TableScanNode)) ---
@@ -80,7 +80,7 @@ TEST(FilterPushdownPass, eliminatesStackedFilterNodesAboveTableScan) {
    // Both FilterNodes are gone; result is the TableScanNode with all three filters merged.
    EXPECT_EQ(result->kind(), operators::NodeKind::TABLE_SCAN);
    auto* table_scan = dynamic_cast<operators::TableScanNode*>(result.get());
-   EXPECT_EQ(table_scan->filter->toString(), "And(And(And(true & false & true)))");
+   EXPECT_EQ(table_scan->filter->toString(), "And(true & false & true)");
 }
 
 // --- MapNode(FilterNode(TableScanNode)) ---
@@ -107,7 +107,7 @@ TEST(FilterPushdownPass, pushesFilterThroughMapIntoTableScan) {
    auto* map = dynamic_cast<operators::MapNode*>(result.get());
    ASSERT_EQ(map->child->kind(), operators::NodeKind::TABLE_SCAN);
    auto* table_scan = dynamic_cast<operators::TableScanNode*>(map->child.get());
-   EXPECT_EQ(table_scan->filter->toString(), "And(And(true & true))");
+   EXPECT_EQ(table_scan->filter->toString(), "And(true & true)");
 }
 
 // --- FilterNode(ProjectNode(MapNode(FilterNode(TableScanNode)))) ---
@@ -138,16 +138,16 @@ TEST(FilterPushdownPass, pushesFilterThroughProjectAndMapIntoTableScan) {
    auto* map = dynamic_cast<operators::MapNode*>(project->child.get());
    ASSERT_EQ(map->child->kind(), operators::NodeKind::TABLE_SCAN);
    auto* table_scan = dynamic_cast<operators::TableScanNode*>(map->child.get());
-   EXPECT_EQ(table_scan->filter->toString(), "And(And(And(true & false & true)))");
+   EXPECT_EQ(table_scan->filter->toString(), "And(true & false & true)");
 }
 
 // --- FilterNode(UnionAllNode(FilterNode(TableScanNode), FilterNode(TableScanNode))) ---
 TEST(FilterPushdownPass, pushesFilterIntoBothUnionAllBranches) {
    // left branch: Filter(false, Scan), right branch: Filter(true, Scan)
-   auto union_all = std::make_unique<operators::UnionAllNode>(
-      makeFilteredScan(false), makeFilteredScan(true)
-   );
-   auto filter_node = std::make_unique<operators::FilterNode>(std::move(union_all), makeDummyFilter());
+   auto union_all =
+      std::make_unique<operators::UnionAllNode>(makeFilteredScan(false), makeFilteredScan(true));
+   auto filter_node =
+      std::make_unique<operators::FilterNode>(std::move(union_all), makeDummyFilter());
 
    auto result = FilterPushdownPass::run(std::move(filter_node));
 
@@ -158,8 +158,8 @@ TEST(FilterPushdownPass, pushesFilterIntoBothUnionAllBranches) {
    auto* left_scan = dynamic_cast<operators::TableScanNode*>(union_node->left.get());
    auto* right_scan = dynamic_cast<operators::TableScanNode*>(union_node->right.get());
    // outer filter (true) + branch filter (false/true) + scan filter (true)
-   EXPECT_EQ(left_scan->filter->toString(), "And(And(And(true & false & true)))");
-   EXPECT_EQ(right_scan->filter->toString(), "And(And(And(true & true & true)))");
+   EXPECT_EQ(left_scan->filter->toString(), "And(true & false & true)");
+   EXPECT_EQ(right_scan->filter->toString(), "And(true & true & true)");
 }
 
 }  // namespace

--- a/src/silo/query_engine/node_resolution_pass.cpp
+++ b/src/silo/query_engine/node_resolution_pass.cpp
@@ -119,7 +119,7 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr NodeResolutionPass::operator()(operators::AggregateNode& node) {
-   propagateToChild(node.child);
+   propagateToNode(node.child);
 
    // Full aggregations (COUNT(*) and only a filter below can be optimized)
    if (node.group_by_fields.empty() && node.aggregates.size() == 1 &&

--- a/src/silo/query_engine/node_resolution_pass.cpp
+++ b/src/silo/query_engine/node_resolution_pass.cpp
@@ -5,23 +5,15 @@
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/query_engine/illegal_query_exception.h"
-#include "silo/query_engine/operator_visitor.h"
 #include "silo/query_engine/operators/aggregate_node.h"
 #include "silo/query_engine/operators/count_filter_node.h"
-#include "silo/query_engine/operators/fetch_node.h"
-#include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/insertions_node.h"
-#include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/mutations_node.h"
-#include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/phylo_subtree_node.h"
-#include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
-#include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/unresolved_phylo_subtree_node.h"
-#include "silo/query_engine/operators/zstd_decompress_node.h"
 
 namespace silo::query_engine {
 
@@ -32,55 +24,7 @@ std::optional<operators::TableScanNode*> getTableScanOrNone(operators::QueryNode
    return scan ? std::optional{scan} : std::nullopt;
 }
 
-// NOLINTNEXTLINE(misc-no-recursion)
-void applyToNode(operators::QueryNodePtr& node, NodeResolutionPass& pass) {
-   while (auto replacement = operators::visit(*node, pass)) {
-      node = std::move(replacement);
-   }
-}
-
 }  // namespace
-
-operators::QueryNodePtr NodeResolutionPass::run(operators::QueryNodePtr node) {
-   NodeResolutionPass pass;
-   applyToNode(node, pass);
-   return node;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr NodeResolutionPass::operator()(operators::FilterNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr NodeResolutionPass::operator()(operators::ProjectNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr NodeResolutionPass::operator()(operators::MapNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr NodeResolutionPass::operator()(operators::OrderByNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr NodeResolutionPass::operator()(operators::FetchNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr NodeResolutionPass::operator()(operators::ZstdDecompressNode& node) {
-   applyToNode(node.child, *this);
-   return nullptr;
-}
 
 template <typename SymbolType>
 // NOLINTNEXTLINE(misc-no-recursion)
@@ -175,7 +119,7 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr NodeResolutionPass::operator()(operators::AggregateNode& node) {
-   applyToNode(node.child, *this);
+   applyToNode(node.child, *this);  // NOLINT(*-static-accessed-through-instance)
 
    // Full aggregations (COUNT(*) and only a filter below can be optimized)
    if (node.group_by_fields.empty() && node.aggregates.size() == 1 &&
@@ -217,13 +161,6 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
       std::move(node.column_name),
       node.print_nodes_not_in_tree
    );
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnionAllNode& node) {
-   applyToNode(node.left, *this);
-   applyToNode(node.right, *this);
-   return nullptr;
 }
 
 template operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedMutationsNode<

--- a/src/silo/query_engine/node_resolution_pass.cpp
+++ b/src/silo/query_engine/node_resolution_pass.cpp
@@ -119,7 +119,7 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr NodeResolutionPass::operator()(operators::AggregateNode& node) {
-   applyToNode(node.child, *this);  // NOLINT(*-static-accessed-through-instance)
+   propagateToChild(node.child);
 
    // Full aggregations (COUNT(*) and only a filter below can be optimized)
    if (node.group_by_fields.empty() && node.aggregates.size() == 1 &&

--- a/src/silo/query_engine/node_resolution_pass.h
+++ b/src/silo/query_engine/node_resolution_pass.h
@@ -1,12 +1,7 @@
 #pragma once
 
-#include <map>
-#include <memory>
-
 #include "silo/query_engine/operators/query_node.h"
 #include "silo/query_engine/pipeline_pass_base.h"
-#include "silo/schema/database_schema.h"
-#include "silo/storage/table.h"
 
 namespace silo::query_engine::operators {
 class AggregateNode;

--- a/src/silo/query_engine/node_resolution_pass.h
+++ b/src/silo/query_engine/node_resolution_pass.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 #include "silo/query_engine/operators/query_node.h"
 #include "silo/query_engine/pipeline_pass_base.h"
 
@@ -23,6 +25,8 @@ namespace silo::query_engine {
 /// - AggregateNode(COUNT(*), TableScanNode) → CountFilterNode
 class NodeResolutionPass : public PipelinePassBase<NodeResolutionPass> {
   public:
+   static constexpr std::string_view NAME = "NodeResolutionPass";
+
    using PipelinePassBase<NodeResolutionPass>::operator();
 
    operators::QueryNodePtr operator()(operators::AggregateNode& node);

--- a/src/silo/query_engine/node_resolution_pass.h
+++ b/src/silo/query_engine/node_resolution_pass.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <string_view>
-
 #include "silo/query_engine/operators/query_node.h"
 #include "silo/query_engine/pipeline_pass_base.h"
 
@@ -25,8 +23,6 @@ namespace silo::query_engine {
 /// - AggregateNode(COUNT(*), TableScanNode) → CountFilterNode
 class NodeResolutionPass : public PipelinePassBase<NodeResolutionPass> {
   public:
-   static constexpr std::string_view NAME = "NodeResolutionPass";
-
    using PipelinePassBase<NodeResolutionPass>::operator();
 
    operators::QueryNodePtr operator()(operators::AggregateNode& node);

--- a/src/silo/query_engine/node_resolution_pass.h
+++ b/src/silo/query_engine/node_resolution_pass.h
@@ -4,24 +4,18 @@
 #include <memory>
 
 #include "silo/query_engine/operators/query_node.h"
+#include "silo/query_engine/pipeline_pass_base.h"
 #include "silo/schema/database_schema.h"
 #include "silo/storage/table.h"
 
 namespace silo::query_engine::operators {
 class AggregateNode;
-class ProjectNode;
-class MapNode;
-class OrderByNode;
-class FetchNode;
-class FilterNode;
 template <typename SymbolType>
 class UnresolvedMutationsNode;
 template <typename SymbolType>
 class UnresolvedInsertionsNode;
-class UnionAllNode;
 class UnresolvedMostRecentCommonAncestorNode;
 class UnresolvedPhyloSubtreeNode;
-class ZstdDecompressNode;
 }  // namespace silo::query_engine::operators
 
 namespace silo::query_engine {
@@ -32,30 +26,17 @@ namespace silo::query_engine {
 /// - UnresolvedPhyloSubtreeNode → PhyloSubtreeNode
 /// - UnresolvedMostRecentCommonAncestorNode → MostRecentCommonAncestorNode
 /// - AggregateNode(COUNT(*), TableScanNode) → CountFilterNode
-class NodeResolutionPass {
+class NodeResolutionPass : public PipelinePassBase<NodeResolutionPass> {
   public:
-   static operators::QueryNodePtr run(operators::QueryNodePtr node);
+   using PipelinePassBase<NodeResolutionPass>::operator();
 
-   operators::QueryNodePtr operator()(operators::FilterNode& node);
    operators::QueryNodePtr operator()(operators::AggregateNode& node);
-   operators::QueryNodePtr operator()(operators::ProjectNode& node);
-   operators::QueryNodePtr operator()(operators::MapNode& node);
-   operators::QueryNodePtr operator()(operators::OrderByNode& node);
-   operators::QueryNodePtr operator()(operators::FetchNode& node);
-   operators::QueryNodePtr operator()(operators::ZstdDecompressNode& node);
    template <typename SymbolType>
    operators::QueryNodePtr operator()(operators::UnresolvedMutationsNode<SymbolType>& node);
    template <typename SymbolType>
    operators::QueryNodePtr operator()(operators::UnresolvedInsertionsNode<SymbolType>& node);
    operators::QueryNodePtr operator()(operators::UnresolvedMostRecentCommonAncestorNode& node);
    operators::QueryNodePtr operator()(operators::UnresolvedPhyloSubtreeNode& node);
-   operators::QueryNodePtr operator()(operators::UnionAllNode& node);
-
-   // Post-resolution nodes are leaves that don't participate in this pass.
-   template <typename T>
-   operators::QueryNodePtr operator()(T& /*node*/) {
-      return nullptr;
-   }
 };
 
 }  // namespace silo::query_engine

--- a/src/silo/query_engine/node_resolution_pass.test.cpp
+++ b/src/silo/query_engine/node_resolution_pass.test.cpp
@@ -12,6 +12,7 @@
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/query_engine/expressions/literal.h"
 #include "silo/query_engine/illegal_query_exception.h"
+#include "silo/query_engine/operators/aggregate_node.h"
 #include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
@@ -71,6 +72,19 @@ std::vector<operators::MapNode::Assignment> makeMapAssignments() {
        .expression = std::make_unique<silo::query_engine::expressions::Int64Literal>(3)}
    );
    return assignments;
+}
+
+// COUNT(*) aggregate (no group-by, single COUNT) over the given child.
+operators::QueryNodePtr makeCountStarAggregate(operators::QueryNodePtr child) {
+   return std::make_unique<operators::AggregateNode>(
+      std::move(child),
+      std::vector<silo::schema::ColumnIdentifier>{},
+      std::vector<operators::AggregateDefinition>{
+         {.output_name = "count",
+          .function = operators::AggregateFunction::COUNT,
+          .source_column = std::nullopt}
+      }
+   );
 }
 
 // --- mutations() ---
@@ -195,6 +209,51 @@ TEST(NodeResolutionPassMap, propagatesChildErrorThroughMap) {
          ::testing::HasSubstr("insertions() must be applied to a table scan")
       )
    );
+}
+
+// --- happy-path resolutions (the replacement-returning handlers) ---
+TEST(NodeResolutionPassMutations, resolvesToMutationsNode) {
+   auto node = std::make_unique<operators::UnresolvedMutationsNode<Nucleotide>>(
+      makeTableScan(), std::vector<std::string>{}, 0.0, std::vector<std::string>{}
+   );
+
+   auto result = NodeResolutionPass::run(std::move(node));
+
+   EXPECT_EQ(result->kind(), operators::NodeKind::MUTATIONS_NUCLEOTIDE);
+}
+
+TEST(NodeResolutionPassInsertions, resolvesToInsertionsNode) {
+   auto node = std::make_unique<operators::UnresolvedInsertionsNode<Nucleotide>>(
+      makeTableScan(), std::vector<std::string>{}
+   );
+
+   auto result = NodeResolutionPass::run(std::move(node));
+
+   EXPECT_EQ(result->kind(), operators::NodeKind::INSERTIONS_NUCLEOTIDE);
+}
+
+// --- aggregate() COUNT(*) optimization ---
+
+// AggregateNode(COUNT(*), TableScan) is rewritten into a CountFilterNode.
+TEST(NodeResolutionPassAggregate, countStarOverTableScanBecomesCountFilter) {
+   auto aggregate = makeCountStarAggregate(makeTableScan());
+
+   auto result = NodeResolutionPass::run(std::move(aggregate));
+
+   EXPECT_EQ(result->kind(), operators::NodeKind::COUNT_FILTER);
+}
+
+// COUNT(*) over a non-scan child (here a FilterNode) is NOT optimizable: the AggregateNode is
+// kept in place (handler returns nullptr) and its child is still resolved/propagated.
+// In the full pipeline, the filter will thus be eliminated before resolving these nodes.
+TEST(NodeResolutionPassAggregate, countStarOverNonScanIsNotOptimized) {
+   auto aggregate = makeCountStarAggregate(makeNonScanChild());
+
+   auto result = NodeResolutionPass::run(std::move(aggregate));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::AGGREGATE);
+   auto* agg = dynamic_cast<operators::AggregateNode*>(result.get());
+   EXPECT_EQ(agg->child->kind(), operators::NodeKind::FILTER);
 }
 
 }  // namespace

--- a/src/silo/query_engine/pipeline_pass_base.h
+++ b/src/silo/query_engine/pipeline_pass_base.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <cstddef>
 #include <utility>
-
-#include <spdlog/spdlog.h>
 
 #include "silo/query_engine/operator_visitor.h"
 #include "silo/query_engine/operators/aggregate_node.h"
@@ -31,13 +28,11 @@ namespace silo::query_engine {
 /// pass.
 ///
 /// A derived pass overrides only the operators that need custom behaviour. It must
-/// pull the defaults into its own scope so they are not hidden by its overrides, and
-/// expose a `static constexpr std::string_view NAME` used for log messages:
+/// pull the defaults into its own scope so they are not hidden by its overrides:
 ///
 /// ```cpp
 /// class MyPass : public PipelinePassBase<MyPass> {
 ///   public:
-///    static constexpr std::string_view NAME = "MyPass";
 ///    using PipelinePassBase<MyPass>::operator();
 ///    operators::QueryNodePtr operator()(operators::FilterNode& node);  // custom
 /// };
@@ -137,27 +132,13 @@ class PipelinePassBase {
    }
 
   protected:
-   /// Repeatedly visit `child` with this pass, replacing it each time a non-null
-   /// replacement is returned, until the pass returns nullptr.
+   /// Visit `node` with this pass once, replacing it if the pass returns a non-null
+   /// replacement. Handlers are responsible for recursing into their own children
+   /// before returning a replacement, so a single visit per node is sufficient.
    // NOLINTNEXTLINE(misc-no-recursion)
    void propagateToNode(operators::QueryNodePtr& node) {
-      constexpr std::size_t MAX_ITERATIONS = 100;
-
       auto& derived = static_cast<Derived&>(*this);
-      std::size_t iterations = 0;
-      while (auto replacement = operators::visit(*node, derived)) {
-         if (++iterations >= MAX_ITERATIONS) {
-            SPDLOG_WARN(
-               "{} aborted after {} iterations on a single node: cyclic optimization "
-               "behaviour detected. Last plan: {}, replacement: {}",
-               Derived::NAME,
-               MAX_ITERATIONS,
-               node->toJson().dump(),
-               replacement->toJson().dump()
-            );
-            break;
-         }
-
+      if (auto replacement = operators::visit(*node, derived)) {
          node = std::move(replacement);
       }
    }

--- a/src/silo/query_engine/pipeline_pass_base.h
+++ b/src/silo/query_engine/pipeline_pass_base.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <cstddef>
 #include <utility>
+
+#include <spdlog/spdlog.h>
 
 #include "silo/query_engine/operator_visitor.h"
 #include "silo/query_engine/operators/aggregate_node.h"
@@ -28,11 +31,13 @@ namespace silo::query_engine {
 /// pass.
 ///
 /// A derived pass overrides only the operators that need custom behaviour. It must
-/// pull the defaults into its own scope so they are not hidden by its overrides:
+/// pull the defaults into its own scope so they are not hidden by its overrides, and
+/// expose a `static constexpr std::string_view NAME` used for log messages:
 ///
 /// ```cpp
 /// class MyPass : public PipelinePassBase<MyPass> {
 ///   public:
+///    static constexpr std::string_view NAME = "MyPass";
 ///    using PipelinePassBase<MyPass>::operator();
 ///    operators::QueryNodePtr operator()(operators::FilterNode& node);  // custom
 /// };
@@ -135,10 +140,24 @@ class PipelinePassBase {
    /// Repeatedly visit `child` with this pass, replacing it each time a non-null
    /// replacement is returned, until the pass returns nullptr.
    // NOLINTNEXTLINE(misc-no-recursion)
-   void propagateToNode(operators::QueryNodePtr& child) {
+   void propagateToNode(operators::QueryNodePtr& node) {
+      static constexpr std::size_t MAX_ITERATIONS = 100;
       auto& derived = static_cast<Derived&>(*this);
-      while (auto replacement = operators::visit(*child, derived)) {
-         child = std::move(replacement);
+      std::size_t iterations = 0;
+      while (auto replacement = operators::visit(*node, derived)) {
+         node = std::move(replacement);
+         SPDLOG_TRACE("{} rewrote node to: {}", Derived::NAME, node->toJson().dump());
+
+         if (++iterations >= MAX_ITERATIONS) {
+            SPDLOG_WARN(
+               "{} aborted after {} iterations on a single node: cyclic optimization "
+               "behaviour detected. Last plan: {}",
+               Derived::NAME,
+               MAX_ITERATIONS,
+               node->toJson().dump()
+            );
+            break;
+         }
       }
    }
 };

--- a/src/silo/query_engine/pipeline_pass_base.h
+++ b/src/silo/query_engine/pipeline_pass_base.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "silo/query_engine/operator_visitor.h"
 #include "silo/query_engine/operators/aggregate_node.h"
 #include "silo/query_engine/operators/fetch_node.h"

--- a/src/silo/query_engine/pipeline_pass_base.h
+++ b/src/silo/query_engine/pipeline_pass_base.h
@@ -141,23 +141,24 @@ class PipelinePassBase {
    /// replacement is returned, until the pass returns nullptr.
    // NOLINTNEXTLINE(misc-no-recursion)
    void propagateToNode(operators::QueryNodePtr& node) {
-      static constexpr std::size_t MAX_ITERATIONS = 100;
+      constexpr std::size_t MAX_ITERATIONS = 100;
+
       auto& derived = static_cast<Derived&>(*this);
       std::size_t iterations = 0;
       while (auto replacement = operators::visit(*node, derived)) {
-         node = std::move(replacement);
-         SPDLOG_TRACE("{} rewrote node to: {}", Derived::NAME, node->toJson().dump());
-
          if (++iterations >= MAX_ITERATIONS) {
             SPDLOG_WARN(
                "{} aborted after {} iterations on a single node: cyclic optimization "
-               "behaviour detected. Last plan: {}",
+               "behaviour detected. Last plan: {}, replacement: {}",
                Derived::NAME,
                MAX_ITERATIONS,
-               node->toJson().dump()
+               node->toJson().dump(),
+               replacement->toJson().dump()
             );
             break;
          }
+
+         node = std::move(replacement);
       }
    }
 };

--- a/src/silo/query_engine/pipeline_pass_base.h
+++ b/src/silo/query_engine/pipeline_pass_base.h
@@ -48,73 +48,73 @@ class PipelinePassBase {
   public:
    static operators::QueryNodePtr run(operators::QueryNodePtr node) {
       Derived pass;
-      pass.propagateToChild(node);
+      pass.propagateToNode(node);
       return node;
    }
 
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::FilterNode& node) {
-      propagateToChild(node.child);
+      propagateToNode(node.child);
       return nullptr;
    }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::AggregateNode& node) {
-      propagateToChild(node.child);
+      propagateToNode(node.child);
       return nullptr;
    }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::ProjectNode& node) {
-      propagateToChild(node.child);
+      propagateToNode(node.child);
       return nullptr;
    }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::MapNode& node) {
-      propagateToChild(node.child);
+      propagateToNode(node.child);
       return nullptr;
    }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::OrderByNode& node) {
-      propagateToChild(node.child);
+      propagateToNode(node.child);
       return nullptr;
    }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::FetchNode& node) {
-      propagateToChild(node.child);
+      propagateToNode(node.child);
       return nullptr;
    }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::ZstdDecompressNode& node) {
-      propagateToChild(node.child);
+      propagateToNode(node.child);
       return nullptr;
    }
 
    template <typename SymbolType>
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::UnresolvedMutationsNode<SymbolType>& node) {
-      propagateToChild(node.child);
+      propagateToNode(node.child);
       return nullptr;
    }
    template <typename SymbolType>
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::UnresolvedInsertionsNode<SymbolType>& node) {
-      propagateToChild(node.child);
+      propagateToNode(node.child);
       return nullptr;
    }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::UnresolvedMostRecentCommonAncestorNode& node) {
-      propagateToChild(node.child);
+      propagateToNode(node.child);
       return nullptr;
    }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::UnresolvedPhyloSubtreeNode& node) {
-      propagateToChild(node.child);
+      propagateToNode(node.child);
       return nullptr;
    }
 
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::UnionAllNode& node) {
-      propagateToChild(node.left);
-      propagateToChild(node.right);
+      propagateToNode(node.left);
+      propagateToNode(node.right);
       return nullptr;
    }
 
@@ -127,7 +127,7 @@ class PipelinePassBase {
    /// Repeatedly visit `child` with this pass, replacing it each time a non-null
    /// replacement is returned, until the pass returns nullptr.
    // NOLINTNEXTLINE(misc-no-recursion)
-   void propagateToChild(operators::QueryNodePtr& child) {
+   void propagateToNode(operators::QueryNodePtr& child) {
       auto& derived = static_cast<Derived&>(*this);
       while (auto replacement = operators::visit(*child, derived)) {
          child = std::move(replacement);

--- a/src/silo/query_engine/pipeline_pass_base.h
+++ b/src/silo/query_engine/pipeline_pass_base.h
@@ -52,7 +52,6 @@ class PipelinePassBase {
       return node;
    }
 
-   // Default propagation for single-child pipeline operators.
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::FilterNode& node) {
       propagateToChild(node.child);
@@ -89,7 +88,6 @@ class PipelinePassBase {
       return nullptr;
    }
 
-   // Default propagation for unresolved placeholder operators (also single-child).
    template <typename SymbolType>
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::UnresolvedMutationsNode<SymbolType>& node) {
@@ -113,7 +111,6 @@ class PipelinePassBase {
       return nullptr;
    }
 
-   // Default propagation for the two-child UnionAll operator.
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::UnionAllNode& node) {
       propagateToChild(node.left);
@@ -121,7 +118,6 @@ class PipelinePassBase {
       return nullptr;
    }
 
-   // Leaf nodes (TableScanNode, MutationsNode, etc.) terminate the walk.
    template <typename T>
    operators::QueryNodePtr operator()(T& /*node*/) {
       return nullptr;

--- a/src/silo/query_engine/pipeline_pass_base.h
+++ b/src/silo/query_engine/pipeline_pass_base.h
@@ -46,70 +46,78 @@ class PipelinePassBase {
    friend Derived;
 
   public:
-   /// Repeatedly visit `node` (replacing it while a replacement is produced), then
-   /// recurse into children via the per-operator handlers.
-   // NOLINTNEXTLINE(misc-no-recursion)
-   static void applyToNode(operators::QueryNodePtr& node, Derived& pass) {
-      while (auto replacement = operators::visit(*node, pass)) {
-         node = std::move(replacement);
-      }
-   }
-
    static operators::QueryNodePtr run(operators::QueryNodePtr node) {
       Derived pass;
-      applyToNode(node, pass);
+      pass.propagateToChild(node);
       return node;
    }
 
    // Default propagation for single-child pipeline operators.
    // NOLINTNEXTLINE(misc-no-recursion)
-   operators::QueryNodePtr operator()(operators::FilterNode& node) { return propagate(node.child); }
+   operators::QueryNodePtr operator()(operators::FilterNode& node) {
+      propagateToChild(node.child);
+      return nullptr;
+   }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::AggregateNode& node) {
-      return propagate(node.child);
+      propagateToChild(node.child);
+      return nullptr;
    }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::ProjectNode& node) {
-      return propagate(node.child);
+      propagateToChild(node.child);
+      return nullptr;
    }
    // NOLINTNEXTLINE(misc-no-recursion)
-   operators::QueryNodePtr operator()(operators::MapNode& node) { return propagate(node.child); }
+   operators::QueryNodePtr operator()(operators::MapNode& node) {
+      propagateToChild(node.child);
+      return nullptr;
+   }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::OrderByNode& node) {
-      return propagate(node.child);
+      propagateToChild(node.child);
+      return nullptr;
    }
    // NOLINTNEXTLINE(misc-no-recursion)
-   operators::QueryNodePtr operator()(operators::FetchNode& node) { return propagate(node.child); }
+   operators::QueryNodePtr operator()(operators::FetchNode& node) {
+      propagateToChild(node.child);
+      return nullptr;
+   }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::ZstdDecompressNode& node) {
-      return propagate(node.child);
+      propagateToChild(node.child);
+      return nullptr;
    }
 
    // Default propagation for unresolved placeholder operators (also single-child).
    template <typename SymbolType>
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::UnresolvedMutationsNode<SymbolType>& node) {
-      return propagate(node.child);
+      propagateToChild(node.child);
+      return nullptr;
    }
    template <typename SymbolType>
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::UnresolvedInsertionsNode<SymbolType>& node) {
-      return propagate(node.child);
+      propagateToChild(node.child);
+      return nullptr;
    }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::UnresolvedMostRecentCommonAncestorNode& node) {
-      return propagate(node.child);
+      propagateToChild(node.child);
+      return nullptr;
    }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::UnresolvedPhyloSubtreeNode& node) {
-      return propagate(node.child);
+      propagateToChild(node.child);
+      return nullptr;
    }
 
    // Default propagation for the two-child UnionAll operator.
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::UnionAllNode& node) {
-      applyToNode(node.left, self());
-      applyToNode(node.right, self());
+      propagateToChild(node.left);
+      propagateToChild(node.right);
       return nullptr;
    }
 
@@ -120,12 +128,14 @@ class PipelinePassBase {
    }
 
   protected:
-   Derived& self() { return static_cast<Derived&>(*this); }
-
+   /// Repeatedly visit `child` with this pass, replacing it each time a non-null
+   /// replacement is returned, until the pass returns nullptr.
    // NOLINTNEXTLINE(misc-no-recursion)
-   operators::QueryNodePtr propagate(operators::QueryNodePtr& child) {
-      applyToNode(child, self());
-      return nullptr;
+   void propagateToChild(operators::QueryNodePtr& child) {
+      auto& derived = static_cast<Derived&>(*this);
+      while (auto replacement = operators::visit(*child, derived)) {
+         child = std::move(replacement);
+      }
    }
 };
 

--- a/src/silo/query_engine/pipeline_pass_base.h
+++ b/src/silo/query_engine/pipeline_pass_base.h
@@ -46,6 +46,9 @@ class PipelinePassBase {
    friend Derived;
 
   public:
+   /// Entry point: walks `node` with a fresh pass and returns the (possibly replaced)
+   /// root. Requires `Derived` to be default-constructible. A pass that needs
+   /// construction arguments (e.g. seeded state) must provide its own `run()` instead.
    static operators::QueryNodePtr run(operators::QueryNodePtr node) {
       Derived pass;
       pass.propagateToNode(node);
@@ -111,6 +114,9 @@ class PipelinePassBase {
       return nullptr;
    }
 
+   // Default propagation for the two-child UnionAll operator. Both branches are
+   // walked by the same pass instance, so this default is only correct for
+   // stateless passes. A stateful pass MUST override this.
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::UnionAllNode& node) {
       propagateToNode(node.left);

--- a/src/silo/query_engine/pipeline_pass_base.h
+++ b/src/silo/query_engine/pipeline_pass_base.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "silo/query_engine/operator_visitor.h"
+#include "silo/query_engine/operators/aggregate_node.h"
+#include "silo/query_engine/operators/fetch_node.h"
+#include "silo/query_engine/operators/filter_node.h"
+#include "silo/query_engine/operators/map_node.h"
+#include "silo/query_engine/operators/order_by_node.h"
+#include "silo/query_engine/operators/project_node.h"
+#include "silo/query_engine/operators/query_node.h"
+#include "silo/query_engine/operators/union_all_node.h"
+#include "silo/query_engine/operators/unresolved_insertions_node.h"
+#include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
+#include "silo/query_engine/operators/unresolved_mutations_node.h"
+#include "silo/query_engine/operators/unresolved_phylo_subtree_node.h"
+#include "silo/query_engine/operators/zstd_decompress_node.h"
+
+namespace silo::query_engine {
+
+/// CRTP base for optimization passes that walk the QueryNode tree.
+///
+/// Provides default propagation for every pipelined (single-child) operator: the
+/// pass is applied to the operator's child and the operator itself is kept in place.
+/// `UnionAllNode` (two children) propagates into both branches. This removes the
+/// boilerplate of writing one identical `operator()` per pipeline operator in each
+/// pass.
+///
+/// A derived pass overrides only the operators that need custom behaviour. It must
+/// pull the defaults into its own scope so they are not hidden by its overrides:
+///
+/// ```cpp
+/// class MyPass : public PipelinePassBase<MyPass> {
+///   public:
+///    using PipelinePassBase<MyPass>::operator();
+///    operators::QueryNodePtr operator()(operators::FilterNode& node);  // custom
+/// };
+/// ```
+///
+/// Replacing a node: returning a non-null `QueryNodePtr` from an `operator()` replaces
+/// the visited node with the returned one; `nullptr` keeps the node in place.
+template <typename Derived>
+class PipelinePassBase {
+   // Private constructor + friend Derived enforces correct CRTP usage: only `Derived`
+   // can instantiate this base, preventing accidental `class X : PipelinePassBase<Y>`.
+   PipelinePassBase() = default;
+   friend Derived;
+
+  public:
+   /// Repeatedly visit `node` (replacing it while a replacement is produced), then
+   /// recurse into children via the per-operator handlers.
+   // NOLINTNEXTLINE(misc-no-recursion)
+   static void applyToNode(operators::QueryNodePtr& node, Derived& pass) {
+      while (auto replacement = operators::visit(*node, pass)) {
+         node = std::move(replacement);
+      }
+   }
+
+   static operators::QueryNodePtr run(operators::QueryNodePtr node) {
+      Derived pass;
+      applyToNode(node, pass);
+      return node;
+   }
+
+   // Default propagation for single-child pipeline operators.
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::FilterNode& node) { return propagate(node.child); }
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::AggregateNode& node) {
+      return propagate(node.child);
+   }
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::ProjectNode& node) {
+      return propagate(node.child);
+   }
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::MapNode& node) { return propagate(node.child); }
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::OrderByNode& node) {
+      return propagate(node.child);
+   }
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::FetchNode& node) { return propagate(node.child); }
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::ZstdDecompressNode& node) {
+      return propagate(node.child);
+   }
+
+   // Default propagation for unresolved placeholder operators (also single-child).
+   template <typename SymbolType>
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::UnresolvedMutationsNode<SymbolType>& node) {
+      return propagate(node.child);
+   }
+   template <typename SymbolType>
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::UnresolvedInsertionsNode<SymbolType>& node) {
+      return propagate(node.child);
+   }
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::UnresolvedMostRecentCommonAncestorNode& node) {
+      return propagate(node.child);
+   }
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::UnresolvedPhyloSubtreeNode& node) {
+      return propagate(node.child);
+   }
+
+   // Default propagation for the two-child UnionAll operator.
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::UnionAllNode& node) {
+      applyToNode(node.left, self());
+      applyToNode(node.right, self());
+      return nullptr;
+   }
+
+   // Leaf nodes (TableScanNode, MutationsNode, etc.) terminate the walk.
+   template <typename T>
+   operators::QueryNodePtr operator()(T& /*node*/) {
+      return nullptr;
+   }
+
+  protected:
+   Derived& self() { return static_cast<Derived&>(*this); }
+
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr propagate(operators::QueryNodePtr& child) {
+      applyToNode(child, self());
+      return nullptr;
+   }
+};
+
+}  // namespace silo::query_engine

--- a/src/silo/query_engine/pipeline_pass_base.h
+++ b/src/silo/query_engine/pipeline_pass_base.h
@@ -48,11 +48,15 @@ class PipelinePassBase {
    friend Derived;
 
   public:
-   /// Entry point: walks `node` with a fresh pass and returns the (possibly replaced)
-   /// root. Requires `Derived` to be default-constructible. A pass that needs
-   /// construction arguments (e.g. seeded state) must provide its own `run()` instead.
+   /// Customization point for constructing the pass instance used by `run()`. The default
+   /// default-constructs `Derived`. A pass that needs to seed state from the root node (e.g.
+   /// from its output schema) overrides this instead of reimplementing `run()`.
+   static Derived makePass(const operators::QueryNodePtr& /*node*/) { return Derived{}; }
+
+   /// Entry point: walks `node` with a pass obtained from `makePass(node)` and returns the
+   /// (possibly replaced) root.
    static operators::QueryNodePtr run(operators::QueryNodePtr node) {
-      Derived pass;
+      Derived pass = Derived::makePass(node);
       pass.propagateToNode(node);
       return node;
    }

--- a/src/silo/query_engine/planner.cpp
+++ b/src/silo/query_engine/planner.cpp
@@ -7,7 +7,6 @@
 #include <nlohmann/json.hpp>
 
 #include "silo/query_engine/column_narrowing_pass.h"
-#include "silo/query_engine/expressions/and.h"
 #include "silo/query_engine/filter_pushdown_pass.h"
 #include "silo/query_engine/node_resolution_pass.h"
 #include "silo/query_engine/saneql/ast_to_query.h"

--- a/src/silo/query_engine/planner.cpp
+++ b/src/silo/query_engine/planner.cpp
@@ -10,7 +10,6 @@
 #include "silo/query_engine/expressions/and.h"
 #include "silo/query_engine/filter_pushdown_pass.h"
 #include "silo/query_engine/node_resolution_pass.h"
-#include "silo/query_engine/operator_visitor.h"
 #include "silo/query_engine/saneql/ast_to_query.h"
 #include "silo/schema/database_schema.h"
 
@@ -43,9 +42,7 @@ QueryPlan Planner::planQuery(
       }
    };
    log_plan("initial");
-   if (auto new_node = operators::visit(*node, ColumnNarrowingPass(node->getOutputSchema()))) {
-      node = std::move(new_node);
-   }
+   node = ColumnNarrowingPass::run(std::move(node));
    log_plan("after ColumnNarrowingPass");
    node = FilterPushdownPass::run(std::move(node));
    log_plan("after FilterPushdownPass");


### PR DESCRIPTION
resolves #1282

### Summary

`NodeResolutionPass` + `FilterPushdownPass` had identical boilerplate `operator()` per pipeline operator (Fetch, Map, Project, ZstdDecompress, OrderBy, Filter, `Unresolved*`, `UnionAll`) — each just recurse into child. New operator = edit every pass, easy to forget.

Extract CRTP base `PipelinePassBase` (`pipeline_pass_base.h`): default propagation for all single-child operators + `UnionAll`, shared `run()` + `propagateToNode()`. Each pass inherits, pulls defaults via `using PipelinePassBase::operator();`, overrides only what it needs. `ColumnNarrowingPass` is migrated onto the base too (overriding `makePass()` to seed its required-column state from the root output schema).

### Traversal

`propagateToNode()` visits a node once, replaces it if the handler returns non-null. Handlers recurse into their own children before returning, so a single visit per node is enough — no fix-point loop needed.

## PR Checklist
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [x] The implemented feature is covered by an appropriate test.
