### PR TITLE
refactor: move optimizer passes into their own namespace

### DIFF
--- a/src/silo/query_engine/optimizer/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.cpp
@@ -1,4 +1,4 @@
-#include "silo/query_engine/column_narrowing_pass.h"
+#include "silo/query_engine/optimizer/column_narrowing_pass.h"
 
 #include "silo/query_engine/operators/aggregate_node.h"
 #include "silo/query_engine/operators/map_node.h"
@@ -8,7 +8,7 @@
 #include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/zstd_decompress_node.h"
 
-namespace silo::query_engine {
+namespace silo::query_engine::optimizer {
 
 ColumnNarrowingPass ColumnNarrowingPass::makePass(const operators::QueryNodePtr& node) {
    return ColumnNarrowingPass{node->getOutputSchema()};
@@ -152,4 +152,4 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::UnionAllNode&
    return nullptr;
 }
 
-}  // namespace silo::query_engine
+}  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/column_narrowing_pass.h
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.h
@@ -3,7 +3,7 @@
 #include <vector>
 
 #include "silo/query_engine/operators/query_node.h"
-#include "silo/query_engine/pipeline_pass_base.h"
+#include "silo/query_engine/optimizer/pipeline_pass_base.h"
 #include "silo/schema/database_schema.h"
 
 namespace silo::query_engine::operators {
@@ -16,7 +16,7 @@ class OrderByNode;
 class UnionAllNode;
 }  // namespace silo::query_engine::operators
 
-namespace silo::query_engine {
+namespace silo::query_engine::optimizer {
 
 /// Optimization pass that narrows the set of columns produced by each node down to those
 /// actually required by its parent, pruning unneeded columns from scans and collapsing
@@ -45,4 +45,4 @@ class ColumnNarrowingPass : public PipelinePassBase<ColumnNarrowingPass> {
    operators::QueryNodePtr operator()(operators::UnionAllNode& node);
 };
 
-}  // namespace silo::query_engine
+}  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/column_narrowing_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.test.cpp
@@ -1,4 +1,4 @@
-#include "silo/query_engine/column_narrowing_pass.h"
+#include "silo/query_engine/optimizer/column_narrowing_pass.h"
 
 #include <memory>
 #include <optional>
@@ -25,6 +25,7 @@
 #include "silo/storage/column/string_column.h"
 #include "silo/storage/table.h"
 
+using silo::query_engine::optimizer::ColumnNarrowingPass;
 using silo::schema::ColumnIdentifier;
 using silo::schema::ColumnType;
 namespace operators = silo::query_engine::operators;
@@ -106,7 +107,7 @@ operators::TableScanNode& leafScan(operators::QueryNode& node) {
 
 TEST(ColumnNarrowingPassScan, keepsOnlyRequiredColumns) {
    auto scan = makeScan({col("a"), col("b"), col("c")});
-   silo::query_engine::ColumnNarrowingPass pass({col("b")});
+   ColumnNarrowingPass pass({col("b")});
    pass(*scan);
 
    EXPECT_THAT(scanSchema(*scan), ::testing::ElementsAre(col("b")));
@@ -114,7 +115,7 @@ TEST(ColumnNarrowingPassScan, keepsOnlyRequiredColumns) {
 
 TEST(ColumnNarrowingPassScan, removesAllWhenNoneRequired) {
    auto scan = makeScan({col("a"), col("b")});
-   silo::query_engine::ColumnNarrowingPass pass({});
+   ColumnNarrowingPass pass({});
    pass(*scan);
 
    EXPECT_THAT(scanSchema(*scan), ::testing::IsEmpty());
@@ -122,7 +123,7 @@ TEST(ColumnNarrowingPassScan, removesAllWhenNoneRequired) {
 
 TEST(ColumnNarrowingPassScan, keepsAllWhenAllRequired) {
    auto scan = makeScan({col("x"), col("y")});
-   silo::query_engine::ColumnNarrowingPass pass({col("x"), col("y")});
+   ColumnNarrowingPass pass({col("x"), col("y")});
    pass(*scan);
 
    EXPECT_THAT(scanSchema(*scan), ::testing::ElementsAre(col("x"), col("y")));
@@ -135,7 +136,7 @@ TEST(ColumnNarrowingPassProject, narrowsScanToProjectedColumns) {
    operators::QueryNodePtr node =
       std::make_unique<operators::ProjectNode>(std::move(scan), std::vector{col("a")});
 
-   silo::query_engine::ColumnNarrowingPass pass({col("a"), col("b"), col("c")});
+   ColumnNarrowingPass pass({col("a"), col("b"), col("c")});
    if (auto new_node = operators::visit(*node, pass)) {
       node = std::move(new_node);
    }
@@ -157,7 +158,7 @@ TEST(ColumnNarrowingPassAggregate, narrowsScanToGroupByColumns) {
       }
    );
 
-   silo::query_engine::ColumnNarrowingPass pass({col("a"), col("b"), col("c")});
+   ColumnNarrowingPass pass({col("a"), col("b"), col("c")});
    pass(*agg);
 
    EXPECT_THAT(scanSchema(leafScan(*agg)), ::testing::ElementsAre(col("b")));
@@ -175,7 +176,7 @@ TEST(ColumnNarrowingPassAggregate, countStarWithNoGroupByKeepsOneColumn) {
       }
    );
 
-   silo::query_engine::ColumnNarrowingPass pass({col("a"), col("b"), col("c")});
+   ColumnNarrowingPass pass({col("a"), col("b"), col("c")});
    pass(*agg);
 
    // COUNT(*) with no group-by needs only one column to drive the row stream.
@@ -193,7 +194,7 @@ TEST(ColumnNarrowingPassOrderBy, appendsSortKeyToRequired) {
    );
 
    // Only "a" is required from above; the pass must add "c" for sorting.
-   silo::query_engine::ColumnNarrowingPass pass({col("a")});
+   ColumnNarrowingPass pass({col("a")});
    pass(*order);
 
    EXPECT_THAT(scanSchema(leafScan(*order)), ::testing::UnorderedElementsAre(col("a"), col("c")));
@@ -207,7 +208,7 @@ TEST(ColumnNarrowingPassProject, collapsesWhenScanNarrowedToProjectFields) {
       std::make_unique<operators::ProjectNode>(std::move(scan), std::vector{col("a"), col("b")});
    auto fetch = std::make_unique<operators::FetchNode>(std::move(proj), std::nullopt, std::nullopt);
 
-   silo::query_engine::ColumnNarrowingPass pass({col("a"), col("b")});
+   ColumnNarrowingPass pass({col("a"), col("b")});
    pass(*fetch);
 
    // The ProjectNode should be removed; FetchNode's child is now directly the TableScanNode.
@@ -226,7 +227,7 @@ TEST(ColumnNarrowingPassProject, stackedProjectsDoNotPropagateSuperfluousColumns
       std::move(inner_proj), std::vector{col("a"), col("b")}
    );
 
-   silo::query_engine::ColumnNarrowingPass pass({col("a")});
+   ColumnNarrowingPass pass({col("a")});
    if (auto new_node = operators::visit(*outer_proj, pass)) {
       outer_proj = std::move(new_node);
    }
@@ -245,7 +246,7 @@ TEST(ColumnNarrowingPassProject, stackedProjectsAreCollapsedAfterNarrowing) {
    auto fetch =
       std::make_unique<operators::FetchNode>(std::move(outer_proj), std::nullopt, std::nullopt);
 
-   silo::query_engine::ColumnNarrowingPass pass({col("a")});
+   ColumnNarrowingPass pass({col("a")});
    pass(*fetch);
 
    EXPECT_NE(dynamic_cast<operators::TableScanNode*>(fetch->child.get()), nullptr);
@@ -269,7 +270,7 @@ TEST(ColumnNarrowingPassZstdDecompress, keepsSequenceColumnInChildWhenRequired) 
    );
 
    // The parent sees "nuc" as STRING (ZstdDecompressNode output schema).
-   silo::query_engine::ColumnNarrowingPass pass({col("nuc")});
+   ColumnNarrowingPass pass({col("nuc")});
    if (auto new_node = operators::visit(*node, pass)) {
       node = std::move(new_node);
    }
@@ -286,7 +287,7 @@ TEST(ColumnNarrowingPassZstdDecompress, doesNotEliminateNodeWhenSequenceColumnRe
       std::move(scan), std::vector{decompressMapping(nuc_col)}
    );
 
-   silo::query_engine::ColumnNarrowingPass pass({col("nuc")});
+   ColumnNarrowingPass pass({col("nuc")});
    if (auto new_node = operators::visit(*node, pass)) {
       node = std::move(new_node);
    }
@@ -306,7 +307,7 @@ TEST(ColumnNarrowingPassZstdDecompress, prunesUnrequiredSequenceColumns) {
    );
 
    // Only "nuc" is required; "aa" and "id" should be dropped from the child scan.
-   silo::query_engine::ColumnNarrowingPass pass({col("nuc")});
+   ColumnNarrowingPass pass({col("nuc")});
    if (auto new_node = operators::visit(*node, pass)) {
       node = std::move(new_node);
    }
@@ -320,7 +321,7 @@ TEST(ColumnNarrowingPassFetch, propagatesRequiredThroughFetch) {
    auto scan = makeScan({col("a"), col("b"), col("c")});
    auto fetch = std::make_unique<operators::FetchNode>(std::move(scan), std::nullopt, std::nullopt);
 
-   silo::query_engine::ColumnNarrowingPass pass({col("b")});
+   ColumnNarrowingPass pass({col("b")});
    pass(*fetch);
 
    EXPECT_THAT(scanSchema(leafScan(*fetch)), ::testing::ElementsAre(col("b")));
@@ -333,7 +334,7 @@ TEST(ColumnNarrowingPassFilter, propagatesRequiredThroughFilter) {
       std::move(scan), std::make_unique<silo::query_engine::expressions::BoolLiteral>(true)
    );
 
-   silo::query_engine::ColumnNarrowingPass pass({col("b")});
+   ColumnNarrowingPass pass({col("b")});
    pass(*filter);
 
    EXPECT_THAT(scanSchema(leafScan(*filter)), ::testing::ElementsAre(col("b")));
@@ -353,7 +354,7 @@ TEST(ColumnNarrowingPassMap, keepsReferencedColumnAndPrunesOthers) {
    );
    auto map = std::make_unique<operators::MapNode>(std::move(scan), std::move(assignments));
 
-   silo::query_engine::ColumnNarrowingPass pass({col("x")});
+   ColumnNarrowingPass pass({col("x")});
    pass(*map);
 
    EXPECT_THAT(scanSchema(leafScan(*map)), ::testing::ElementsAre(col("b")));
@@ -370,7 +371,7 @@ TEST(ColumnNarrowingPassUnionAll, narrowsBothBranchesIndependently) {
    const auto union_all =
       std::make_unique<operators::UnionAllNode>(std::move(left), std::move(right));
 
-   silo::query_engine::ColumnNarrowingPass pass({col("a")});
+   ColumnNarrowingPass pass({col("a")});
    pass(*union_all);
 
    EXPECT_THAT(scanSchema(leafScan(*union_all->left)), ::testing::ElementsAre(col("a")));

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
@@ -1,4 +1,4 @@
-#include "silo/query_engine/filter_pushdown_pass.h"
+#include "silo/query_engine/optimizer/filter_pushdown_pass.h"
 
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
@@ -11,7 +11,7 @@
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
 
-namespace silo::query_engine {
+namespace silo::query_engine::optimizer {
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr FilterPushdownPass::operator()(operators::FilterNode& node) {
@@ -83,4 +83,4 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::UnionAllNode& 
    return nullptr;
 }
 
-}  // namespace silo::query_engine
+}  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.h
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.h
@@ -2,7 +2,7 @@
 
 #include "silo/query_engine/expressions/expression.h"
 #include "silo/query_engine/operators/query_node.h"
-#include "silo/query_engine/pipeline_pass_base.h"
+#include "silo/query_engine/optimizer/pipeline_pass_base.h"
 
 namespace silo::query_engine::operators {
 class FilterNode;
@@ -16,7 +16,7 @@ class MostRecentCommonAncestorNode;
 class UnionAllNode;
 }  // namespace silo::query_engine::operators
 
-namespace silo::query_engine {
+namespace silo::query_engine::optimizer {
 
 /// Optimization pass that eliminates FilterNodes by pushing their filter expression
 /// into the child node's filter field
@@ -39,4 +39,4 @@ class FilterPushdownPass : public PipelinePassBase<FilterPushdownPass> {
    operators::QueryNodePtr operator()(operators::UnionAllNode& node);
 };
 
-}  // namespace silo::query_engine
+}  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.test.cpp
@@ -1,4 +1,4 @@
-#include "silo/query_engine/filter_pushdown_pass.h"
+#include "silo/query_engine/optimizer/filter_pushdown_pass.h"
 
 #include <map>
 #include <memory>
@@ -16,7 +16,7 @@
 #include "silo/storage/column/string_column.h"
 #include "silo/storage/table.h"
 
-using silo::query_engine::FilterPushdownPass;
+using silo::query_engine::optimizer::FilterPushdownPass;
 namespace operators = silo::query_engine::operators;
 namespace expressions = silo::query_engine::expressions;
 

--- a/src/silo/query_engine/optimizer/node_resolution_pass.cpp
+++ b/src/silo/query_engine/optimizer/node_resolution_pass.cpp
@@ -1,4 +1,4 @@
-#include "silo/query_engine/node_resolution_pass.h"
+#include "silo/query_engine/optimizer/node_resolution_pass.h"
 
 #include <optional>
 
@@ -15,7 +15,7 @@
 #include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/unresolved_phylo_subtree_node.h"
 
-namespace silo::query_engine {
+namespace silo::query_engine::optimizer {
 
 namespace {
 
@@ -172,4 +172,4 @@ template operators::QueryNodePtr NodeResolutionPass::operator()(operators::Unres
 template operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedInsertionsNode<
                                                                 silo::AminoAcid>&);
 
-}  // namespace silo::query_engine
+}  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/node_resolution_pass.h
+++ b/src/silo/query_engine/optimizer/node_resolution_pass.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "silo/query_engine/operators/query_node.h"
-#include "silo/query_engine/pipeline_pass_base.h"
+#include "silo/query_engine/optimizer/pipeline_pass_base.h"
 
 namespace silo::query_engine::operators {
 class AggregateNode;
@@ -13,7 +13,7 @@ class UnresolvedMostRecentCommonAncestorNode;
 class UnresolvedPhyloSubtreeNode;
 }  // namespace silo::query_engine::operators
 
-namespace silo::query_engine {
+namespace silo::query_engine::optimizer {
 
 /// Optimization pass that resolves placeholder nodes into concrete, table-backed nodes.
 /// - UnresolvedMutationsNode → MutationsNode
@@ -34,4 +34,4 @@ class NodeResolutionPass : public PipelinePassBase<NodeResolutionPass> {
    operators::QueryNodePtr operator()(operators::UnresolvedPhyloSubtreeNode& node);
 };
 
-}  // namespace silo::query_engine
+}  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/node_resolution_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/node_resolution_pass.test.cpp
@@ -1,4 +1,4 @@
-#include "silo/query_engine/node_resolution_pass.h"
+#include "silo/query_engine/optimizer/node_resolution_pass.h"
 
 #include <map>
 #include <memory>
@@ -27,7 +27,7 @@
 using silo::AminoAcid;
 using silo::Nucleotide;
 using silo::query_engine::IllegalQueryException;
-using silo::query_engine::NodeResolutionPass;
+using silo::query_engine::optimizer::NodeResolutionPass;
 namespace operators = silo::query_engine::operators;
 
 namespace {

--- a/src/silo/query_engine/optimizer/pipeline_pass_base.h
+++ b/src/silo/query_engine/optimizer/pipeline_pass_base.h
@@ -17,7 +17,7 @@
 #include "silo/query_engine/operators/unresolved_phylo_subtree_node.h"
 #include "silo/query_engine/operators/zstd_decompress_node.h"
 
-namespace silo::query_engine {
+namespace silo::query_engine::optimizer {
 
 /// CRTP base for optimization passes that walk the QueryNode tree.
 ///
@@ -148,4 +148,4 @@ class PipelinePassBase {
    }
 };
 
-}  // namespace silo::query_engine
+}  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/planner.cpp
+++ b/src/silo/query_engine/planner.cpp
@@ -6,15 +6,19 @@
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/column_narrowing_pass.h"
-#include "silo/query_engine/filter_pushdown_pass.h"
-#include "silo/query_engine/node_resolution_pass.h"
+#include "silo/query_engine/optimizer/column_narrowing_pass.h"
+#include "silo/query_engine/optimizer/filter_pushdown_pass.h"
+#include "silo/query_engine/optimizer/node_resolution_pass.h"
 #include "silo/query_engine/saneql/ast_to_query.h"
 #include "silo/schema/database_schema.h"
 
 namespace silo::query_engine {
 
 namespace {
+
+using optimizer::ColumnNarrowingPass;
+using optimizer::FilterPushdownPass;
+using optimizer::NodeResolutionPass;
 
 arrow::Result<QueryPlan> planQueryOrError(
    const operators::QueryNode& node,


### PR DESCRIPTION

### Summary


As a follow up to #1324 and a preparation for #1258, I thought it would be good to declutter the `query_engine/` directory and move all the `Pass`es into a subdirectory.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [x] The implemented feature is covered by an appropriate test.
