### PR TITLE
feat(SaneQL): add `schema` operator to get query result schema

### DIFF
--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -358,59 +358,33 @@ unionAll(
 
 ### `schema()`
 
-Reports the output schema of whatever it is applied to — a base table or any
-intermediate query result. It emits one row per output field with two columns:
-`fieldName` and `type`, where `type` is the field's column type as a string.
-
-Schema of a base table:
+Describes the output schema of whatever it is applied to — a table or the result of any pipeline.
+It does not read or return any data; it only reports the fields that the input would produce.
 
 ```
 default.schema()
-```
-
-```
-{"fieldName":"primaryKey","type":"STRING"}
-{"fieldName":"country","type":"STRING"}
-{"fieldName":"date","type":"DATE32"}
-{"fieldName":"age","type":"INT32"}
-```
-
-Schema of an intermediate result (the same operator, after a pipeline). The
-aggregate `count` is `INT64`:
-
-```
 default.filter(country='CH').groupBy({count:=count()}, {age}).schema()
-```
-
-```
-{"fieldName":"count","type":"INT64"}
-{"fieldName":"age","type":"INT32"}
-```
-
-For `mutations()` the `count` field is `INT32`:
-
-```
 default.mutations(minProportion:=0.1).schema()
 ```
 
-```
-{"fieldName":"mutation","type":"STRING"}
-{"fieldName":"mutationFrom","type":"STRING"}
-{"fieldName":"mutationTo","type":"STRING"}
-{"fieldName":"sequenceName","type":"STRING"}
-{"fieldName":"position","type":"INT32"}
-{"fieldName":"proportion","type":"FLOAT"}
-{"fieldName":"coverage","type":"INT32"}
-{"fieldName":"count","type":"INT32"}
+**Output:** one row per field of the described result, with two columns:
+
+| Field       | Type   | Description                                  |
+|-------------|--------|----------------------------------------------|
+| `fieldName` | string | Name of the field                            |
+| `type`      | string | Type of the field (e.g. `STRING`, `INT32`, `INT64`, `DATE32`, `BOOL`, `FLOAT`, `INDEXED_STRING`) |
+
+```json
+{"fieldName": "age", "type": "INT32"}
+{"fieldName": "count", "type": "INT64"}
 ```
 
-**Limitation:** sequence columns are reported as `STRING`. When a
-nucleotide/amino-acid sequence column is read into a pipeline it is decompressed
-to a plain string, so `schema()` sees `STRING` rather than `NUCLEOTIDE_SEQUENCE`
-or `AMINO_ACID_SEQUENCE`.
+`schema()` produces an ordinary two-column relation,
+so schema-preserving and schema-defining operators (such as `project` and `orderBy`) can be chained after it.
 
-**Output:** one row per field of the described schema, with columns `fieldName`
-and `type` (both `STRING`).
+**Limitation:** sequence columns are reported with type `STRING`.
+When a sequence column is read into a pipeline it is decompressed to a string before `schema()` observes it,
+so nucleotide and amino acid sequences cannot be distinguished from ordinary strings at this point.
 
 ---
 

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -386,6 +386,10 @@ so schema-preserving and schema-defining operators (such as `project` and `order
 When a sequence column is read into a pipeline it is decompressed to a string before `schema()` observes it,
 so nucleotide and amino acid sequences cannot be distinguished from ordinary strings at this point.
 
+**Limitation:** `schema()` is a result-producing source, so `filter(...)` cannot be applied to its output.
+Filtering is realized by pushing the predicate down into the underlying data source,
+and there is no data source above `schema()` to push into.
+
 ---
 
 ## Scalar Functions

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -387,8 +387,6 @@ When a sequence column is read into a pipeline it is decompressed to a string be
 so nucleotide and amino acid sequences cannot be distinguished from ordinary strings at this point.
 
 **Limitation:** `schema()` is a result-producing source, so `filter(...)` cannot be applied to its output.
-Filtering is realized by pushing the predicate down into the underlying data source,
-and there is no data source above `schema()` to push into.
 
 ---
 

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -356,6 +356,62 @@ unionAll(
 
 **Output:** all rows from both inputs. The order of rows is not guaranteed.
 
+### `schema()`
+
+Reports the output schema of whatever it is applied to — a base table or any
+intermediate query result. It emits one row per output field with two columns:
+`fieldName` and `type`, where `type` is the field's column type as a string.
+
+Schema of a base table:
+
+```
+default.schema()
+```
+
+```
+{"fieldName":"primaryKey","type":"STRING"}
+{"fieldName":"country","type":"STRING"}
+{"fieldName":"date","type":"DATE32"}
+{"fieldName":"age","type":"INT32"}
+```
+
+Schema of an intermediate result (the same operator, after a pipeline). The
+aggregate `count` is `INT64`:
+
+```
+default.filter(country='CH').groupBy({count:=count()}, {age}).schema()
+```
+
+```
+{"fieldName":"count","type":"INT64"}
+{"fieldName":"age","type":"INT32"}
+```
+
+For `mutations()` the `count` field is `INT32`:
+
+```
+default.mutations(minProportion:=0.1).schema()
+```
+
+```
+{"fieldName":"mutation","type":"STRING"}
+{"fieldName":"mutationFrom","type":"STRING"}
+{"fieldName":"mutationTo","type":"STRING"}
+{"fieldName":"sequenceName","type":"STRING"}
+{"fieldName":"position","type":"INT32"}
+{"fieldName":"proportion","type":"FLOAT"}
+{"fieldName":"coverage","type":"INT32"}
+{"fieldName":"count","type":"INT32"}
+```
+
+**Limitation:** sequence columns are reported as `STRING`. When a
+nucleotide/amino-acid sequence column is read into a pipeline it is decompressed
+to a plain string, so `schema()` sees `STRING` rather than `NUCLEOTIDE_SEQUENCE`
+or `AMINO_ACID_SEQUENCE`.
+
+**Output:** one row per field of the described schema, with columns `fieldName`
+and `type` (both `STRING`).
+
 ---
 
 ## Scalar Functions

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -380,13 +380,15 @@ default.mutations(minProportion:=0.1).schema()
 ```
 
 `schema()` produces an ordinary two-column relation,
-so schema-preserving and schema-defining operators (such as `project` and `orderBy`) can be chained after it.
+so operators such as `project`, `map`, `orderBy` and `limit` can be chained after it.
+
+`schema()` is a *pipeline breaker*: like `groupBy`, `mutations` and `insertions`, it produces a new result relation instead of forwarding its child's rows.
 
 **Limitation:** sequence columns are reported with type `STRING`.
 When a sequence column is read into a pipeline it is decompressed to a string before `schema()` observes it,
 so nucleotide and amino acid sequences cannot be distinguished from ordinary strings at this point.
 
-**Limitation:** `schema()` is a result-producing source, so `filter(...)` cannot be applied to its output.
+**Limitation:** `filter(...)` cannot be applied to `schema()`. A filter is only realizable when it can be pushed into a table scan, and there is none above `schema()`.
 
 ---
 

--- a/src/silo/query_engine/operator_visitor.h
+++ b/src/silo/query_engine/operator_visitor.h
@@ -14,6 +14,7 @@
 #include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/phylo_subtree_node.h"
 #include "silo/query_engine/operators/project_node.h"
+#include "silo/query_engine/operators/schema_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/unresolved_insertions_node.h"
@@ -77,6 +78,8 @@ decltype(auto) visit(QueryNode& node, Func&& func) {
          return std::forward<Func>(func)(static_cast<CountFilterNode&>(node));
       case NodeKind::UNION_ALL:
          return std::forward<Func>(func)(static_cast<UnionAllNode&>(node));
+      case NodeKind::SCHEMA:
+         return std::forward<Func>(func)(static_cast<SchemaNode&>(node));
    }
    SILO_UNREACHABLE();
 }

--- a/src/silo/query_engine/operators/query_node.cpp
+++ b/src/silo/query_engine/operators/query_node.cpp
@@ -54,6 +54,8 @@ std::string_view nodeKindToString(NodeKind kind) {
          return "Map";
       case NodeKind::UNION_ALL:
          return "UnionAll";
+      case NodeKind::SCHEMA:
+         return "Schema";
    }
    SILO_UNREACHABLE();
 }

--- a/src/silo/query_engine/operators/query_node.h
+++ b/src/silo/query_engine/operators/query_node.h
@@ -37,6 +37,7 @@ enum class NodeKind : uint8_t {
    TABLE_SCAN,
    COUNT_FILTER,
    UNION_ALL,
+   SCHEMA,
 };
 
 class QueryNode {

--- a/src/silo/query_engine/operators/schema_node.cpp
+++ b/src/silo/query_engine/operators/schema_node.cpp
@@ -17,13 +17,35 @@
 
 namespace silo::query_engine::operators {
 
+namespace {
+
+arrow::Result<arrow::ExecBatch> buildSchemaBatch(
+   const std::vector<schema::ColumnIdentifier>& input_schema
+) {
+   arrow::StringBuilder field_name_builder{};
+   arrow::StringBuilder type_builder{};
+   for (const auto& field : input_schema) {
+      ARROW_RETURN_NOT_OK(field_name_builder.Append(field.name));
+      ARROW_RETURN_NOT_OK(type_builder.Append(schema::columnTypeToString(field.type)));
+   }
+
+   arrow::Datum field_name_datum;
+   ARROW_ASSIGN_OR_RAISE(field_name_datum, field_name_builder.Finish());
+   arrow::Datum type_datum;
+   ARROW_ASSIGN_OR_RAISE(type_datum, type_builder.Finish());
+
+   return arrow::ExecBatch::Make({field_name_datum, type_datum});
+}
+
+}  // namespace
+
 SchemaNode::SchemaNode(QueryNodePtr child)
     : child(std::move(child)) {}
 
 std::vector<schema::ColumnIdentifier> SchemaNode::getOutputSchema() const {
    return {
-      {std::string{FIELD_NAME_COLUMN}, schema::ColumnType::STRING},
-      {std::string{TYPE_COLUMN}, schema::ColumnType::STRING},
+      {.name = std::string{FIELD_NAME_COLUMN}, .type = schema::ColumnType::STRING},
+      {.name = std::string{TYPE_COLUMN}, .type = schema::ColumnType::STRING},
    };
 }
 
@@ -41,22 +63,8 @@ arrow::Result<arrow::acero::ExecNode*> SchemaNode::addToExecPlan(
       }
       already_produced = true;
 
-      arrow::StringBuilder field_name_builder{};
-      arrow::StringBuilder type_builder{};
-      for (const auto& field : input_schema) {
-         ARROW_RETURN_NOT_OK(field_name_builder.Append(field.name));
-         ARROW_RETURN_NOT_OK(type_builder.Append(schema::columnTypeToString(field.type)));
-      }
-
-      arrow::Datum field_name_datum;
-      ARROW_ASSIGN_OR_RAISE(field_name_datum, field_name_builder.Finish());
-      arrow::Datum type_datum;
-      ARROW_ASSIGN_OR_RAISE(type_datum, type_builder.Finish());
-
-      ARROW_ASSIGN_OR_RAISE(
-         const std::optional<arrow::ExecBatch> result,
-         arrow::ExecBatch::Make({field_name_datum, type_datum})
-      );
+      ARROW_ASSIGN_OR_RAISE(const arrow::ExecBatch batch, buildSchemaBatch(input_schema));
+      const std::optional<arrow::ExecBatch> result = batch;
       return arrow::Future{result};
    };
 

--- a/src/silo/query_engine/operators/schema_node.cpp
+++ b/src/silo/query_engine/operators/schema_node.cpp
@@ -22,8 +22,8 @@ SchemaNode::SchemaNode(QueryNodePtr child)
 
 std::vector<schema::ColumnIdentifier> SchemaNode::getOutputSchema() const {
    return {
-      {"fieldName", schema::ColumnType::STRING},
-      {"type", schema::ColumnType::STRING},
+      {std::string{FIELD_NAME_COLUMN}, schema::ColumnType::STRING},
+      {std::string{TYPE_COLUMN}, schema::ColumnType::STRING},
    };
 }
 

--- a/src/silo/query_engine/operators/schema_node.cpp
+++ b/src/silo/query_engine/operators/schema_node.cpp
@@ -45,8 +45,7 @@ arrow::Result<arrow::acero::ExecNode*> SchemaNode::addToExecPlan(
       arrow::StringBuilder type_builder{};
       for (const auto& field : input_schema) {
          ARROW_RETURN_NOT_OK(field_name_builder.Append(field.name));
-         ARROW_RETURN_NOT_OK(type_builder.Append(std::string{schema::columnTypeToString(field.type)}
-         ));
+         ARROW_RETURN_NOT_OK(type_builder.Append(schema::columnTypeToString(field.type)));
       }
 
       arrow::Datum field_name_datum;

--- a/src/silo/query_engine/operators/schema_node.cpp
+++ b/src/silo/query_engine/operators/schema_node.cpp
@@ -17,8 +17,8 @@
 
 namespace silo::query_engine::operators {
 
-SchemaNode::SchemaNode(std::vector<schema::ColumnIdentifier> input_schema)
-    : input_schema(std::move(input_schema)) {}
+SchemaNode::SchemaNode(QueryNodePtr child)
+    : child(std::move(child)) {}
 
 std::vector<schema::ColumnIdentifier> SchemaNode::getOutputSchema() const {
    return {
@@ -33,7 +33,7 @@ arrow::Result<arrow::acero::ExecNode*> SchemaNode::addToExecPlan(
    const config::QueryOptions& /*query_options*/
 ) const {
    std::function<arrow::Future<std::optional<arrow::ExecBatch>>()> producer =
-      [input_schema = input_schema,
+      [input_schema = child->getOutputSchema(),
        already_produced = false]() mutable -> arrow::Future<std::optional<arrow::ExecBatch>> {
       if (already_produced) {
          const std::optional<arrow::ExecBatch> result = std::nullopt;
@@ -72,7 +72,7 @@ arrow::Result<arrow::acero::ExecNode*> SchemaNode::addToExecPlan(
 nlohmann::json SchemaNode::toJson() const {
    return {
       {"type", nodeKindToString(kind())},
-      {"fields", columnsToJson(input_schema)},
+      {"child", child->toJson()},
    };
 }
 

--- a/src/silo/query_engine/operators/schema_node.cpp
+++ b/src/silo/query_engine/operators/schema_node.cpp
@@ -1,0 +1,79 @@
+#include "silo/query_engine/operators/schema_node.h"
+
+#include <functional>
+#include <map>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/acero/options.h>
+#include <arrow/builder.h>
+#include <nlohmann/json.hpp>
+
+#include "silo/query_engine/exec_node/arrow_util.h"
+#include "silo/schema/database_schema.h"
+
+namespace silo::query_engine::operators {
+
+SchemaNode::SchemaNode(std::vector<schema::ColumnIdentifier> input_schema)
+    : input_schema(std::move(input_schema)) {}
+
+std::vector<schema::ColumnIdentifier> SchemaNode::getOutputSchema() const {
+   return {
+      {"fieldName", schema::ColumnType::STRING},
+      {"type", schema::ColumnType::STRING},
+   };
+}
+
+arrow::Result<arrow::acero::ExecNode*> SchemaNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
+   const std::map<schema::TableName, std::shared_ptr<storage::Table>>& /*tables*/,
+   const config::QueryOptions& /*query_options*/
+) const {
+   std::function<arrow::Future<std::optional<arrow::ExecBatch>>()> producer =
+      [input_schema = input_schema,
+       already_produced = false]() mutable -> arrow::Future<std::optional<arrow::ExecBatch>> {
+      if (already_produced) {
+         const std::optional<arrow::ExecBatch> result = std::nullopt;
+         return arrow::Future{result};
+      }
+      already_produced = true;
+
+      arrow::StringBuilder field_name_builder{};
+      arrow::StringBuilder type_builder{};
+      for (const auto& field : input_schema) {
+         ARROW_RETURN_NOT_OK(field_name_builder.Append(field.name));
+         ARROW_RETURN_NOT_OK(type_builder.Append(std::string{schema::columnTypeToString(field.type)}
+         ));
+      }
+
+      arrow::Datum field_name_datum;
+      ARROW_ASSIGN_OR_RAISE(field_name_datum, field_name_builder.Finish());
+      arrow::Datum type_datum;
+      ARROW_ASSIGN_OR_RAISE(type_datum, type_builder.Finish());
+
+      ARROW_ASSIGN_OR_RAISE(
+         const std::optional<arrow::ExecBatch> result,
+         arrow::ExecBatch::Make({field_name_datum, type_datum})
+      );
+      return arrow::Future{result};
+   };
+
+   const arrow::acero::SourceNodeOptions options{
+      exec_node::columnsToArrowSchema(getOutputSchema()),
+      std::move(producer),
+      arrow::Ordering::Implicit()
+   };
+   return arrow::acero::MakeExecNode("source", &plan, {}, options);
+}
+
+nlohmann::json SchemaNode::toJson() const {
+   return {
+      {"type", nodeKindToString(kind())},
+      {"fields", columnsToJson(input_schema)},
+   };
+}
+
+}  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/schema_node.h
+++ b/src/silo/query_engine/operators/schema_node.h
@@ -12,9 +12,16 @@
 
 namespace silo::query_engine::operators {
 
-/// Terminal node that reports the output schema of its child as data rows.
-/// Emits one row per child field.
-/// The child's query plan is never executed; only its output schema is inspected.
+/// Source-type node that reports the output schema of its child as data rows,
+/// one row per child field. The child's query plan is never executed; only its
+/// output schema is inspected.
+///
+/// This is a "pipeline breaker": it produces a fresh result relation rather than
+/// forwarding its child's rows. Schema-preserving operators that do not need to
+/// push work into an underlying data source (e.g. `orderBy`, `limit`, `map`,
+/// `project`) can be chained after it. `filter()` currently cannot, because it is
+/// only realizable when pushed into a table scan, and there is none above
+/// `schema()`.
 class SchemaNode final : public QueryNode {
   public:
    static constexpr std::string_view FIELD_NAME_COLUMN = "fieldName";

--- a/src/silo/query_engine/operators/schema_node.h
+++ b/src/silo/query_engine/operators/schema_node.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <string_view>
 #include <vector>
 
 #include <arrow/result.h>
@@ -16,6 +17,9 @@ namespace silo::query_engine::operators {
 /// The child's query plan is never executed; only its output schema is inspected.
 class SchemaNode final : public QueryNode {
   public:
+   static constexpr std::string_view FIELD_NAME_COLUMN = "fieldName";
+   static constexpr std::string_view TYPE_COLUMN = "type";
+
    QueryNodePtr child;
 
    explicit SchemaNode(QueryNodePtr child);

--- a/src/silo/query_engine/operators/schema_node.h
+++ b/src/silo/query_engine/operators/schema_node.h
@@ -11,13 +11,14 @@
 
 namespace silo::query_engine::operators {
 
-/// Leaf node that reports the output schema of whatever it was applied to.
-/// Emits one row per described field with two STRING columns: `fieldName` and `type`.
+/// Terminal node that reports the output schema of its child as data rows.
+/// Emits one row per child field.
+/// The child's query plan is never executed; only its output schema is inspected.
 class SchemaNode final : public QueryNode {
   public:
-   std::vector<schema::ColumnIdentifier> input_schema;
+   QueryNodePtr child;
 
-   explicit SchemaNode(std::vector<schema::ColumnIdentifier> input_schema);
+   explicit SchemaNode(QueryNodePtr child);
 
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
 

--- a/src/silo/query_engine/operators/schema_node.h
+++ b/src/silo/query_engine/operators/schema_node.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include <arrow/result.h>
+
+#include "silo/query_engine/operators/query_node.h"
+#include "silo/schema/database_schema.h"
+#include "silo/storage/table.h"
+
+namespace silo::query_engine::operators {
+
+/// Leaf node that reports the output schema of whatever it was applied to.
+/// Emits one row per described field with two STRING columns: `fieldName` and `type`.
+class SchemaNode final : public QueryNode {
+  public:
+   std::vector<schema::ColumnIdentifier> input_schema;
+
+   explicit SchemaNode(std::vector<schema::ColumnIdentifier> input_schema);
+
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
+
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
+      const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
+      const config::QueryOptions& query_options
+   ) const override;
+
+   [[nodiscard]] NodeKind kind() const override { return NodeKind::SCHEMA; }
+
+   [[nodiscard]] nlohmann::json toJson() const override;
+};
+
+}  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/schema_node.test.cpp
+++ b/src/silo/query_engine/operators/schema_node.test.cpp
@@ -33,7 +33,7 @@ nlohmann::json alignedSequence(const std::string& sequence) {
    return {{"sequence", sequence}, {"insertions", nlohmann::json::array()}};
 }
 
-const std::vector<nlohmann::json> DATA = {
+const std::vector DATA = {
    createData("id_0", "CH", "2024-01-01", 31, true, 0.5, alignedSequence("ACGT")),
    createData("id_1", "DE", "2024-01-02", 42, false, 0.75, alignedSequence("ACGA")),
 };
@@ -70,9 +70,6 @@ const QueryTestData TEST_DATA{
    .reference_genomes = REFERENCE_GENOMES
 };
 
-// schema() on a base table reports every output field of the scan. The queried
-// sequence column `segment1` is decompressed to STRING, so it is reported as
-// STRING rather than NUCLEOTIDE_SEQUENCE (documented limitation).
 const QueryTestScenario TABLE_SCHEMA_SCENARIO = {
    .name = "TABLE_SCHEMA",
    .query = "default.schema()",
@@ -89,8 +86,6 @@ const QueryTestScenario TABLE_SCHEMA_SCENARIO = {
    )
 };
 
-// schema() after a pipeline reports the intermediate result's schema. The
-// aggregate count column is INT64.
 const QueryTestScenario GROUP_BY_SCHEMA_SCENARIO = {
    .name = "GROUP_BY_SCHEMA",
    .query = "default.filter(country='CH').groupBy({count := count()}, {age}).schema()",
@@ -99,8 +94,6 @@ const QueryTestScenario GROUP_BY_SCHEMA_SCENARIO = {
    )
 };
 
-// schema() output is itself a regular 2-column relation, so pipeline operators
-// can be chained after it.
 const QueryTestScenario CHAINING_SCHEMA_SCENARIO = {
    .name = "CHAINING_SCHEMA",
    .query =
@@ -108,9 +101,6 @@ const QueryTestScenario CHAINING_SCHEMA_SCENARIO = {
    .expected_query_result = nlohmann::json({{{"type", "INT32"}}, {{"type", "INT64"}}})
 };
 
-// schema() on a mutations result reports the mutations default fields. The
-// mutations `count` is INT32 (unlike the INT64 aggregate count). The queried
-// sequence appears only via the derived columns, no NUCLEOTIDE_SEQUENCE column.
 const QueryTestScenario MUTATIONS_SCHEMA_SCENARIO = {
    .name = "MUTATIONS_SCHEMA",
    .query = "default.mutations(minProportion:=0.1).schema()",

--- a/src/silo/query_engine/operators/schema_node.test.cpp
+++ b/src/silo/query_engine/operators/schema_node.test.cpp
@@ -12,6 +12,8 @@ nlohmann::json createData(
    const std::string& country,
    const std::string& date,
    int age,
+   bool is_covered,
+   double proportion,
    const nlohmann::json& segment1 = nullptr
 ) {
    return {
@@ -19,6 +21,8 @@ nlohmann::json createData(
       {"country", country},
       {"date", date},
       {"age", age},
+      {"is_covered", is_covered},
+      {"proportion", proportion},
       {"segment1", segment1},
       {"gene1", nullptr},
       {"unaligned_segment1", nullptr},
@@ -30,8 +34,8 @@ nlohmann::json alignedSequence(const std::string& sequence) {
 }
 
 const std::vector<nlohmann::json> DATA = {
-   createData("id_0", "CH", "2024-01-01", 31, alignedSequence("ACGT")),
-   createData("id_1", "DE", "2024-01-02", 42, alignedSequence("ACGA")),
+   createData("id_0", "CH", "2024-01-01", 31, true, 0.5, alignedSequence("ACGT")),
+   createData("id_1", "DE", "2024-01-02", 42, false, 0.75, alignedSequence("ACGA")),
 };
 
 const auto DATABASE_CONFIG =
@@ -48,6 +52,10 @@ schema:
       type: "date"
     - name: "age"
       type: "int"
+    - name: "is_covered"
+      type: "boolean"
+    - name: "proportion"
+      type: "float"
   primaryKey: "primaryKey"
 )";
 
@@ -73,7 +81,9 @@ const QueryTestScenario TABLE_SCHEMA_SCENARIO = {
        {{"fieldName", "country"}, {"type", "STRING"}},
        {{"fieldName", "date"}, {"type", "DATE32"}},
        {{"fieldName", "gene1"}, {"type", "STRING"}},
+       {{"fieldName", "is_covered"}, {"type", "BOOL"}},
        {{"fieldName", "primaryKey"}, {"type", "STRING"}},
+       {{"fieldName", "proportion"}, {"type", "FLOAT"}},
        {{"fieldName", "segment1"}, {"type", "STRING"}},
        {{"fieldName", "unaligned_segment1"}, {"type", "STRING"}}}
    )

--- a/src/silo/query_engine/operators/schema_node.test.cpp
+++ b/src/silo/query_engine/operators/schema_node.test.cpp
@@ -33,7 +33,7 @@ nlohmann::json alignedSequence(const std::string& sequence) {
    return {{"sequence", sequence}, {"insertions", nlohmann::json::array()}};
 }
 
-const std::vector DATA = {
+const std::vector<nlohmann::json> DATA = {
    createData("id_0", "CH", "2024-01-01", 31, true, 0.5, alignedSequence("ACGT")),
    createData("id_1", "DE", "2024-01-02", 42, false, 0.75, alignedSequence("ACGA")),
 };

--- a/src/silo/query_engine/operators/schema_node.test.cpp
+++ b/src/silo/query_engine/operators/schema_node.test.cpp
@@ -212,6 +212,38 @@ const QueryTestScenario FILTER_AFTER_SCHEMA_ERROR_SCENARIO = {
       "and its result cannot be filtered. Apply filter() before schema() instead."
 };
 
+// schema() must validate its child the same way it would be validated without the trailing
+const QueryTestScenario SCHEMA_PROPAGATES_BAD_SEQUENCE_ERROR_SCENARIO = {
+   .name = "SCHEMA_PROPAGATES_BAD_SEQUENCE_ERROR",
+   .query = "default.aminoAcidMutations(minProportion:=0.1, sequenceNames:={noseq}).schema()",
+   .expected_error_message = "The database does not contain the AminoAcid sequence 'noseq'"
+};
+
+// mutations() must be applied to a table scan and schema() must not suppress that error.
+const QueryTestScenario SCHEMA_PROPAGATES_NON_SCAN_ERROR_SCENARIO = {
+   .name = "SCHEMA_PROPAGATES_NON_SCAN_ERROR",
+   .query = "default.project({age}).mutations(minProportion:=0.1).schema()",
+   .expected_error_message = "mutations() must be applied to a table scan"
+};
+
+// Positive control: a filter() before mutations() inside the child must still be pushed
+// down so that mutations() resolves against a bare table scan. schema() then reports the
+// resolved mutations schema correctly.
+const QueryTestScenario SCHEMA_AFTER_FILTERED_MUTATIONS_SCENARIO = {
+   .name = "SCHEMA_AFTER_FILTERED_MUTATIONS",
+   .query = "default.filter(country='CH').mutations(minProportion:=0.1).schema()",
+   .expected_query_result = nlohmann::json(
+      {{{"fieldName", "mutation"}, {"type", "STRING"}},
+       {{"fieldName", "mutationFrom"}, {"type", "STRING"}},
+       {{"fieldName", "mutationTo"}, {"type", "STRING"}},
+       {{"fieldName", "sequenceName"}, {"type", "STRING"}},
+       {{"fieldName", "position"}, {"type", "INT32"}},
+       {{"fieldName", "proportion"}, {"type", "FLOAT"}},
+       {{"fieldName", "coverage"}, {"type", "INT32"}},
+       {{"fieldName", "count"}, {"type", "INT32"}}}
+   )
+};
+
 }  // namespace
 
 QUERY_TEST(
@@ -230,6 +262,9 @@ QUERY_TEST(
       SCHEMA_OF_SCHEMA_SCENARIO,
       SCHEMA_IGNORES_DATA_SCENARIO,
       SCHEMA_EXTRA_ARG_ERROR_SCENARIO,
-      FILTER_AFTER_SCHEMA_ERROR_SCENARIO
+      FILTER_AFTER_SCHEMA_ERROR_SCENARIO,
+      SCHEMA_PROPAGATES_BAD_SEQUENCE_ERROR_SCENARIO,
+      SCHEMA_PROPAGATES_NON_SCAN_ERROR_SCENARIO,
+      SCHEMA_AFTER_FILTERED_MUTATIONS_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/schema_node.test.cpp
+++ b/src/silo/query_engine/operators/schema_node.test.cpp
@@ -1,0 +1,130 @@
+#include <nlohmann/json.hpp>
+
+#include "silo/test/query_fixture.test.h"
+
+namespace {
+using silo::ReferenceGenomes;
+using silo::test::QueryTestData;
+using silo::test::QueryTestScenario;
+
+nlohmann::json createData(
+   const std::string& primaryKey,
+   const std::string& country,
+   const std::string& date,
+   int age,
+   const nlohmann::json& segment1 = nullptr
+) {
+   return {
+      {"primaryKey", primaryKey},
+      {"country", country},
+      {"date", date},
+      {"age", age},
+      {"segment1", segment1},
+      {"gene1", nullptr},
+      {"unaligned_segment1", nullptr},
+   };
+}
+
+nlohmann::json alignedSequence(const std::string& sequence) {
+   return {{"sequence", sequence}, {"insertions", nlohmann::json::array()}};
+}
+
+const std::vector<nlohmann::json> DATA = {
+   createData("id_0", "CH", "2024-01-01", 31, alignedSequence("ACGT")),
+   createData("id_1", "DE", "2024-01-02", 42, alignedSequence("ACGA")),
+};
+
+const auto DATABASE_CONFIG =
+   R"(
+defaultNucleotideSequence: "segment1"
+schema:
+  instanceName: "dummy name"
+  metadata:
+    - name: "primaryKey"
+      type: "string"
+    - name: "country"
+      type: "string"
+    - name: "date"
+      type: "date"
+    - name: "age"
+      type: "int"
+  primaryKey: "primaryKey"
+)";
+
+const auto REFERENCE_GENOMES = ReferenceGenomes{
+   {{"segment1", "ACGT"}},
+   {{"gene1", "*"}},
+};
+
+const QueryTestData TEST_DATA{
+   .ndjson_input_data = DATA,
+   .database_config = DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES
+};
+
+// schema() on a base table reports every output field of the scan. The queried
+// sequence column `segment1` is decompressed to STRING, so it is reported as
+// STRING rather than NUCLEOTIDE_SEQUENCE (documented limitation).
+const QueryTestScenario TABLE_SCHEMA_SCENARIO = {
+   .name = "TABLE_SCHEMA",
+   .query = "default.schema()",
+   .expected_query_result = nlohmann::json(
+      {{{"fieldName", "age"}, {"type", "INT32"}},
+       {{"fieldName", "country"}, {"type", "STRING"}},
+       {{"fieldName", "date"}, {"type", "DATE32"}},
+       {{"fieldName", "gene1"}, {"type", "STRING"}},
+       {{"fieldName", "primaryKey"}, {"type", "STRING"}},
+       {{"fieldName", "segment1"}, {"type", "STRING"}},
+       {{"fieldName", "unaligned_segment1"}, {"type", "STRING"}}}
+   )
+};
+
+// schema() after a pipeline reports the intermediate result's schema. The
+// aggregate count column is INT64.
+const QueryTestScenario GROUP_BY_SCHEMA_SCENARIO = {
+   .name = "GROUP_BY_SCHEMA",
+   .query = "default.filter(country='CH').groupBy({count := count()}, {age}).schema()",
+   .expected_query_result = nlohmann::json(
+      {{{"fieldName", "age"}, {"type", "INT32"}}, {{"fieldName", "count"}, {"type", "INT64"}}}
+   )
+};
+
+// schema() output is itself a regular 2-column relation, so pipeline operators
+// can be chained after it.
+const QueryTestScenario CHAINING_SCHEMA_SCENARIO = {
+   .name = "CHAINING_SCHEMA",
+   .query =
+      "default.filter(country='CH').groupBy({count := count()}, {age}).schema().project({type})",
+   .expected_query_result = nlohmann::json({{{"type", "INT32"}}, {{"type", "INT64"}}})
+};
+
+// schema() on a mutations result reports the mutations default fields. The
+// mutations `count` is INT32 (unlike the INT64 aggregate count). The queried
+// sequence appears only via the derived columns, no NUCLEOTIDE_SEQUENCE column.
+const QueryTestScenario MUTATIONS_SCHEMA_SCENARIO = {
+   .name = "MUTATIONS_SCHEMA",
+   .query = "default.mutations(minProportion:=0.1).schema()",
+   .expected_query_result = nlohmann::json(
+      {{{"fieldName", "mutation"}, {"type", "STRING"}},
+       {{"fieldName", "mutationFrom"}, {"type", "STRING"}},
+       {{"fieldName", "mutationTo"}, {"type", "STRING"}},
+       {{"fieldName", "sequenceName"}, {"type", "STRING"}},
+       {{"fieldName", "position"}, {"type", "INT32"}},
+       {{"fieldName", "proportion"}, {"type", "FLOAT"}},
+       {{"fieldName", "coverage"}, {"type", "INT32"}},
+       {{"fieldName", "count"}, {"type", "INT32"}}}
+   )
+};
+
+}  // namespace
+
+QUERY_TEST(
+   SchemaTest,
+   TEST_DATA,
+   ::testing::Values(
+      TABLE_SCHEMA_SCENARIO,
+      GROUP_BY_SCHEMA_SCENARIO,
+      MUTATIONS_SCHEMA_SCENARIO,
+      CHAINING_SCHEMA_SCENARIO
+   )
+);

--- a/src/silo/query_engine/operators/schema_node.test.cpp
+++ b/src/silo/query_engine/operators/schema_node.test.cpp
@@ -201,6 +201,27 @@ const QueryTestScenario SCHEMA_EXTRA_ARG_ERROR_SCENARIO = {
    .expected_error_message = "schema() received too many positional arguments"
 };
 
+// KNOWN LIMITATION: filter() after schema() is NOT applied.
+// Filtering is realized by pushing the predicate down into a data
+// source, and schema() is itself a source with nothing above it to push into, so the
+// FilterPushdownPass discards the predicate. The result is the FULL, unfiltered schema
+// rather than the rows matching `type='STRING'` (and notably not an error).
+const QueryTestScenario FILTER_AFTER_SCHEMA_IS_DROPPED_SCENARIO = {
+   .name = "FILTER_AFTER_SCHEMA_IS_DROPPED",
+   .query = "default.schema().filter(type='STRING')",
+   .expected_query_result = nlohmann::json(
+      {{{"fieldName", "age"}, {"type", "INT32"}},
+       {{"fieldName", "country"}, {"type", "STRING"}},
+       {{"fieldName", "date"}, {"type", "DATE32"}},
+       {{"fieldName", "gene1"}, {"type", "STRING"}},
+       {{"fieldName", "is_covered"}, {"type", "BOOL"}},
+       {{"fieldName", "primaryKey"}, {"type", "STRING"}},
+       {{"fieldName", "proportion"}, {"type", "FLOAT"}},
+       {{"fieldName", "segment1"}, {"type", "STRING"}},
+       {{"fieldName", "unaligned_segment1"}, {"type", "STRING"}}}
+   )
+};
+
 }  // namespace
 
 QUERY_TEST(
@@ -209,6 +230,7 @@ QUERY_TEST(
    ::testing::Values(
       TABLE_SCHEMA_SCENARIO,
       GROUP_BY_SCHEMA_SCENARIO,
+      CHAINING_SCHEMA_SCENARIO,
       MUTATIONS_SCHEMA_SCENARIO,
       AMINO_ACID_MUTATIONS_SCHEMA_SCENARIO,
       INSERTIONS_SCHEMA_SCENARIO,
@@ -218,6 +240,6 @@ QUERY_TEST(
       SCHEMA_OF_SCHEMA_SCENARIO,
       SCHEMA_IGNORES_DATA_SCENARIO,
       SCHEMA_EXTRA_ARG_ERROR_SCENARIO,
-      CHAINING_SCHEMA_SCENARIO
+      FILTER_AFTER_SCHEMA_IS_DROPPED_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/schema_node.test.cpp
+++ b/src/silo/query_engine/operators/schema_node.test.cpp
@@ -201,25 +201,15 @@ const QueryTestScenario SCHEMA_EXTRA_ARG_ERROR_SCENARIO = {
    .expected_error_message = "schema() received too many positional arguments"
 };
 
-// KNOWN LIMITATION: filter() after schema() is NOT applied.
-// Filtering is realized by pushing the predicate down into a data
-// source, and schema() is itself a source with nothing above it to push into, so the
-// FilterPushdownPass discards the predicate. The result is the FULL, unfiltered schema
-// rather than the rows matching `type='STRING'` (and notably not an error).
-const QueryTestScenario FILTER_AFTER_SCHEMA_IS_DROPPED_SCENARIO = {
-   .name = "FILTER_AFTER_SCHEMA_IS_DROPPED",
+// schema() is a source operator: there is no underlying data source above it for a
+// predicate to be pushed into, so filter() cannot be realized on its output. The query
+// is rejected at planning time rather than silently returning the unfiltered schema.
+const QueryTestScenario FILTER_AFTER_SCHEMA_ERROR_SCENARIO = {
+   .name = "FILTER_AFTER_SCHEMA_ERROR",
    .query = "default.schema().filter(type='STRING')",
-   .expected_query_result = nlohmann::json(
-      {{{"fieldName", "age"}, {"type", "INT32"}},
-       {{"fieldName", "country"}, {"type", "STRING"}},
-       {{"fieldName", "date"}, {"type", "DATE32"}},
-       {{"fieldName", "gene1"}, {"type", "STRING"}},
-       {{"fieldName", "is_covered"}, {"type", "BOOL"}},
-       {{"fieldName", "primaryKey"}, {"type", "STRING"}},
-       {{"fieldName", "proportion"}, {"type", "FLOAT"}},
-       {{"fieldName", "segment1"}, {"type", "STRING"}},
-       {{"fieldName", "unaligned_segment1"}, {"type", "STRING"}}}
-   )
+   .expected_error_message =
+      "filter() cannot be applied to the output of schema(); schema() is a source operator "
+      "and its result cannot be filtered. Apply filter() before schema() instead."
 };
 
 }  // namespace
@@ -240,6 +230,6 @@ QUERY_TEST(
       SCHEMA_OF_SCHEMA_SCENARIO,
       SCHEMA_IGNORES_DATA_SCENARIO,
       SCHEMA_EXTRA_ARG_ERROR_SCENARIO,
-      FILTER_AFTER_SCHEMA_IS_DROPPED_SCENARIO
+      FILTER_AFTER_SCHEMA_ERROR_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/schema_node.test.cpp
+++ b/src/silo/query_engine/operators/schema_node.test.cpp
@@ -167,6 +167,40 @@ const QueryTestScenario SCHEMA_OF_SCHEMA_SCENARIO = {
    )
 };
 
+// Amino acid mutations resolve through a different node template than nucleotide mutations
+const QueryTestScenario AMINO_ACID_MUTATIONS_SCHEMA_SCENARIO = {
+   .name = "AMINO_ACID_MUTATIONS_SCHEMA",
+   .query = "default.aminoAcidMutations(minProportion:=0.1).schema()",
+   .expected_query_result = nlohmann::json(
+      {{{"fieldName", "mutation"}, {"type", "STRING"}},
+       {{"fieldName", "mutationFrom"}, {"type", "STRING"}},
+       {{"fieldName", "mutationTo"}, {"type", "STRING"}},
+       {{"fieldName", "sequenceName"}, {"type", "STRING"}},
+       {{"fieldName", "position"}, {"type", "INT32"}},
+       {{"fieldName", "proportion"}, {"type", "FLOAT"}},
+       {{"fieldName", "coverage"}, {"type", "INT32"}},
+       {{"fieldName", "count"}, {"type", "INT32"}}}
+   )
+};
+
+// schema() inspects only the declared output schema, never the data: a child that
+// filters out every row still reports the full table schema (not zero rows).
+const QueryTestScenario SCHEMA_IGNORES_DATA_SCENARIO = {
+   .name = "SCHEMA_IGNORES_DATA",
+   .query = "default.filter(country='does-not-exist').project({primaryKey, age}).schema()",
+   .expected_query_result = nlohmann::json(
+      {{{"fieldName", "primaryKey"}, {"type", "STRING"}}, {{"fieldName", "age"}, {"type", "INT32"}}}
+   )
+};
+
+// schema() takes no arguments beyond its input; passing an extra positional argument
+// must be rejected at planning time.
+const QueryTestScenario SCHEMA_EXTRA_ARG_ERROR_SCENARIO = {
+   .name = "SCHEMA_EXTRA_ARG_ERROR",
+   .query = "default.schema(age)",
+   .expected_error_message = "schema() received too many positional arguments"
+};
+
 }  // namespace
 
 QUERY_TEST(
@@ -176,11 +210,14 @@ QUERY_TEST(
       TABLE_SCHEMA_SCENARIO,
       GROUP_BY_SCHEMA_SCENARIO,
       MUTATIONS_SCHEMA_SCENARIO,
+      AMINO_ACID_MUTATIONS_SCHEMA_SCENARIO,
       INSERTIONS_SCHEMA_SCENARIO,
       SCHEMA_AFTER_MAP_SCENARIO,
       SCHEMA_AFTER_PROJECT_ORDER_SCENARIO,
       MAP_AFTER_SCHEMA_SCENARIO,
       SCHEMA_OF_SCHEMA_SCENARIO,
+      SCHEMA_IGNORES_DATA_SCENARIO,
+      SCHEMA_EXTRA_ARG_ERROR_SCENARIO,
       CHAINING_SCHEMA_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/schema_node.test.cpp
+++ b/src/silo/query_engine/operators/schema_node.test.cpp
@@ -116,6 +116,57 @@ const QueryTestScenario MUTATIONS_SCHEMA_SCENARIO = {
    )
 };
 
+const QueryTestScenario INSERTIONS_SCHEMA_SCENARIO = {
+   .name = "INSERTIONS_SCHEMA",
+   .query = "default.insertions().schema()",
+   .expected_query_result = nlohmann::json(
+      {{{"fieldName", "position"}, {"type", "INT32"}},
+       {{"fieldName", "insertedSymbols"}, {"type", "STRING"}},
+       {{"fieldName", "sequenceName"}, {"type", "STRING"}},
+       {{"fieldName", "insertion"}, {"type", "STRING"}},
+       {{"fieldName", "count"}, {"type", "INT32"}}}
+   )
+};
+
+const QueryTestScenario SCHEMA_AFTER_MAP_SCENARIO = {
+   .name = "SCHEMA_AFTER_MAP",
+   .query = "default.map({tag := 42, label := 'x'}).project({primaryKey, tag, label}).schema()",
+   .expected_query_result = nlohmann::json(
+      {{{"fieldName", "primaryKey"}, {"type", "STRING"}},
+       {{"fieldName", "tag"}, {"type", "INT64"}},
+       {{"fieldName", "label"}, {"type", "STRING"}}}
+   )
+};
+
+// project() before schema() controls field selection and order
+const QueryTestScenario SCHEMA_AFTER_PROJECT_ORDER_SCENARIO = {
+   .name = "SCHEMA_AFTER_PROJECT_ORDER",
+   .query = "default.project({date, age, primaryKey}).schema()",
+   .expected_query_result = nlohmann::json(
+      {{{"fieldName", "date"}, {"type", "DATE32"}},
+       {{"fieldName", "age"}, {"type", "INT32"}},
+       {{"fieldName", "primaryKey"}, {"type", "STRING"}}}
+   )
+};
+
+const QueryTestScenario MAP_AFTER_SCHEMA_SCENARIO = {
+   .name = "MAP_AFTER_SCHEMA",
+   .query = "default.groupBy({count := count()}, {age}).schema().map({kind := 'field'})",
+   .expected_query_result = nlohmann::json(
+      {{{"fieldName", "age"}, {"type", "INT32"}, {"kind", "field"}},
+       {{"fieldName", "count"}, {"type", "INT64"}, {"kind", "field"}}}
+   )
+};
+
+const QueryTestScenario SCHEMA_OF_SCHEMA_SCENARIO = {
+   .name = "SCHEMA_OF_SCHEMA",
+   .query = "default.schema().schema()",
+   .expected_query_result = nlohmann::json(
+      {{{"fieldName", "fieldName"}, {"type", "STRING"}}, {{"fieldName", "type"}, {"type", "STRING"}}
+      }
+   )
+};
+
 }  // namespace
 
 QUERY_TEST(
@@ -125,6 +176,11 @@ QUERY_TEST(
       TABLE_SCHEMA_SCENARIO,
       GROUP_BY_SCHEMA_SCENARIO,
       MUTATIONS_SCHEMA_SCENARIO,
+      INSERTIONS_SCHEMA_SCENARIO,
+      SCHEMA_AFTER_MAP_SCENARIO,
+      SCHEMA_AFTER_PROJECT_ORDER_SCENARIO,
+      MAP_AFTER_SCHEMA_SCENARIO,
+      SCHEMA_OF_SCHEMA_SCENARIO,
       CHAINING_SCHEMA_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/schema_node.test.cpp
+++ b/src/silo/query_engine/operators/schema_node.test.cpp
@@ -149,6 +149,23 @@ const QueryTestScenario SCHEMA_AFTER_PROJECT_ORDER_SCENARIO = {
    )
 };
 
+// orderBy() after schema() is schema-preserving and needs no data source below it,
+// so it reorders schema() rows out of the box.
+const QueryTestScenario ORDER_BY_AFTER_SCHEMA_SCENARIO = {
+   .name = "ORDER_BY_AFTER_SCHEMA",
+   .query = "default.groupBy({count := count()}, {age}).schema().orderBy({fieldName})",
+   .expected_query_result = nlohmann::json(
+      {{{"fieldName", "age"}, {"type", "INT32"}}, {{"fieldName", "count"}, {"type", "INT64"}}}
+   )
+};
+
+// limit() after schema() truncates the schema() rows.
+const QueryTestScenario LIMIT_AFTER_SCHEMA_SCENARIO = {
+   .name = "LIMIT_AFTER_SCHEMA",
+   .query = "default.groupBy({count := count()}, {age}).schema().orderBy({fieldName}).limit(1)",
+   .expected_query_result = nlohmann::json({{{"fieldName", "age"}, {"type", "INT32"}}})
+};
+
 const QueryTestScenario MAP_AFTER_SCHEMA_SCENARIO = {
    .name = "MAP_AFTER_SCHEMA",
    .query = "default.groupBy({count := count()}, {age}).schema().map({kind := 'field'})",
@@ -258,6 +275,8 @@ QUERY_TEST(
       INSERTIONS_SCHEMA_SCENARIO,
       SCHEMA_AFTER_MAP_SCENARIO,
       SCHEMA_AFTER_PROJECT_ORDER_SCENARIO,
+      ORDER_BY_AFTER_SCHEMA_SCENARIO,
+      LIMIT_AFTER_SCHEMA_SCENARIO,
       MAP_AFTER_SCHEMA_SCENARIO,
       SCHEMA_OF_SCHEMA_SCENARIO,
       SCHEMA_IGNORES_DATA_SCENARIO,

--- a/src/silo/query_engine/optimizer/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.cpp
@@ -7,6 +7,7 @@
 #include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/project_node.h"
+#include "silo/query_engine/operators/schema_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
 
@@ -154,6 +155,19 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::OrderByNode& 
       }
    }
    propagateToNode(node.child);
+   return nullptr;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::SchemaNode& node) {
+   // schema() reports its child's full output schema, so NO column may be pruned from the
+   // child (unlike the base default, which would prune against this pass's `required` set —
+   // seeded from the root, i.e. schema()'s own {fieldName, type} columns — and corrupt the
+   // reported schema). We still recurse with a fresh pass seeded with the child's complete
+   // output schema as "required": this keeps every column while still allowing the pass's
+   // structural simplifications to run.
+   ColumnNarrowingPass child_pass{node.child->getOutputSchema()};
+   child_pass.propagateToNode(node.child);
    return nullptr;
 }
 

--- a/src/silo/query_engine/optimizer/column_narrowing_pass.h
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.h
@@ -13,6 +13,7 @@ class ProjectNode;
 class MapNode;
 class OrderByNode;
 class UnionAllNode;
+class SchemaNode;
 }  // namespace silo::query_engine::operators
 
 namespace silo::query_engine::optimizer {
@@ -41,6 +42,7 @@ class ColumnNarrowingPass : public PipelinePassBase<ColumnNarrowingPass> {
    operators::QueryNodePtr operator()(operators::MapNode& node);
    operators::QueryNodePtr operator()(operators::OrderByNode& node);
    operators::QueryNodePtr operator()(operators::UnionAllNode& node);
+   operators::QueryNodePtr operator()(operators::SchemaNode& node);
 };
 
 }  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
@@ -70,7 +70,8 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::MostRecentComm
    return nullptr;
 }
 
-operators::QueryNodePtr FilterPushdownPass::operator()(operators::SchemaNode& /*node*/) {
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr FilterPushdownPass::operator()(operators::SchemaNode& node) {
    // schema() reports a child's output schema; it is a result-producing source with no
    // place to push a predicate into. A filter() applied to its output therefore cannot be
    // realized -> reject the query.
@@ -79,6 +80,13 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::SchemaNode& /*
       "filter() cannot be applied to the output of schema(); schema() is a source operator "
       "and its result cannot be filtered. Apply filter() before schema() instead."
    );
+   // Push filters down *within* the child subtree using a fresh pass, so that filters inside
+   // the child (e.g. `default.filter(...).mutations().schema()`) are pushed into the scan.
+   // NodeResolutionPass requires this: it expects a bare table scan beneath
+   // mutations()/insertions(). A separate instance is used so the filters from above schema()
+   // cannot leak into the child.
+   FilterPushdownPass child_pass;
+   child_pass.propagateToNode(node.child);
    return nullptr;
 }
 

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
@@ -3,11 +3,13 @@
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/query_engine/expressions/and.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/insertions_node.h"
 #include "silo/query_engine/operators/most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/mutations_node.h"
 #include "silo/query_engine/operators/phylo_subtree_node.h"
+#include "silo/query_engine/operators/schema_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
 
@@ -65,6 +67,18 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::MostRecentComm
 ) {
    current_filters.push_back(std::move(node.filter));
    node.filter = std::make_unique<expressions::And>(std::move(current_filters));
+   return nullptr;
+}
+
+operators::QueryNodePtr FilterPushdownPass::operator()(operators::SchemaNode& /*node*/) {
+   // schema() reports a child's output schema; it is a result-producing source with no
+   // place to push a predicate into. A filter() applied to its output therefore cannot be
+   // realized -> reject the query.
+   CHECK_SILO_QUERY(
+      current_filters.empty(),
+      "filter() cannot be applied to the output of schema(); schema() is a source operator "
+      "and its result cannot be filtered. Apply filter() before schema() instead."
+   );
    return nullptr;
 }
 

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.h
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.h
@@ -14,6 +14,7 @@ class InsertionsNode;
 class PhyloSubtreeNode;
 class MostRecentCommonAncestorNode;
 class UnionAllNode;
+class SchemaNode;
 }  // namespace silo::query_engine::operators
 
 namespace silo::query_engine::optimizer {
@@ -35,6 +36,7 @@ class FilterPushdownPass : public PipelinePassBase<FilterPushdownPass> {
    operators::QueryNodePtr operator()(operators::InsertionsNode<AminoAcid>& node);
    operators::QueryNodePtr operator()(operators::PhyloSubtreeNode& node);
    operators::QueryNodePtr operator()(operators::MostRecentCommonAncestorNode& node);
+   operators::QueryNodePtr operator()(operators::SchemaNode& node);
 
    operators::QueryNodePtr operator()(operators::UnionAllNode& node);
 };

--- a/src/silo/query_engine/optimizer/node_resolution_pass.cpp
+++ b/src/silo/query_engine/optimizer/node_resolution_pass.cpp
@@ -11,6 +11,7 @@
 #include "silo/query_engine/operators/most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/mutations_node.h"
 #include "silo/query_engine/operators/phylo_subtree_node.h"
+#include "silo/query_engine/operators/schema_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/unresolved_phylo_subtree_node.h"
@@ -161,6 +162,13 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
       std::move(node.column_name),
       node.print_nodes_not_in_tree
    );
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr NodeResolutionPass::operator()(operators::SchemaNode& node) {
+   // Resolution does not change a node's output schema, so the reported schema is unaffected.
+   propagateToNode(node.child);
+   return nullptr;
 }
 
 template operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedMutationsNode<

--- a/src/silo/query_engine/optimizer/node_resolution_pass.h
+++ b/src/silo/query_engine/optimizer/node_resolution_pass.h
@@ -11,6 +11,7 @@ template <typename SymbolType>
 class UnresolvedInsertionsNode;
 class UnresolvedMostRecentCommonAncestorNode;
 class UnresolvedPhyloSubtreeNode;
+class SchemaNode;
 }  // namespace silo::query_engine::operators
 
 namespace silo::query_engine::optimizer {
@@ -32,6 +33,7 @@ class NodeResolutionPass : public PipelinePassBase<NodeResolutionPass> {
    operators::QueryNodePtr operator()(operators::UnresolvedInsertionsNode<SymbolType>& node);
    operators::QueryNodePtr operator()(operators::UnresolvedMostRecentCommonAncestorNode& node);
    operators::QueryNodePtr operator()(operators::UnresolvedPhyloSubtreeNode& node);
+   operators::QueryNodePtr operator()(operators::SchemaNode& node);
 };
 
 }  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/pipeline_pass_base.h
+++ b/src/silo/query_engine/optimizer/pipeline_pass_base.h
@@ -125,13 +125,17 @@ class PipelinePassBase {
       return nullptr;
    }
 
-   // `SchemaNode` deliberately does NOT propagate into its child. The child plan is
-   // never executed; only `child->getOutputSchema()` is inspected at exec-plan-build
-   // time. Optimization passes (column narrowing, filter pushdown, node resolution)
-   // exist to make execution correct/fast and must not run on a subtree that is never
-   // executed. This is correct only because every operator's `getOutputSchema()` is
-   // invariant under those passes (e.g. an unresolved node reports the same schema as
-   // its resolved form). If that ever stops holding, this must resolve the child first.
+   // Default for `SchemaNode`: do NOT propagate into its child. `schema()` never executes
+   // the child plan; it only inspects `child->getOutputSchema()`. Pure optimization passes
+   // (e.g. ColumnNarrowingPass) must not touch the child: narrowing in particular would
+   // prune the child's columns against the *root* required-set (`{fieldName, type}`) and
+   // corrupt the very schema we report.
+   //
+   // Passes that perform query *validation* on the child override this to recurse, so that a query
+   // like `default.mutations(sequenceNames:={'noseq'}).schema()` is rejected with the same error it
+   // would produce without the trailing `schema()`. This is sound because every operator's
+   // `getOutputSchema()` is invariant under those passes (an unresolved node reports the same
+   // schema as its resolved form).
    operators::QueryNodePtr operator()(operators::SchemaNode& /*node*/) { return nullptr; }
 
    template <typename T>

--- a/src/silo/query_engine/optimizer/pipeline_pass_base.h
+++ b/src/silo/query_engine/optimizer/pipeline_pass_base.h
@@ -10,6 +10,7 @@
 #include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/query_node.h"
+#include "silo/query_engine/operators/schema_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/unresolved_insertions_node.h"
 #include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"

--- a/src/silo/query_engine/optimizer/pipeline_pass_base.h
+++ b/src/silo/query_engine/optimizer/pipeline_pass_base.h
@@ -10,7 +10,6 @@
 #include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/query_node.h"
-#include "silo/query_engine/operators/schema_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/unresolved_insertions_node.h"
 #include "silo/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
@@ -124,19 +123,6 @@ class PipelinePassBase {
       propagateToNode(node.right);
       return nullptr;
    }
-
-   // Default for `SchemaNode`: do NOT propagate into its child. `schema()` never executes
-   // the child plan; it only inspects `child->getOutputSchema()`. Pure optimization passes
-   // (e.g. ColumnNarrowingPass) must not touch the child: narrowing in particular would
-   // prune the child's columns against the *root* required-set (`{fieldName, type}`) and
-   // corrupt the very schema we report.
-   //
-   // Passes that perform query *validation* on the child override this to recurse, so that a query
-   // like `default.mutations(sequenceNames:={'noseq'}).schema()` is rejected with the same error it
-   // would produce without the trailing `schema()`. This is sound because every operator's
-   // `getOutputSchema()` is invariant under those passes (an unresolved node reports the same
-   // schema as its resolved form).
-   operators::QueryNodePtr operator()(operators::SchemaNode& /*node*/) { return nullptr; }
 
    template <typename T>
    operators::QueryNodePtr operator()(T& /*node*/) {

--- a/src/silo/query_engine/optimizer/pipeline_pass_base.h
+++ b/src/silo/query_engine/optimizer/pipeline_pass_base.h
@@ -125,6 +125,15 @@ class PipelinePassBase {
       return nullptr;
    }
 
+   // `SchemaNode` deliberately does NOT propagate into its child. The child plan is
+   // never executed; only `child->getOutputSchema()` is inspected at exec-plan-build
+   // time. Optimization passes (column narrowing, filter pushdown, node resolution)
+   // exist to make execution correct/fast and must not run on a subtree that is never
+   // executed. This is correct only because every operator's `getOutputSchema()` is
+   // invariant under those passes (e.g. an unresolved node reports the same schema as
+   // its resolved form). If that ever stops holding, this must resolve the child first.
+   operators::QueryNodePtr operator()(operators::SchemaNode& /*node*/) { return nullptr; }
+
    template <typename T>
    operators::QueryNodePtr operator()(T& /*node*/) {
       return nullptr;

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -50,6 +50,7 @@
 #include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/project_node.h"
+#include "silo/query_engine/operators/schema_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/operators/unresolved_insertions_node.h"
@@ -964,6 +965,16 @@ operators::QueryNodePtr handleFilter(
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr handleSchema(
+   const BoundArguments& args,
+   const Tables& tables,
+   const ChildConverter& convert_child
+) {
+   auto child = convert_child(args.at("input"), tables);
+   return std::make_unique<operators::SchemaNode>(child->getOutputSchema());
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr handleGroupBy(
    const BoundArguments& args,
    const Tables& tables,
@@ -1403,6 +1414,8 @@ ParameterDefinition named(std::string name, bool required = true) {
 
 FunctionRegistry::FunctionRegistry() {
    registerFunction("filter", {{pos("input"), pos("predicate")}}, handleFilter);
+
+   registerFunction("schema", {{pos("input")}}, handleSchema);
 
    registerFunction(
       "groupBy", {{pos("input"), pos("aggregates"), pos("columns", false)}}, handleGroupBy

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -971,7 +971,7 @@ operators::QueryNodePtr handleSchema(
    const ChildConverter& convert_child
 ) {
    auto child = convert_child(args.at("input"), tables);
-   return std::make_unique<operators::SchemaNode>(child->getOutputSchema());
+   return std::make_unique<operators::SchemaNode>(std::move(child));
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)


### PR DESCRIPTION
resolves #1331

### Summary

Adds a `schema()` SaneQL operator that returns the output schema of a query (or any pipeline result) as rows, without executing the underlying query plan:

```
default.filter(country='CH').groupBy({count:=count()}, {age}).schema()
// → {"fieldName":"age","type":"INT32"}
//   {"fieldName":"count","type":"INT64"}
```

Each row has `fieldName` (STRING) and `type` (STRING). The child plan is never executed — only its declared output schema is inspected.

**Limitations (documented):**
- Sequence columns report as `STRING` (decompressed to string before `schema()` observes them).
- `filter()` after `schema()` is rejected at planning time — there is no data source above `schema()` to push a predicate into.

**Implementation notes for reviewers:**
- `SchemaNode` is a source-type leaf; it hits `FilterPushdownPass`, `NodeResolutionPass`, and `ColumnNarrowingPass` with per-pass overrides so the child subtree is validated (bad sequence names, mutations-not-on-scan, etc.) but never executed.
- `ColumnNarrowingPass` recurses into the child seeded with the child's *full* output schema (no pruning), preserving the structural Map/Project collapses that `NodeResolutionPass` depends on.

## PR Checklist

- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
