### PR TITLE
refactor(SaneQL): map pull up: pull map expressions through fetch nodes

### DIFF
--- a/src/silo/query_engine/AGENTS.md
+++ b/src/silo/query_engine/AGENTS.md
@@ -9,7 +9,7 @@ IMPORTANT: Changes here may require updates to query docs: `documentation/query_
 SaneQL string
   → Parser (saneql/parser.cpp) → AST (saneql/ast.h)
   → ast_to_query.cpp → QueryNode tree (operators/*.h)
-  → ColumnNarrowingPass → FilterPushdownPass → NodeResolutionPass
+  → ColumnNarrowingPass → MapPullupPass → FilterPushdownPass → NodeResolutionPass
   → addToExecPlan() → Arrow Acero ExecPlan (single shared plan)
   → QueryPlan execution → send result
 ```

--- a/src/silo/query_engine/AGENTS.md
+++ b/src/silo/query_engine/AGENTS.md
@@ -9,7 +9,7 @@ IMPORTANT: Changes here may require updates to query docs: `documentation/query_
 SaneQL string
   → Parser (saneql/parser.cpp) → AST (saneql/ast.h)
   → ast_to_query.cpp → QueryNode tree (operators/*.h)
-  → ColumnNarrowingPass → MapPullupPass → FilterPushdownPass → NodeResolutionPass
+  → ColumnNarrowingPass → FilterPushdownPass → MapPullupPass → NodeResolutionPass
   → addToExecPlan() → Arrow Acero ExecPlan (single shared plan)
   → QueryPlan execution → send result
 ```

--- a/src/silo/query_engine/operators/map_node.test.cpp
+++ b/src/silo/query_engine/operators/map_node.test.cpp
@@ -194,14 +194,21 @@ const QueryTestScenario DECOMPRESS_WITH_USER_MAP_SCENARIO = {
 };
 
 // Regression guard: selecting the (zstd-compressed) sequence column together with a
-// `limit` must still return the correct, order-stable result. (For this particular
-// query shape the decompression MapNode is not adjacent to the FetchNode, so the pass
-// does not rewrite it; correctness is the property under test.)
+// `limit` must still return the correct, order-stable result.
 const QueryTestScenario DECOMPRESS_SEQUENCE_WITH_LIMIT_SCENARIO = {
    .name = "DECOMPRESS_SEQUENCE_WITH_LIMIT",
    .query = "default.project({primaryKey, unaligned_segment1}).orderBy({primaryKey}).limit(1)",
    .expected_query_result =
       nlohmann::json({{{"primaryKey", "id_0"}, {"unaligned_segment1", "ACGT"}}})
+};
+
+// End-to-end coverage that MapPullupPass actually fires: `map({...}).limit(...)` builds a
+// FetchNode directly above the user MapNode (Fetch(Map(scan))), which the pass rewrites to
+// Map(Fetch(scan)).
+const QueryTestScenario MAP_WITH_LIMIT_TRIGGERS_PULLUP_SCENARIO = {
+   .name = "MAP_WITH_LIMIT_TRIGGERS_PULLUP",
+   .query = "default.map({a := 3}).orderBy({primaryKey}).map({b := 7}).limit(1).project({a, b})",
+   .expected_query_result = nlohmann::json({{{"a", 3}, {"b", 7}}})
 };
 
 }  // namespace
@@ -223,6 +230,7 @@ QUERY_TEST(
       MAP_DUPLICATE_OUTPUT_NAME_SCENARIO,
       DECOMPRESS_SEQUENCE_SCENARIO,
       DECOMPRESS_WITH_USER_MAP_SCENARIO,
-      DECOMPRESS_SEQUENCE_WITH_LIMIT_SCENARIO
+      DECOMPRESS_SEQUENCE_WITH_LIMIT_SCENARIO,
+      MAP_WITH_LIMIT_TRIGGERS_PULLUP_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/map_node.test.cpp
+++ b/src/silo/query_engine/operators/map_node.test.cpp
@@ -202,9 +202,11 @@ const QueryTestScenario DECOMPRESS_SEQUENCE_WITH_LIMIT_SCENARIO = {
       nlohmann::json({{{"primaryKey", "id_0"}, {"unaligned_segment1", "ACGT"}}})
 };
 
-// End-to-end coverage that MapPullupPass actually fires: `map({...}).limit(...)` builds a
-// FetchNode directly above the user MapNode (Fetch(Map(scan))), which the pass rewrites to
-// Map(Fetch(scan)).
+// Correctness regression guard for a shape MapPullupPass is eligible to rewrite:
+// `map({...}).limit(...)` builds a FetchNode directly above the user MapNode
+// (Fetch(Map(scan))), which the pass may rewrite to Map(Fetch(scan)). QUERY_TEST asserts
+// only the query result (it does not inspect the optimized plan), so this checks that the
+// rewrite - when it happens - does not change the result.
 const QueryTestScenario MAP_WITH_LIMIT_TRIGGERS_PULLUP_SCENARIO = {
    .name = "MAP_WITH_LIMIT_TRIGGERS_PULLUP",
    .query = "default.map({a := 3}).orderBy({primaryKey}).map({b := 7}).limit(1).project({a, b})",

--- a/src/silo/query_engine/operators/map_node.test.cpp
+++ b/src/silo/query_engine/operators/map_node.test.cpp
@@ -193,10 +193,10 @@ const QueryTestScenario DECOMPRESS_WITH_USER_MAP_SCENARIO = {
    )
 };
 
-// The (zstd-compressed) sequence column is selected together with a `limit`. The
-// MapPullupPass moves the decompression MapNode above the FetchNode, so only the
-// retained row is decompressed. The result must still be correct: ordered by
-// primaryKey, the first row is id_0 with sequence "ACGT".
+// Regression guard: selecting the (zstd-compressed) sequence column together with a
+// `limit` must still return the correct, order-stable result. (For this particular
+// query shape the decompression MapNode is not adjacent to the FetchNode, so the pass
+// does not rewrite it; correctness is the property under test.)
 const QueryTestScenario DECOMPRESS_SEQUENCE_WITH_LIMIT_SCENARIO = {
    .name = "DECOMPRESS_SEQUENCE_WITH_LIMIT",
    .query = "default.project({primaryKey, unaligned_segment1}).orderBy({primaryKey}).limit(1)",

--- a/src/silo/query_engine/operators/map_node.test.cpp
+++ b/src/silo/query_engine/operators/map_node.test.cpp
@@ -193,6 +193,17 @@ const QueryTestScenario DECOMPRESS_WITH_USER_MAP_SCENARIO = {
    )
 };
 
+// The (zstd-compressed) sequence column is selected together with a `limit`. The
+// MapPullupPass moves the decompression MapNode above the FetchNode, so only the
+// retained row is decompressed. The result must still be correct: ordered by
+// primaryKey, the first row is id_0 with sequence "ACGT".
+const QueryTestScenario DECOMPRESS_SEQUENCE_WITH_LIMIT_SCENARIO = {
+   .name = "DECOMPRESS_SEQUENCE_WITH_LIMIT",
+   .query = "default.project({primaryKey, unaligned_segment1}).orderBy({primaryKey}).limit(1)",
+   .expected_query_result =
+      nlohmann::json({{{"primaryKey", "id_0"}, {"unaligned_segment1", "ACGT"}}})
+};
+
 }  // namespace
 
 QUERY_TEST(
@@ -211,6 +222,7 @@ QUERY_TEST(
       MAP_ONLY_MAPPED_COLUMN_SCENARIO,
       MAP_DUPLICATE_OUTPUT_NAME_SCENARIO,
       DECOMPRESS_SEQUENCE_SCENARIO,
-      DECOMPRESS_WITH_USER_MAP_SCENARIO
+      DECOMPRESS_WITH_USER_MAP_SCENARIO,
+      DECOMPRESS_SEQUENCE_WITH_LIMIT_SCENARIO
    )
 );

--- a/src/silo/query_engine/optimizer/map_pullup_pass.cpp
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.cpp
@@ -1,0 +1,28 @@
+#include "silo/query_engine/optimizer/map_pullup_pass.h"
+
+#include <memory>
+
+#include "silo/query_engine/operators/fetch_node.h"
+#include "silo/query_engine/operators/map_node.h"
+
+namespace silo::query_engine::optimizer {
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr MapPullupPass::operator()(operators::FetchNode& node) {
+   propagateToNode(node.child);
+
+   // A FetchNode only limits/offsets rows; it references no columns, so a MapNode below
+   // it can always be pulled up.
+   if (node.child->kind() != operators::NodeKind::MAP) {
+      return nullptr;
+   }
+   operators::QueryNodePtr map_owner = std::move(node.child);
+   auto& map = static_cast<operators::MapNode&>(*map_owner);
+
+   auto new_fetch =
+      std::make_unique<operators::FetchNode>(std::move(map.child), node.count, node.offset);
+   map.child = std::move(new_fetch);
+   return map_owner;
+}
+
+}  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/map_pullup_pass.h
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "silo/query_engine/operators/query_node.h"
+#include "silo/query_engine/optimizer/pipeline_pass_base.h"
+
+namespace silo::query_engine::operators {
+class FetchNode;
+}  // namespace silo::query_engine::operators
+
+namespace silo::query_engine::optimizer {
+
+/// Optimization pass that moves a MapNode up the plan tree, so expensive per-row
+/// computation (especially zstd decompression, which lives as a ScalarExpression inside
+/// a MapNode) runs on as few rows as possible.
+///
+/// A MapNode is pulled up through a parent that reduces or reorders rows but does not
+/// reference any column the MapNode produces:
+///
+/// ```
+/// P(M(child))  →  M(P(child))
+/// ```
+///
+/// Both the parent and the MapNode preserve row count and ordering, so the swap is
+/// semantics-preserving. The main win is pulling a MapNode above a FetchNode (limit/offset)
+/// so a `limit` no longer forces every row to be decompressed and then discarded.
+///
+/// Scope (this pass): pull through FetchNode only, which references no columns and is
+/// therefore always safe. Pulling through FilterNode requires knowing the columns a filter
+/// predicate references (Expression::freeIUs), which most predicate types do not yet report;
+/// that, along with Project/OrderBy/Aggregate, is a follow-up (see #1336). The pass blocks
+/// (leaves the MapNode in place) at every other node and at the root.
+class MapPullupPass : public PipelinePassBase<MapPullupPass> {
+  public:
+   using PipelinePassBase<MapPullupPass>::operator();
+
+   operators::QueryNodePtr operator()(operators::FetchNode& node);
+};
+
+}  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/map_pullup_pass.h
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.h
@@ -20,8 +20,7 @@ namespace silo::query_engine::optimizer {
 /// P(M(child))  →  M(P(child))
 /// ```
 ///
-/// Both the parent and the MapNode preserve row count and ordering, so the swap is
-/// semantics-preserving. The main win is pulling a MapNode above a FetchNode (limit/offset)
+/// The main win is pulling a MapNode above a FetchNode (limit/offset)
 /// so a `limit` no longer forces every row to be decompressed and then discarded.
 ///
 /// Scope (this pass): pull through FetchNode only, which references no columns and is

--- a/src/silo/query_engine/optimizer/map_pullup_pass.h
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.h
@@ -20,14 +20,8 @@ namespace silo::query_engine::optimizer {
 /// P(M(child))  →  M(P(child))
 /// ```
 ///
-/// The main win is pulling a MapNode above a FetchNode (limit/offset)
+/// One goal is pulling a MapNode above a FetchNode (limit/offset)
 /// so a `limit` no longer forces every row to be decompressed and then discarded.
-///
-/// Scope (this pass): pull through FetchNode only, which references no columns and is
-/// therefore always safe. Pulling through FilterNode requires knowing the columns a filter
-/// predicate references (Expression::freeIUs), which most predicate types do not yet report;
-/// that, along with Project/OrderBy/Aggregate, is a follow-up (see #1336). The pass blocks
-/// (leaves the MapNode in place) at every other node and at the root.
 class MapPullupPass : public PipelinePassBase<MapPullupPass> {
   public:
    using PipelinePassBase<MapPullupPass>::operator();

--- a/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
@@ -78,6 +78,39 @@ TEST(MapPullupPass, pullsMapUpThroughFetch) {
    EXPECT_EQ(moved_fetch->child->kind(), operators::NodeKind::TABLE_SCAN);
 }
 
+// An offset-only Fetch (no count) keeps its fields after the Map is pulled above it.
+
+TEST(MapPullupPass, pullsMapUpThroughOffsetOnlyFetch) {
+   auto fetch = std::make_unique<operators::FetchNode>(makeMap(makeScan()), std::nullopt, 7);
+
+   auto result = MapPullupPass::run(std::move(fetch));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* map = dynamic_cast<operators::MapNode*>(result.get());
+   ASSERT_EQ(map->child->kind(), operators::NodeKind::FETCH);
+   auto* moved_fetch = dynamic_cast<operators::FetchNode*>(map->child.get());
+   EXPECT_FALSE(moved_fetch->count.has_value());
+   EXPECT_EQ(moved_fetch->offset, 7);
+}
+
+// A MapNode with no assignments is still pulled up (it is a no-op pass-through; the pass
+// does not need to special-case it, and ColumnNarrowingPass normally removes such Maps
+// before this pass runs).
+
+TEST(MapPullupPass, pullsEmptyMapUpThroughFetch) {
+   auto map = std::make_unique<operators::MapNode>(
+      makeScan(), std::vector<operators::MapNode::Assignment>{}
+   );
+   auto fetch = std::make_unique<operators::FetchNode>(std::move(map), 5, std::nullopt);
+
+   auto result = MapPullupPass::run(std::move(fetch));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* result_map = dynamic_cast<operators::MapNode*>(result.get());
+   EXPECT_TRUE(result_map->assignments.empty());
+   EXPECT_EQ(result_map->child->kind(), operators::NodeKind::FETCH);
+}
+
 // --- A zstd-decompression MapNode (the real motivating case) is pulled above a Fetch ---
 
 TEST(MapPullupPass, pullsDecompressMapUpThroughFetch) {

--- a/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
@@ -1,0 +1,172 @@
+#include "silo/query_engine/optimizer/map_pullup_pass.h"
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "silo/query_engine/expressions/literal.h"
+#include "silo/query_engine/operators/aggregate_node.h"
+#include "silo/query_engine/operators/fetch_node.h"
+#include "silo/query_engine/operators/filter_node.h"
+#include "silo/query_engine/operators/map_node.h"
+#include "silo/query_engine/operators/order_by_node.h"
+#include "silo/query_engine/operators/project_node.h"
+#include "silo/query_engine/operators/table_scan_node.h"
+#include "silo/query_engine/order_by_field.h"
+#include "silo/schema/database_schema.h"
+#include "silo/storage/column/string_column.h"
+#include "silo/storage/table.h"
+
+using silo::query_engine::optimizer::MapPullupPass;
+namespace operators = silo::query_engine::operators;
+namespace expressions = silo::query_engine::expressions;
+
+using silo::schema::ColumnIdentifier;
+using silo::schema::ColumnType;
+
+namespace {
+
+std::shared_ptr<silo::storage::Table> makeTable() {
+   using silo::storage::column::ColumnMetadata;
+   using silo::storage::column::StringColumnMetadata;
+
+   ColumnIdentifier primary_key{.name = "id", .type = ColumnType::STRING};
+   std::map<ColumnIdentifier, std::shared_ptr<ColumnMetadata>> col_meta{
+      {primary_key, std::make_shared<StringColumnMetadata>(primary_key.name)}
+   };
+   auto schema = std::make_shared<silo::schema::TableSchema>(std::move(col_meta), primary_key);
+   return std::make_shared<silo::storage::Table>(silo::schema::TableName("default"), schema);
+}
+
+std::unique_ptr<expressions::Expression> trueFilter() {
+   return std::make_unique<expressions::BoolLiteral>(true);
+}
+
+operators::QueryNodePtr makeScan() {
+   return std::make_unique<operators::TableScanNode>(
+      makeTable(), trueFilter(), std::vector<ColumnIdentifier>{}
+   );
+}
+
+// MapNode producing a new column `x := 3` on top of `child`.
+operators::QueryNodePtr makeMap(operators::QueryNodePtr child) {
+   std::vector<operators::MapNode::Assignment> assignments;
+   assignments.push_back(
+      {.output_column = {.name = "x", .type = ColumnType::INT64},
+       .expression = std::make_unique<expressions::Int64Literal>(3)}
+   );
+   return std::make_unique<operators::MapNode>(std::move(child), std::move(assignments));
+}
+
+// --- FetchNode(MapNode(...)) → MapNode(FetchNode(...)) ---
+
+TEST(MapPullupPass, pullsMapUpThroughFetch) {
+   auto fetch = std::make_unique<operators::FetchNode>(makeMap(makeScan()), 5, 2);
+
+   auto result = MapPullupPass::run(std::move(fetch));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* map = dynamic_cast<operators::MapNode*>(result.get());
+   ASSERT_EQ(map->child->kind(), operators::NodeKind::FETCH);
+   auto* moved_fetch = dynamic_cast<operators::FetchNode*>(map->child.get());
+   EXPECT_EQ(moved_fetch->count, 5);
+   EXPECT_EQ(moved_fetch->offset, 2);
+   EXPECT_EQ(moved_fetch->child->kind(), operators::NodeKind::TABLE_SCAN);
+}
+
+// --- FetchNode(FetchNode(MapNode(...))): the map bubbles up through both ---
+
+TEST(MapPullupPass, bubblesMapUpThroughStackedFetch) {
+   auto inner_fetch = std::make_unique<operators::FetchNode>(makeMap(makeScan()), 5, std::nullopt);
+   auto outer_fetch = std::make_unique<operators::FetchNode>(std::move(inner_fetch), 3, 1);
+
+   auto result = MapPullupPass::run(std::move(outer_fetch));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* map = dynamic_cast<operators::MapNode*>(result.get());
+   ASSERT_EQ(map->child->kind(), operators::NodeKind::FETCH);
+   auto* outer = dynamic_cast<operators::FetchNode*>(map->child.get());
+   ASSERT_EQ(outer->child->kind(), operators::NodeKind::FETCH);
+   auto* inner = dynamic_cast<operators::FetchNode*>(outer->child.get());
+   EXPECT_EQ(inner->child->kind(), operators::NodeKind::TABLE_SCAN);
+}
+
+// --- Blocked: FilterNode. Pulling a MapNode up through a filter needs the columns the
+// filter references (Expression::freeIUs), which most predicates don't report yet, so this
+// pass leaves the MapNode below the filter (see #1336). ---
+
+TEST(MapPullupPass, doesNotPullMapUpThroughFilter) {
+   auto filter = std::make_unique<operators::FilterNode>(makeMap(makeScan()), trueFilter());
+
+   auto result = MapPullupPass::run(std::move(filter));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::FILTER);
+   auto* filter_node = dynamic_cast<operators::FilterNode*>(result.get());
+   EXPECT_EQ(filter_node->child->kind(), operators::NodeKind::MAP);
+}
+
+// --- Blocked: ProjectNode is the root over the MapNode ---
+
+TEST(MapPullupPass, doesNotPullMapUpThroughProject) {
+   auto project = std::make_unique<operators::ProjectNode>(
+      makeMap(makeScan()), std::vector<ColumnIdentifier>{{.name = "x", .type = ColumnType::INT64}}
+   );
+
+   auto result = MapPullupPass::run(std::move(project));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::PROJECT);
+   auto* project_node = dynamic_cast<operators::ProjectNode*>(result.get());
+   EXPECT_EQ(project_node->child->kind(), operators::NodeKind::MAP);
+}
+
+// --- Blocked: OrderByNode ---
+
+TEST(MapPullupPass, doesNotPullMapUpThroughOrderBy) {
+   std::vector<silo::query_engine::OrderByField> fields{
+      {.field = {.name = "id", .type = ColumnType::STRING}, .ascending = true}
+   };
+   auto order_by = std::make_unique<operators::OrderByNode>(
+      makeMap(makeScan()), std::move(fields), std::nullopt
+   );
+
+   auto result = MapPullupPass::run(std::move(order_by));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::ORDER_BY);
+   auto* order_by_node = dynamic_cast<operators::OrderByNode*>(result.get());
+   EXPECT_EQ(order_by_node->child->kind(), operators::NodeKind::MAP);
+}
+
+// --- Blocked: AggregateNode ---
+
+TEST(MapPullupPass, doesNotPullMapUpThroughAggregate) {
+   auto aggregate = std::make_unique<operators::AggregateNode>(
+      makeMap(makeScan()),
+      std::vector<ColumnIdentifier>{},
+      std::vector<operators::AggregateDefinition>{
+         {.output_name = "count", .function = operators::AggregateFunction::COUNT}
+      }
+   );
+
+   auto result = MapPullupPass::run(std::move(aggregate));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::AGGREGATE);
+   auto* aggregate_node = dynamic_cast<operators::AggregateNode*>(result.get());
+   EXPECT_EQ(aggregate_node->child->kind(), operators::NodeKind::MAP);
+}
+
+// --- Blocked: a MapNode at the root is left untouched ---
+
+TEST(MapPullupPass, leavesRootMapInPlace) {
+   auto map = makeMap(makeScan());
+
+   auto result = MapPullupPass::run(std::move(map));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* root_map = dynamic_cast<operators::MapNode*>(result.get());
+   EXPECT_EQ(root_map->child->kind(), operators::NodeKind::TABLE_SCAN);
+}
+
+}  // namespace

--- a/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
@@ -191,7 +191,7 @@ TEST(MapPullupPass, pullsInnerMapUpUnderRootMap) {
 
 // --- Blocked: FilterNode. Pulling a MapNode up through a filter needs the columns the
 // filter references (Expression::freeIUs), which most predicates don't report yet, so this
-// pass leaves the MapNode below the filter (see #1336). ---
+// pass leaves the MapNode below the filter (#1343). ---
 
 TEST(MapPullupPass, doesNotPullMapUpThroughFilter) {
    auto filter = std::make_unique<operators::FilterNode>(makeMap(makeScan()), trueFilter());

--- a/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <gmock/gmock.h>

--- a/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
@@ -159,6 +159,36 @@ TEST(MapPullupPass, bubblesMapUpThroughStackedFetch) {
    EXPECT_EQ(inner->child->kind(), operators::NodeKind::TABLE_SCAN);
 }
 
+TEST(MapPullupPass, leavesFetchOverNonMapInPlace) {
+   auto fetch = std::make_unique<operators::FetchNode>(makeScan(), 5, std::nullopt);
+
+   auto result = MapPullupPass::run(std::move(fetch));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::FETCH);
+   auto* fetch_node = dynamic_cast<operators::FetchNode*>(result.get());
+   EXPECT_EQ(fetch_node->count, 5);
+   EXPECT_EQ(fetch_node->child->kind(), operators::NodeKind::TABLE_SCAN);
+}
+
+// --- MapNode(FetchNode(MapNode(...))): the inner map is pulled above the fetch and comes to
+// rest directly under the (blocked) root map, giving Map(Map(Fetch(scan))). The root map is
+// not itself moved (it is the root). ---
+
+TEST(MapPullupPass, pullsInnerMapUpUnderRootMap) {
+   auto inner_fetch = std::make_unique<operators::FetchNode>(makeMap(makeScan()), 5, std::nullopt);
+   auto root_map = makeMap(std::move(inner_fetch));
+
+   auto result = MapPullupPass::run(std::move(root_map));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* outer_map = dynamic_cast<operators::MapNode*>(result.get());
+   ASSERT_EQ(outer_map->child->kind(), operators::NodeKind::MAP);
+   auto* inner_map = dynamic_cast<operators::MapNode*>(outer_map->child.get());
+   ASSERT_EQ(inner_map->child->kind(), operators::NodeKind::FETCH);
+   auto* fetch = dynamic_cast<operators::FetchNode*>(inner_map->child.get());
+   EXPECT_EQ(fetch->child->kind(), operators::NodeKind::TABLE_SCAN);
+}
+
 // --- Blocked: FilterNode. Pulling a MapNode up through a filter needs the columns the
 // filter references (Expression::freeIUs), which most predicates don't report yet, so this
 // pass leaves the MapNode below the filter (see #1336). ---

--- a/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
@@ -5,7 +5,6 @@
 #include <optional>
 #include <vector>
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "silo/query_engine/expressions/literal.h"

--- a/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "silo/query_engine/expressions/literal.h"
+#include "silo/query_engine/expressions/zstd_decompress_scalar.h"
 #include "silo/query_engine/operators/aggregate_node.h"
 #include "silo/query_engine/operators/fetch_node.h"
 #include "silo/query_engine/operators/filter_node.h"
@@ -74,6 +75,37 @@ TEST(MapPullupPass, pullsMapUpThroughFetch) {
    auto* moved_fetch = dynamic_cast<operators::FetchNode*>(map->child.get());
    EXPECT_EQ(moved_fetch->count, 5);
    EXPECT_EQ(moved_fetch->offset, 2);
+   EXPECT_EQ(moved_fetch->child->kind(), operators::NodeKind::TABLE_SCAN);
+}
+
+// --- A zstd-decompression MapNode (the real motivating case) is pulled above a Fetch ---
+
+TEST(MapPullupPass, pullsDecompressMapUpThroughFetch) {
+   const auto seq_column = ColumnIdentifier{.name = "seq", .type = ColumnType::NUCLEOTIDE_SEQUENCE};
+   std::vector<operators::MapNode::Assignment> assignments;
+   assignments.push_back(
+      {.output_column = {.name = "seq", .type = ColumnType::STRING},
+       .expression = std::make_unique<expressions::ZstdDecompressScalar>(seq_column, "A")}
+   );
+   auto map = std::make_unique<operators::MapNode>(
+      std::make_unique<operators::TableScanNode>(
+         makeTable(), trueFilter(), std::vector<ColumnIdentifier>{seq_column}
+      ),
+      std::move(assignments)
+   );
+   auto fetch = std::make_unique<operators::FetchNode>(std::move(map), 1, std::nullopt);
+
+   auto result = MapPullupPass::run(std::move(fetch));
+
+   // Decompression now runs above the limit, so only the retained row is decompressed.
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* result_map = dynamic_cast<operators::MapNode*>(result.get());
+   ASSERT_EQ(result_map->assignments.size(), 1);
+   EXPECT_EQ(
+      result_map->assignments.front().expression->kind(), expressions::ZstdDecompressScalar::KIND
+   );
+   ASSERT_EQ(result_map->child->kind(), operators::NodeKind::FETCH);
+   auto* moved_fetch = dynamic_cast<operators::FetchNode*>(result_map->child.get());
    EXPECT_EQ(moved_fetch->child->kind(), operators::NodeKind::TABLE_SCAN);
 }
 

--- a/src/silo/query_engine/planner.cpp
+++ b/src/silo/query_engine/planner.cpp
@@ -8,6 +8,7 @@
 
 #include "silo/query_engine/optimizer/column_narrowing_pass.h"
 #include "silo/query_engine/optimizer/filter_pushdown_pass.h"
+#include "silo/query_engine/optimizer/map_pullup_pass.h"
 #include "silo/query_engine/optimizer/node_resolution_pass.h"
 #include "silo/query_engine/saneql/ast_to_query.h"
 #include "silo/schema/database_schema.h"
@@ -18,6 +19,7 @@ namespace {
 
 using optimizer::ColumnNarrowingPass;
 using optimizer::FilterPushdownPass;
+using optimizer::MapPullupPass;
 using optimizer::NodeResolutionPass;
 
 arrow::Result<QueryPlan> planQueryOrError(
@@ -47,6 +49,8 @@ QueryPlan Planner::planQuery(
    log_plan("initial");
    node = ColumnNarrowingPass::run(std::move(node));
    log_plan("after ColumnNarrowingPass");
+   node = MapPullupPass::run(std::move(node));
+   log_plan("after MapPullupPass");
    node = FilterPushdownPass::run(std::move(node));
    log_plan("after FilterPushdownPass");
    node = NodeResolutionPass::run(std::move(node));

--- a/src/silo/query_engine/planner.cpp
+++ b/src/silo/query_engine/planner.cpp
@@ -49,10 +49,13 @@ QueryPlan Planner::planQuery(
    log_plan("initial");
    node = ColumnNarrowingPass::run(std::move(node));
    log_plan("after ColumnNarrowingPass");
-   node = MapPullupPass::run(std::move(node));
-   log_plan("after MapPullupPass");
    node = FilterPushdownPass::run(std::move(node));
    log_plan("after FilterPushdownPass");
+   // Runs after FilterPushdownPass: removing FilterNodes can expose a Fetch(Map(...)) shape
+   // (e.g. `filter(...).limit(...)` over a decompression MapNode), which this pass can then
+   // pull up.
+   node = MapPullupPass::run(std::move(node));
+   log_plan("after MapPullupPass");
    node = NodeResolutionPass::run(std::move(node));
    log_plan("after NodeResolutionPass");
    auto result = planQueryOrError(*node, tables, query_options, request_id);


### PR DESCRIPTION
resolves #1335

### Summary

New optimizer pass `MapPullupPass` moves a `map` expression above an adjacent `limit`/`offset`
so it runs only on the rows kept, not every row. Rewrites `Fetch(Map(child)) → Map(Fetch(child))`;
the swap is always safe because `Fetch` references no columns and preserves ordering.

- **`MapPullupPass`** — pulls a `MapNode` up through a directly-adjacent `FetchNode`; blocked at every other node and at the root.
- **Wired into `Planner::planQuery`** after `FilterPushdownPass` (which can expose a `Fetch(Map(...))` shape) and before `NodeResolutionPass`.
- **Tests** — unit coverage of the swap, stacked-fetch bubbling, `Fetch(non-Map)` no-op, nested `Map(Fetch(Map))`, and all blocked nodes; one E2E (`MAP_WITH_LIMIT_TRIGGERS_PULLUP`) where a real `map({...}).limit()` query triggers the rewrite.

v1 does **not** yet move the zstd-decompression `MapNode` above a `limit`: it sits over the `TableScan` with Project/OrderBy between it and any `Fetch`. Pull-through of Filter/Project/OrderBy to reach it is deferred to #1336.

## PR Checklist

- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
