### PR TITLE
refactor(SaneQL): map pull up: pull filter nodes across map nodes

### DIFF
--- a/src/silo/query_engine/expressions/and.cpp
+++ b/src/silo/query_engine/expressions/and.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>
@@ -27,6 +28,10 @@ using filter::operators::OperatorVector;
 
 And::And(ExpressionVector&& children)
     : children(std::move(children)) {}
+
+std::vector<schema::ColumnIdentifier> And::freeIUs() const {
+   return collectFreeIUs(children);
+}
 
 std::string And::toString() const {
    std::string res = "And(";

--- a/src/silo/query_engine/expressions/and.h
+++ b/src/silo/query_engine/expressions/and.h
@@ -36,6 +36,8 @@ class And : public Expression {
    static constexpr Kind KIND = Kind::AND;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/bool_equals.cpp
+++ b/src/silo/query_engine/expressions/bool_equals.cpp
@@ -1,6 +1,7 @@
 #include "silo/query_engine/expressions/bool_equals.h"
 
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -14,6 +15,10 @@ namespace silo::query_engine::expressions {
 BoolEquals::BoolEquals(std::string column_name, std::optional<bool> value)
     : column_name(std::move(column_name)),
       value(value) {}
+
+std::vector<schema::ColumnIdentifier> BoolEquals::freeIUs() const {
+   return {{column_name, schema::ColumnType::BOOL}};
+}
 
 std::string BoolEquals::toString() const {
    if (value.has_value()) {

--- a/src/silo/query_engine/expressions/bool_equals.cpp
+++ b/src/silo/query_engine/expressions/bool_equals.cpp
@@ -17,7 +17,7 @@ BoolEquals::BoolEquals(std::string column_name, std::optional<bool> value)
       value(value) {}
 
 std::vector<schema::ColumnIdentifier> BoolEquals::freeIUs() const {
-   return {{column_name, schema::ColumnType::BOOL}};
+   return {{.name = column_name, .type = schema::ColumnType::BOOL}};
 }
 
 std::string BoolEquals::toString() const {

--- a/src/silo/query_engine/expressions/bool_equals.h
+++ b/src/silo/query_engine/expressions/bool_equals.h
@@ -24,6 +24,8 @@ struct BoolEquals : public Expression {
    static constexpr Kind KIND = Kind::BOOL_EQUALS;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/date_between.cpp
+++ b/src/silo/query_engine/expressions/date_between.cpp
@@ -4,6 +4,7 @@
 #include <limits>
 #include <map>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -30,6 +31,10 @@ DateBetween::DateBetween(
     : column_name(std::move(column_name)),
       date_from(date_from),
       date_to(date_to) {}
+
+std::vector<schema::ColumnIdentifier> DateBetween::freeIUs() const {
+   return {{column_name, schema::ColumnType::BOOL}};
+}
 
 std::string DateBetween::toString() const {
    std::string res = "[Date-between ";

--- a/src/silo/query_engine/expressions/date_between.cpp
+++ b/src/silo/query_engine/expressions/date_between.cpp
@@ -33,7 +33,7 @@ DateBetween::DateBetween(
       date_to(date_to) {}
 
 std::vector<schema::ColumnIdentifier> DateBetween::freeIUs() const {
-   return {{column_name, schema::ColumnType::BOOL}};
+   return {{.name = column_name, .type = schema::ColumnType::BOOL}};
 }
 
 std::string DateBetween::toString() const {

--- a/src/silo/query_engine/expressions/date_between.h
+++ b/src/silo/query_engine/expressions/date_between.h
@@ -37,6 +37,8 @@ class DateBetween : public Expression {
    static constexpr Kind KIND = Kind::DATE_BETWEEN;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/date_equals.cpp
+++ b/src/silo/query_engine/expressions/date_equals.cpp
@@ -22,7 +22,7 @@ DateEquals::DateEquals(std::string column_name, std::optional<silo::common::Date
       value(value) {}
 
 std::vector<schema::ColumnIdentifier> DateEquals::freeIUs() const {
-   return {{column_name, schema::ColumnType::BOOL}};
+   return {{.name = column_name, .type = schema::ColumnType::BOOL}};
 }
 
 std::string DateEquals::toString() const {

--- a/src/silo/query_engine/expressions/date_equals.cpp
+++ b/src/silo/query_engine/expressions/date_equals.cpp
@@ -1,6 +1,7 @@
 #include "silo/query_engine/expressions/date_equals.h"
 
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -19,6 +20,10 @@ namespace silo::query_engine::expressions {
 DateEquals::DateEquals(std::string column_name, std::optional<silo::common::Date32> value)
     : column_name(std::move(column_name)),
       value(value) {}
+
+std::vector<schema::ColumnIdentifier> DateEquals::freeIUs() const {
+   return {{column_name, schema::ColumnType::BOOL}};
+}
 
 std::string DateEquals::toString() const {
    if (value.has_value()) {

--- a/src/silo/query_engine/expressions/date_equals.h
+++ b/src/silo/query_engine/expressions/date_equals.h
@@ -26,6 +26,8 @@ class DateEquals : public Expression {
    static constexpr Kind KIND = Kind::DATE_EQUALS;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/exact.cpp
+++ b/src/silo/query_engine/expressions/exact.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -15,6 +16,10 @@ namespace silo::query_engine::expressions {
 
 Exact::Exact(std::unique_ptr<Expression> child)
     : child(std::move(child)) {}
+
+std::vector<schema::ColumnIdentifier> Exact::freeIUs() const {
+   return child->freeIUs();
+}
 
 std::string Exact::toString() const {
    return fmt::format("Exact ({})", child->toString());

--- a/src/silo/query_engine/expressions/exact.h
+++ b/src/silo/query_engine/expressions/exact.h
@@ -22,6 +22,8 @@ class Exact : public Expression {
    static constexpr Kind KIND = Kind::EXACT;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/expression.h
+++ b/src/silo/query_engine/expressions/expression.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>
@@ -79,8 +80,11 @@ class Expression {
    /// determine whether it is safe to reorder a node with respect to this expression.
    ///
    /// For scalar expressions (FieldRef, At, ZstdDecompressScalar) both `.name` and
-   /// `.type` of each returned identifier are accurate. For filter predicates, only
-   /// `.name` is reliable; `.type` is always `ColumnType::BOOL` (a placeholder).
+   /// `.type` of each returned identifier are accurate. Sequence predicates
+   /// (SymbolEquals, SymbolInSet, HasMutation, InsertionContains, MutationProfile) also
+   /// report an accurate sequence `.type` (NUCLEOTIDE_SEQUENCE / AMINO_ACID_SEQUENCE),
+   /// which FilterPushdownPass relies on. For all other filter predicates only `.name`
+   /// is reliable; `.type` is `ColumnType::BOOL` as a placeholder.
    [[nodiscard]] virtual std::vector<schema::ColumnIdentifier> freeIUs() const { return {}; }
 
    [[nodiscard]] virtual std::unique_ptr<Expression> rewrite(
@@ -125,14 +129,20 @@ void appendVectorToVector(
 
 using ExpressionVector = std::vector<std::unique_ptr<Expression>>;
 
-/// Union of freeIUs() across all expressions in a vector.
+/// Union of freeIUs() across all expressions in a vector, deduplicated by column name
+/// (consistent with the name-based matching used by the optimizer passes).
 [[nodiscard]] inline std::vector<schema::ColumnIdentifier> collectFreeIUs(
    const ExpressionVector& expressions
 ) {
    std::vector<schema::ColumnIdentifier> result;
    for (const auto& expr : expressions) {
       for (const auto& col : expr->freeIUs()) {
-         result.push_back(col);
+         const bool already_present = std::ranges::any_of(result, [&](const auto& existing) {
+            return existing.name == col.name;
+         });
+         if (!already_present) {
+            result.push_back(col);
+         }
       }
    }
    return result;

--- a/src/silo/query_engine/expressions/expression.h
+++ b/src/silo/query_engine/expressions/expression.h
@@ -75,7 +75,12 @@ class Expression {
    /// The columns ("identifiable units") this expression references and that an
    /// upstream node must therefore provide. Literals reference none; a column
    /// reference yields that column. Used by column narrowing to keep the child
-   /// columns a scalar expression depends on alive.
+   /// columns a scalar expression depends on alive, and by optimizer passes to
+   /// determine whether it is safe to reorder a node with respect to this expression.
+   ///
+   /// For scalar expressions (FieldRef, At, ZstdDecompressScalar) both `.name` and
+   /// `.type` of each returned identifier are accurate. For filter predicates, only
+   /// `.name` is reliable; `.type` is always `ColumnType::BOOL` (a placeholder).
    [[nodiscard]] virtual std::vector<schema::ColumnIdentifier> freeIUs() const { return {}; }
 
    [[nodiscard]] virtual std::unique_ptr<Expression> rewrite(
@@ -119,5 +124,18 @@ void appendVectorToVector(
 }
 
 using ExpressionVector = std::vector<std::unique_ptr<Expression>>;
+
+/// Union of freeIUs() across all expressions in a vector.
+[[nodiscard]] inline std::vector<schema::ColumnIdentifier> collectFreeIUs(
+   const ExpressionVector& expressions
+) {
+   std::vector<schema::ColumnIdentifier> result;
+   for (const auto& expr : expressions) {
+      for (const auto& col : expr->freeIUs()) {
+         result.push_back(col);
+      }
+   }
+   return result;
+}
 
 }  // namespace silo::query_engine::expressions

--- a/src/silo/query_engine/expressions/float_between.cpp
+++ b/src/silo/query_engine/expressions/float_between.cpp
@@ -27,7 +27,7 @@ FloatBetween::FloatBetween(
       to(to) {}
 
 std::vector<schema::ColumnIdentifier> FloatBetween::freeIUs() const {
-   return {{column_name, schema::ColumnType::BOOL}};
+   return {{.name = column_name, .type = schema::ColumnType::BOOL}};
 }
 
 std::string FloatBetween::toString() const {

--- a/src/silo/query_engine/expressions/float_between.cpp
+++ b/src/silo/query_engine/expressions/float_between.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "silo/query_engine/expressions/expression.h"
 #include "silo/query_engine/filter/operators/complement.h"
@@ -24,6 +25,10 @@ FloatBetween::FloatBetween(
     : column_name(std::move(column_name)),
       from(from),
       to(to) {}
+
+std::vector<schema::ColumnIdentifier> FloatBetween::freeIUs() const {
+   return {{column_name, schema::ColumnType::BOOL}};
+}
 
 std::string FloatBetween::toString() const {
    const auto from_string = from.has_value() ? std::to_string(from.value()) : "unbounded";

--- a/src/silo/query_engine/expressions/float_between.h
+++ b/src/silo/query_engine/expressions/float_between.h
@@ -30,6 +30,8 @@ class FloatBetween : public Expression {
    static constexpr Kind KIND = Kind::FLOAT_BETWEEN;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/float_equals.cpp
+++ b/src/silo/query_engine/expressions/float_equals.cpp
@@ -22,7 +22,7 @@ FloatEquals::FloatEquals(std::string column_name, std::optional<double> value)
       value(value) {}
 
 std::vector<schema::ColumnIdentifier> FloatEquals::freeIUs() const {
-   return {{column_name, schema::ColumnType::BOOL}};
+   return {{.name = column_name, .type = schema::ColumnType::BOOL}};
 }
 
 std::string FloatEquals::toString() const {

--- a/src/silo/query_engine/expressions/float_equals.cpp
+++ b/src/silo/query_engine/expressions/float_equals.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -19,6 +20,10 @@ namespace silo::query_engine::expressions {
 FloatEquals::FloatEquals(std::string column_name, std::optional<double> value)
     : column_name(std::move(column_name)),
       value(value) {}
+
+std::vector<schema::ColumnIdentifier> FloatEquals::freeIUs() const {
+   return {{column_name, schema::ColumnType::BOOL}};
+}
 
 std::string FloatEquals::toString() const {
    if (value.has_value()) {

--- a/src/silo/query_engine/expressions/float_equals.h
+++ b/src/silo/query_engine/expressions/float_equals.h
@@ -24,6 +24,8 @@ class FloatEquals : public Expression {
    static constexpr Kind KIND = Kind::FLOAT_EQUALS;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/has_mutation.h
+++ b/src/silo/query_engine/expressions/has_mutation.h
@@ -35,6 +35,16 @@ class HasMutation : public Expression {
                                    : Kind::HAS_MUTATION_AMINO_ACID;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override {
+      const auto col_type = std::is_same_v<SymbolType, Nucleotide>
+                               ? schema::ColumnType::NUCLEOTIDE_SEQUENCE
+                               : schema::ColumnType::AMINO_ACID_SEQUENCE;
+      // When sequence_name is nullopt the actual name is resolved from the schema at
+      // rewrite() time; we return an empty name as a safe placeholder (it cannot match
+      // any real column name in a MapNode assignment).
+      return {{sequence_name.value_or(""), col_type}};
+   }
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/has_mutation.h
+++ b/src/silo/query_engine/expressions/has_mutation.h
@@ -42,7 +42,7 @@ class HasMutation : public Expression {
       // When sequence_name is nullopt the actual name is resolved from the schema at
       // rewrite() time; we return an empty name as a safe placeholder (it cannot match
       // any real column name in a MapNode assignment).
-      return {{sequence_name.value_or(""), col_type}};
+      return {{.name = sequence_name.value_or(""), .type = col_type}};
    }
 
    [[nodiscard]] std::unique_ptr<Expression> rewrite(

--- a/src/silo/query_engine/expressions/insertion_contains.h
+++ b/src/silo/query_engine/expressions/insertion_contains.h
@@ -44,7 +44,7 @@ class InsertionContains : public Expression {
       const auto col_type = std::is_same_v<SymbolType, Nucleotide>
                                ? schema::ColumnType::NUCLEOTIDE_SEQUENCE
                                : schema::ColumnType::AMINO_ACID_SEQUENCE;
-      return {{sequence_name.value_or(""), col_type}};
+      return {{.name = sequence_name.value_or(""), .type = col_type}};
    }
 
    [[nodiscard]] std::unique_ptr<Expression> rewrite(

--- a/src/silo/query_engine/expressions/insertion_contains.h
+++ b/src/silo/query_engine/expressions/insertion_contains.h
@@ -40,6 +40,13 @@ class InsertionContains : public Expression {
                                    : Kind::INSERTION_CONTAINS_AMINO_ACID;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override {
+      const auto col_type = std::is_same_v<SymbolType, Nucleotide>
+                               ? schema::ColumnType::NUCLEOTIDE_SEQUENCE
+                               : schema::ColumnType::AMINO_ACID_SEQUENCE;
+      return {{sequence_name.value_or(""), col_type}};
+   }
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/int_between.cpp
+++ b/src/silo/query_engine/expressions/int_between.cpp
@@ -30,7 +30,7 @@ IntBetween::IntBetween(
       to(to) {}
 
 std::vector<schema::ColumnIdentifier> IntBetween::freeIUs() const {
-   return {{column_name, schema::ColumnType::BOOL}};
+   return {{.name = column_name, .type = schema::ColumnType::BOOL}};
 }
 
 std::string IntBetween::toString() const {

--- a/src/silo/query_engine/expressions/int_between.cpp
+++ b/src/silo/query_engine/expressions/int_between.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
@@ -27,6 +28,10 @@ IntBetween::IntBetween(
     : column_name(std::move(column_name)),
       from(from),
       to(to) {}
+
+std::vector<schema::ColumnIdentifier> IntBetween::freeIUs() const {
+   return {{column_name, schema::ColumnType::BOOL}};
+}
 
 std::string IntBetween::toString() const {
    const auto from_string = from.has_value() ? std::to_string(from.value()) : "unbounded";

--- a/src/silo/query_engine/expressions/int_between.h
+++ b/src/silo/query_engine/expressions/int_between.h
@@ -33,6 +33,8 @@ class IntBetween : public Expression {
    static constexpr Kind KIND = Kind::INT_BETWEEN;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/int_equals.cpp
+++ b/src/silo/query_engine/expressions/int_equals.cpp
@@ -1,6 +1,7 @@
 #include "silo/query_engine/expressions/int_equals.h"
 
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
@@ -18,6 +19,10 @@ namespace silo::query_engine::expressions {
 IntEquals::IntEquals(std::string column_name, std::optional<int32_t> value)
     : column_name(std::move(column_name)),
       value(value) {}
+
+std::vector<schema::ColumnIdentifier> IntEquals::freeIUs() const {
+   return {{column_name, schema::ColumnType::BOOL}};
+}
 
 std::string IntEquals::toString() const {
    if (value.has_value()) {

--- a/src/silo/query_engine/expressions/int_equals.cpp
+++ b/src/silo/query_engine/expressions/int_equals.cpp
@@ -21,7 +21,7 @@ IntEquals::IntEquals(std::string column_name, std::optional<int32_t> value)
       value(value) {}
 
 std::vector<schema::ColumnIdentifier> IntEquals::freeIUs() const {
-   return {{column_name, schema::ColumnType::BOOL}};
+   return {{.name = column_name, .type = schema::ColumnType::BOOL}};
 }
 
 std::string IntEquals::toString() const {

--- a/src/silo/query_engine/expressions/int_equals.h
+++ b/src/silo/query_engine/expressions/int_equals.h
@@ -27,6 +27,8 @@ class IntEquals : public Expression {
    static constexpr Kind KIND = Kind::INT_EQUALS;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/is_null.cpp
+++ b/src/silo/query_engine/expressions/is_null.cpp
@@ -18,7 +18,7 @@ IsNull::IsNull(std::string column_name)
     : column_name(std::move(column_name)) {}
 
 std::vector<schema::ColumnIdentifier> IsNull::freeIUs() const {
-   return {{column_name, schema::ColumnType::BOOL}};
+   return {{.name = column_name, .type = schema::ColumnType::BOOL}};
 }
 
 std::string IsNull::toString() const {

--- a/src/silo/query_engine/expressions/is_null.cpp
+++ b/src/silo/query_engine/expressions/is_null.cpp
@@ -1,6 +1,7 @@
 #include "silo/query_engine/expressions/is_null.h"
 
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -15,6 +16,10 @@ namespace silo::query_engine::expressions {
 
 IsNull::IsNull(std::string column_name)
     : column_name(std::move(column_name)) {}
+
+std::vector<schema::ColumnIdentifier> IsNull::freeIUs() const {
+   return {{column_name, schema::ColumnType::BOOL}};
+}
 
 std::string IsNull::toString() const {
    return fmt::format("{} IS NULL", column_name);

--- a/src/silo/query_engine/expressions/is_null.h
+++ b/src/silo/query_engine/expressions/is_null.h
@@ -23,6 +23,8 @@ class IsNull : public Expression {
    static constexpr Kind KIND = Kind::IS_NULL;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/lineage_filter.cpp
+++ b/src/silo/query_engine/expressions/lineage_filter.cpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <ranges>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>
@@ -26,6 +27,10 @@ LineageFilter::LineageFilter(
     : column_name(std::move(column_name)),
       lineage(std::move(lineage)),
       sublineage_mode(sublineage_mode) {}
+
+std::vector<schema::ColumnIdentifier> LineageFilter::freeIUs() const {
+   return {{column_name, schema::ColumnType::BOOL}};
+}
 
 std::string LineageFilter::toString() const {
    if (!lineage.has_value()) {

--- a/src/silo/query_engine/expressions/lineage_filter.cpp
+++ b/src/silo/query_engine/expressions/lineage_filter.cpp
@@ -29,7 +29,7 @@ LineageFilter::LineageFilter(
       sublineage_mode(sublineage_mode) {}
 
 std::vector<schema::ColumnIdentifier> LineageFilter::freeIUs() const {
-   return {{column_name, schema::ColumnType::BOOL}};
+   return {{.name = column_name, .type = schema::ColumnType::BOOL}};
 }
 
 std::string LineageFilter::toString() const {

--- a/src/silo/query_engine/expressions/lineage_filter.h
+++ b/src/silo/query_engine/expressions/lineage_filter.h
@@ -30,6 +30,8 @@ class LineageFilter : public Expression {
    static constexpr Kind KIND = Kind::LINEAGE_FILTER;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/maybe.cpp
+++ b/src/silo/query_engine/expressions/maybe.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -15,6 +16,10 @@ namespace silo::query_engine::expressions {
 
 Maybe::Maybe(std::unique_ptr<Expression> child)
     : child(std::move(child)) {}
+
+std::vector<schema::ColumnIdentifier> Maybe::freeIUs() const {
+   return child->freeIUs();
+}
 
 std::string Maybe::toString() const {
    return "Maybe (" + child->toString() + ")";

--- a/src/silo/query_engine/expressions/maybe.h
+++ b/src/silo/query_engine/expressions/maybe.h
@@ -24,6 +24,8 @@ class Maybe : public Expression {
    static constexpr Kind KIND = Kind::MAYBE;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/mutation_profile.h
+++ b/src/silo/query_engine/expressions/mutation_profile.h
@@ -79,6 +79,13 @@ class MutationProfile : public Expression {
                                    : Kind::MUTATION_PROFILE_AMINO_ACID;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override {
+      const auto col_type = std::is_same_v<SymbolType, Nucleotide>
+                               ? schema::ColumnType::NUCLEOTIDE_SEQUENCE
+                               : schema::ColumnType::AMINO_ACID_SEQUENCE;
+      return {{sequence_name.value_or(""), col_type}};
+   }
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/mutation_profile.h
+++ b/src/silo/query_engine/expressions/mutation_profile.h
@@ -83,7 +83,7 @@ class MutationProfile : public Expression {
       const auto col_type = std::is_same_v<SymbolType, Nucleotide>
                                ? schema::ColumnType::NUCLEOTIDE_SEQUENCE
                                : schema::ColumnType::AMINO_ACID_SEQUENCE;
-      return {{sequence_name.value_or(""), col_type}};
+      return {{.name = sequence_name.value_or(""), .type = col_type}};
    }
 
    [[nodiscard]] std::unique_ptr<Expression> rewrite(

--- a/src/silo/query_engine/expressions/negation.cpp
+++ b/src/silo/query_engine/expressions/negation.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -14,6 +15,10 @@ namespace silo::query_engine::expressions {
 
 Negation::Negation(std::unique_ptr<Expression> child)
     : child(std::move(child)) {}
+
+std::vector<schema::ColumnIdentifier> Negation::freeIUs() const {
+   return child->freeIUs();
+}
 
 std::string Negation::toString() const {
    return "!(" + child->toString() + ")";

--- a/src/silo/query_engine/expressions/negation.h
+++ b/src/silo/query_engine/expressions/negation.h
@@ -27,6 +27,8 @@ class Negation : public Expression {
    static constexpr Kind KIND = Kind::NEGATION;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/nof.cpp
+++ b/src/silo/query_engine/expressions/nof.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "silo/common/string_utils.h"
 #include "silo/query_engine/expressions/and.h"
@@ -156,6 +157,10 @@ NOf::NOf(ExpressionVector&& children, int number_of_matchers, bool match_exactly
     : children(std::move(children)),
       number_of_matchers(number_of_matchers),
       match_exactly(match_exactly) {}
+
+std::vector<schema::ColumnIdentifier> NOf::freeIUs() const {
+   return collectFreeIUs(children);
+}
 
 std::string NOf::toString() const {
    std::string res;

--- a/src/silo/query_engine/expressions/nof.h
+++ b/src/silo/query_engine/expressions/nof.h
@@ -45,6 +45,8 @@ class NOf : public Expression {
    static constexpr Kind KIND = Kind::N_OF;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/or.cpp
+++ b/src/silo/query_engine/expressions/or.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "silo/common/string_utils.h"
 #include "silo/query_engine/expressions/expression.h"
@@ -22,6 +23,10 @@ using filter::operators::OperatorVector;
 
 Or::Or(ExpressionVector&& children)
     : children(std::move(children)) {}
+
+std::vector<schema::ColumnIdentifier> Or::freeIUs() const {
+   return collectFreeIUs(children);
+}
 
 std::string Or::toString() const {
    std::string res = "Or(";

--- a/src/silo/query_engine/expressions/or.h
+++ b/src/silo/query_engine/expressions/or.h
@@ -27,6 +27,8 @@ class Or : public Expression {
    static constexpr Kind KIND = Kind::OR;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/phylo_child_filter.cpp
+++ b/src/silo/query_engine/expressions/phylo_child_filter.cpp
@@ -19,7 +19,7 @@ PhyloChildFilter::PhyloChildFilter(std::string column_name, std::string internal
       internal_node(std::move(internal_node)) {}
 
 std::vector<schema::ColumnIdentifier> PhyloChildFilter::freeIUs() const {
-   return {{column_name, schema::ColumnType::BOOL}};
+   return {{.name = column_name, .type = schema::ColumnType::BOOL}};
 }
 
 std::string PhyloChildFilter::toString() const {

--- a/src/silo/query_engine/expressions/phylo_child_filter.cpp
+++ b/src/silo/query_engine/expressions/phylo_child_filter.cpp
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -16,6 +17,10 @@ namespace silo::query_engine::expressions {
 PhyloChildFilter::PhyloChildFilter(std::string column_name, std::string internal_node)
     : column_name(std::move(column_name)),
       internal_node(std::move(internal_node)) {}
+
+std::vector<schema::ColumnIdentifier> PhyloChildFilter::freeIUs() const {
+   return {{column_name, schema::ColumnType::BOOL}};
+}
 
 std::string PhyloChildFilter::toString() const {
    return fmt::format("column {} phylo_child_of {}", column_name, internal_node);

--- a/src/silo/query_engine/expressions/phylo_child_filter.h
+++ b/src/silo/query_engine/expressions/phylo_child_filter.h
@@ -23,6 +23,8 @@ class PhyloChildFilter : public Expression {
    static constexpr Kind KIND = Kind::PHYLO_CHILD_FILTER;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/string_equals.cpp
+++ b/src/silo/query_engine/expressions/string_equals.cpp
@@ -22,7 +22,7 @@ StringEquals::StringEquals(std::string column_name, std::optional<std::string> v
       value(std::move(value)) {}
 
 std::vector<schema::ColumnIdentifier> StringEquals::freeIUs() const {
-   return {{column_name, schema::ColumnType::BOOL}};
+   return {{.name = column_name, .type = schema::ColumnType::BOOL}};
 }
 
 std::string StringEquals::toString() const {

--- a/src/silo/query_engine/expressions/string_equals.cpp
+++ b/src/silo/query_engine/expressions/string_equals.cpp
@@ -3,6 +3,7 @@
 
 #include <optional>
 #include <utility>
+#include <vector>
 
 #include "silo/common/panic.h"
 #include "silo/query_engine/expressions/expression.h"
@@ -19,6 +20,10 @@ namespace silo::query_engine::expressions {
 StringEquals::StringEquals(std::string column_name, std::optional<std::string> value)
     : column_name(std::move(column_name)),
       value(std::move(value)) {}
+
+std::vector<schema::ColumnIdentifier> StringEquals::freeIUs() const {
+   return {{column_name, schema::ColumnType::BOOL}};
+}
 
 std::string StringEquals::toString() const {
    if (value.has_value()) {

--- a/src/silo/query_engine/expressions/string_equals.h
+++ b/src/silo/query_engine/expressions/string_equals.h
@@ -24,6 +24,8 @@ class StringEquals : public Expression {
    static constexpr Kind KIND = Kind::STRING_EQUALS;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/string_in_set.cpp
+++ b/src/silo/query_engine/expressions/string_in_set.cpp
@@ -1,6 +1,7 @@
 #include "silo/query_engine/expressions/string_in_set.h"
 
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>
@@ -23,6 +24,10 @@ using storage::column::StringColumn;
 StringInSet::StringInSet(std::string column_name, std::unordered_set<std::string> values)
     : column_name(std::move(column_name)),
       values(std::move(values)) {}
+
+std::vector<schema::ColumnIdentifier> StringInSet::freeIUs() const {
+   return {{column_name, schema::ColumnType::BOOL}};
+}
 
 std::string StringInSet::toString() const {
    std::vector<std::string> sorted_values;

--- a/src/silo/query_engine/expressions/string_in_set.cpp
+++ b/src/silo/query_engine/expressions/string_in_set.cpp
@@ -26,7 +26,7 @@ StringInSet::StringInSet(std::string column_name, std::unordered_set<std::string
       values(std::move(values)) {}
 
 std::vector<schema::ColumnIdentifier> StringInSet::freeIUs() const {
-   return {{column_name, schema::ColumnType::BOOL}};
+   return {{.name = column_name, .type = schema::ColumnType::BOOL}};
 }
 
 std::string StringInSet::toString() const {

--- a/src/silo/query_engine/expressions/string_in_set.h
+++ b/src/silo/query_engine/expressions/string_in_set.h
@@ -29,6 +29,8 @@ class StringInSet : public Expression {
    static constexpr Kind KIND = Kind::STRING_IN_SET;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/string_search.cpp
+++ b/src/silo/query_engine/expressions/string_search.cpp
@@ -1,6 +1,7 @@
 #include "silo/query_engine/expressions/string_search.h"
 
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -15,6 +16,10 @@ namespace silo::query_engine::expressions {
 StringSearch::StringSearch(std::string column_name, std::unique_ptr<re2::RE2> search_expression)
     : column_name(std::move(column_name)),
       search_expression(std::move(search_expression)) {}
+
+std::vector<schema::ColumnIdentifier> StringSearch::freeIUs() const {
+   return {{column_name, schema::ColumnType::BOOL}};
+}
 
 std::string StringSearch::toString() const {
    return fmt::format("column {} regex_matches \"{}\"", column_name, search_expression->pattern());

--- a/src/silo/query_engine/expressions/string_search.cpp
+++ b/src/silo/query_engine/expressions/string_search.cpp
@@ -18,7 +18,7 @@ StringSearch::StringSearch(std::string column_name, std::unique_ptr<re2::RE2> se
       search_expression(std::move(search_expression)) {}
 
 std::vector<schema::ColumnIdentifier> StringSearch::freeIUs() const {
-   return {{column_name, schema::ColumnType::BOOL}};
+   return {{.name = column_name, .type = schema::ColumnType::BOOL}};
 }
 
 std::string StringSearch::toString() const {

--- a/src/silo/query_engine/expressions/string_search.h
+++ b/src/silo/query_engine/expressions/string_search.h
@@ -29,6 +29,8 @@ class StringSearch : public Expression {
    static constexpr Kind KIND = Kind::STRING_SEARCH;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/symbol_equals.h
+++ b/src/silo/query_engine/expressions/symbol_equals.h
@@ -57,6 +57,13 @@ class SymbolEquals : public Expression {
                                    : Kind::SYMBOL_EQUALS_AMINO_ACID;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override {
+      const auto col_type = std::is_same_v<SymbolType, Nucleotide>
+                               ? schema::ColumnType::NUCLEOTIDE_SEQUENCE
+                               : schema::ColumnType::AMINO_ACID_SEQUENCE;
+      return {{sequence_name.value_or(""), col_type}};
+   }
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/symbol_equals.h
+++ b/src/silo/query_engine/expressions/symbol_equals.h
@@ -61,7 +61,7 @@ class SymbolEquals : public Expression {
       const auto col_type = std::is_same_v<SymbolType, Nucleotide>
                                ? schema::ColumnType::NUCLEOTIDE_SEQUENCE
                                : schema::ColumnType::AMINO_ACID_SEQUENCE;
-      return {{sequence_name.value_or(""), col_type}};
+      return {{.name = sequence_name.value_or(""), .type = col_type}};
    }
 
    [[nodiscard]] std::unique_ptr<Expression> rewrite(

--- a/src/silo/query_engine/expressions/symbol_in_set.h
+++ b/src/silo/query_engine/expressions/symbol_in_set.h
@@ -43,6 +43,13 @@ class SymbolInSet : public Expression {
                                    : Kind::SYMBOL_IN_SET_AMINO_ACID;
    [[nodiscard]] Kind kind() const override { return KIND; }
 
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override {
+      const auto col_type = std::is_same_v<SymbolType, Nucleotide>
+                               ? schema::ColumnType::NUCLEOTIDE_SEQUENCE
+                               : schema::ColumnType::AMINO_ACID_SEQUENCE;
+      return {{sequence_name.value_or(""), col_type}};
+   }
+
    [[nodiscard]] std::unique_ptr<Expression> rewrite(
       const storage::Table& table,
       AmbiguityMode mode

--- a/src/silo/query_engine/expressions/symbol_in_set.h
+++ b/src/silo/query_engine/expressions/symbol_in_set.h
@@ -47,7 +47,7 @@ class SymbolInSet : public Expression {
       const auto col_type = std::is_same_v<SymbolType, Nucleotide>
                                ? schema::ColumnType::NUCLEOTIDE_SEQUENCE
                                : schema::ColumnType::AMINO_ACID_SEQUENCE;
-      return {{sequence_name.value_or(""), col_type}};
+      return {{.name = sequence_name.value_or(""), .type = col_type}};
    }
 
    [[nodiscard]] std::unique_ptr<Expression> rewrite(

--- a/src/silo/query_engine/optimizer/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "silo/query_engine/operators/aggregate_node.h"
+#include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
 #include "silo/query_engine/operators/project_node.h"
@@ -151,6 +152,24 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::OrderByNode& 
    for (const auto& field : node.fields) {
       if (std::ranges::find(required, field.field) == required.end()) {
          required.push_back(field.field);
+      }
+   }
+   propagateToNode(node.child);
+   return nullptr;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::FilterNode& node) {
+   // A FilterNode passes through all of its child's columns but its predicate references
+   // some of them. Those referenced columns must be kept alive in the child (e.g. a Map
+   // assignment that produces a column the predicate filters on must not be pruned).
+   // Columns are deduplicated by name, consistent with the rest of the pass.
+   for (const auto& referenced_column : node.filter->freeIUs()) {
+      const bool already_required = std::ranges::any_of(required, [&](const auto& existing) {
+         return existing.name == referenced_column.name;
+      });
+      if (!already_required) {
+         required.push_back(referenced_column);
       }
    }
    propagateToNode(node.child);

--- a/src/silo/query_engine/optimizer/column_narrowing_pass.h
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.h
@@ -12,6 +12,7 @@ class AggregateNode;
 class ProjectNode;
 class MapNode;
 class OrderByNode;
+class FilterNode;
 class UnionAllNode;
 }  // namespace silo::query_engine::operators
 
@@ -40,6 +41,7 @@ class ColumnNarrowingPass : public PipelinePassBase<ColumnNarrowingPass> {
    operators::QueryNodePtr operator()(operators::ProjectNode& node);
    operators::QueryNodePtr operator()(operators::MapNode& node);
    operators::QueryNodePtr operator()(operators::OrderByNode& node);
+   operators::QueryNodePtr operator()(operators::FilterNode& node);
    operators::QueryNodePtr operator()(operators::UnionAllNode& node);
 };
 

--- a/src/silo/query_engine/optimizer/column_narrowing_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.test.cpp
@@ -11,6 +11,7 @@
 
 #include "silo/query_engine/expressions/field_ref.h"
 #include "silo/query_engine/expressions/literal.h"
+#include "silo/query_engine/expressions/string_equals.h"
 #include "silo/query_engine/expressions/zstd_decompress_scalar.h"
 #include "silo/query_engine/operators/aggregate_node.h"
 #include "silo/query_engine/operators/fetch_node.h"
@@ -402,6 +403,61 @@ TEST(ColumnNarrowingPassFilter, propagatesRequiredThroughFilter) {
    pass(*filter);
 
    EXPECT_THAT(scanSchema(leafScan(*filter)), ::testing::ElementsAre(col("b")));
+}
+
+// FilterNode whose predicate references a Map-produced column that is NOT in the
+// required set from above (e.g. Project only needs "id", filter needs "seq").
+//
+// Tree:   Project({id}) → Filter(seq='X') → Map(seq := decompress(seq_compressed)) → Scan
+//
+// The `seq` decompression assignment is NOT required by the Project, so narrowing
+// would naively prune it. But the FilterNode's predicate references `seq`, so the
+// assignment MUST be kept alive.
+//
+// Currently FAILS: ColumnNarrowingPass has no FilterNode override and does not add
+// predicate column references to `required` before descending.
+TEST(ColumnNarrowingPassFilter, keepsMapAssignmentRequiredByFilterPredicate) {
+   const auto seq_compressed = colWithType("seq", ColumnType::ZSTD_COMPRESSED_STRING);
+   const auto id_col = col("id");
+
+   auto scan = makeScan({seq_compressed, id_col});
+   operators::QueryNodePtr node =
+      std::make_unique<operators::MapNode>(std::move(scan), decompressAssignments(seq_compressed));
+
+   // Filter predicate references `seq` — the Map-produced STRING column.
+   node = std::make_unique<operators::FilterNode>(
+      std::move(node),
+      std::make_unique<silo::query_engine::expressions::StringEquals>(
+         "seq", std::optional<std::string>{"ACGT"}
+      )
+   );
+
+   // Project only requires "id" — not "seq".
+   operators::QueryNodePtr root =
+      std::make_unique<operators::ProjectNode>(std::move(node), std::vector{id_col});
+
+   root = ColumnNarrowingPass::run(std::move(root));
+
+   // Walk past any ProjectNode (narrowing may collapse it) to find the FilterNode.
+   operators::QueryNode* cur = root.get();
+   if (auto* proj = dynamic_cast<operators::ProjectNode*>(cur)) {
+      cur = proj->child.get();
+   }
+
+   // The FilterNode must still exist above the MapNode.
+   const auto* filter = dynamic_cast<operators::FilterNode*>(cur);
+   ASSERT_NE(filter, nullptr) << "FilterNode was unexpectedly removed";
+
+   // The MapNode must still exist and its decompression assignment must not have been
+   // pruned, because the FilterNode above it references the `seq` column it produces.
+   const auto* map = dynamic_cast<operators::MapNode*>(filter->child.get());
+   ASSERT_NE(map, nullptr)
+      << "ColumnNarrowingPass incorrectly pruned the MapNode whose assignment is "
+         "referenced by the FilterNode predicate";
+   EXPECT_FALSE(map->assignments.empty())
+      << "ColumnNarrowingPass incorrectly pruned the `seq` decompression assignment "
+         "needed by the FilterNode predicate (bug: filter predicate columns not added "
+         "to `required` before descending into Map)";
 }
 
 // --- MapNode -> TableScanNode ---

--- a/src/silo/query_engine/optimizer/column_narrowing_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.test.cpp
@@ -412,10 +412,8 @@ TEST(ColumnNarrowingPassFilter, propagatesRequiredThroughFilter) {
 //
 // The `seq` decompression assignment is NOT required by the Project, so narrowing
 // would naively prune it. But the FilterNode's predicate references `seq`, so the
-// assignment MUST be kept alive.
-//
-// Currently FAILS: ColumnNarrowingPass has no FilterNode override and does not add
-// predicate column references to `required` before descending.
+// assignment MUST be kept alive (ColumnNarrowingPass's FilterNode override adds the
+// predicate's referenced columns to `required` before descending into the Map).
 TEST(ColumnNarrowingPassFilter, keepsMapAssignmentRequiredByFilterPredicate) {
    const auto seq_compressed = colWithType("seq", ColumnType::ZSTD_COMPRESSED_STRING);
    const auto id_col = col("id");

--- a/src/silo/query_engine/optimizer/column_narrowing_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.test.cpp
@@ -451,9 +451,10 @@ TEST(ColumnNarrowingPassFilter, keepsMapAssignmentRequiredByFilterPredicate) {
    // The MapNode must still exist and its decompression assignment must not have been
    // pruned, because the FilterNode above it references the `seq` column it produces.
    const auto* map = dynamic_cast<operators::MapNode*>(filter->child.get());
-   ASSERT_NE(map, nullptr)
-      << "ColumnNarrowingPass incorrectly pruned the MapNode whose assignment is "
-         "referenced by the FilterNode predicate";
+   ASSERT_NE(
+      map, nullptr
+   ) << "ColumnNarrowingPass incorrectly pruned the MapNode whose assignment is "
+        "referenced by the FilterNode predicate";
    EXPECT_FALSE(map->assignments.empty())
       << "ColumnNarrowingPass incorrectly pruned the `seq` decompression assignment "
          "needed by the FilterNode predicate (bug: filter predicate columns not added "

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
@@ -1,15 +1,21 @@
 #include "silo/query_engine/optimizer/filter_pushdown_pass.h"
 
+#include <algorithm>
+#include <utility>
+#include <vector>
+
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/query_engine/expressions/and.h"
 #include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/insertions_node.h"
+#include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/mutations_node.h"
 #include "silo/query_engine/operators/phylo_subtree_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
+#include "silo/schema/database_schema.h"
 
 namespace silo::query_engine::optimizer {
 
@@ -19,6 +25,64 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::FilterNode& no
    auto child = std::move(node.child);
    propagateToNode(child);
    return child;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr FilterPushdownPass::operator()(operators::MapNode& node) {
+   // A MapNode produces (or replaces) columns via scalar assignments. A filter whose
+   // predicate consumes a produced column MUST NOT be pushed below this Map: below the Map
+   // that produced value does not exist yet. The motivating case is the decompression Map,
+   // which produces a STRING `seq` from a sequence-typed `seq` of the same name. A filter
+   // on the decompressed STRING (e.g. StringEquals) must stay above the Map; a filter that
+   // consumes the underlying sequence column directly (e.g. SymbolEquals / HasMutation,
+   // which compile to bitmap operators on the sequence-typed storage) must still push down
+   // to the scan.
+   //
+   // We distinguish the two by the type the predicate reports for the column in freeIUs:
+   // sequence predicates report the sequence type (they reference the Map's input column,
+   // which survives below the Map), while predicates that operate on the produced STRING
+   // report a non-sequence placeholder type. So a filter is dependent (stays above) only
+   // when it references a produced column name with a non-sequence type.
+   const auto references_produced_column =
+      [&](const std::unique_ptr<expressions::Expression>& filter) {
+         const auto referenced = filter->freeIUs();
+         return std::ranges::any_of(node.assignments, [&](const auto& assignment) {
+            return std::ranges::any_of(referenced, [&](const auto& column) {
+               return column.name == assignment.output_column.name &&
+                      !schema::isSequenceColumn(column.type);
+            });
+         });
+      };
+
+   std::vector<std::unique_ptr<expressions::Expression>> dependent_filters;
+   std::vector<std::unique_ptr<expressions::Expression>> independent_filters;
+   for (auto& filter : current_filters) {
+      if (references_produced_column(filter)) {
+         dependent_filters.push_back(std::move(filter));
+      } else {
+         independent_filters.push_back(std::move(filter));
+      }
+   }
+
+   // Only the independent filters keep flowing down past the Map.
+   current_filters = std::move(independent_filters);
+   propagateToNode(node.child);
+
+   if (dependent_filters.empty()) {
+      return nullptr;
+   }
+
+   // Re-erect the filters that depend on produced columns as a single FilterNode directly
+   // above the Map, AND-merging when there is more than one.
+   std::unique_ptr<expressions::Expression> surviving_filter =
+      std::make_unique<expressions::And>(std::move(dependent_filters));
+
+   // Returning a replacement node swaps out the visited MapNode. Move the visited Map's
+   // contents into a fresh MapNode and return Filter(Map(child)), keeping the dependent
+   // filters above the Map.
+   auto map =
+      std::make_unique<operators::MapNode>(std::move(node.child), std::move(node.assignments));
+   return std::make_unique<operators::FilterNode>(std::move(map), std::move(surviving_filter));
 }
 
 operators::QueryNodePtr FilterPushdownPass::operator()(operators::TableScanNode& node) {

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
@@ -72,10 +72,11 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::MapNode& node)
       return nullptr;
    }
 
-   // Re-erect the filters that depend on produced columns as a single FilterNode directly
-   // above the Map, AND-merging when there is more than one.
+   // Re-erect the filters that depend on produced columns as FilterNode directly above the Map
    std::unique_ptr<expressions::Expression> surviving_filter =
-      std::make_unique<expressions::And>(std::move(dependent_filters));
+      dependent_filters.size() == 1
+         ? std::move(dependent_filters.front())
+         : std::make_unique<expressions::And>(std::move(dependent_filters));
 
    // Returning a replacement node swaps out the visited MapNode. Move the visited Map's
    // contents into a fresh MapNode and return Filter(Map(child)), keeping the dependent

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.h
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.h
@@ -6,6 +6,7 @@
 
 namespace silo::query_engine::operators {
 class FilterNode;
+class MapNode;
 class TableScanNode;
 template <typename SymbolType>
 class MutationsNode;
@@ -27,6 +28,7 @@ class FilterPushdownPass : public PipelinePassBase<FilterPushdownPass> {
    using PipelinePassBase<FilterPushdownPass>::operator();
 
    operators::QueryNodePtr operator()(operators::FilterNode& node);
+   operators::QueryNodePtr operator()(operators::MapNode& node);
 
    operators::QueryNodePtr operator()(operators::TableScanNode& node);
    operators::QueryNodePtr operator()(operators::MutationsNode<Nucleotide>& node);

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.test.cpp
@@ -7,6 +7,8 @@
 #include <gtest/gtest.h>
 
 #include "silo/query_engine/expressions/literal.h"
+#include "silo/query_engine/expressions/string_equals.h"
+#include "silo/query_engine/expressions/zstd_decompress_scalar.h"
 #include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/project_node.h"
@@ -160,6 +162,59 @@ TEST(FilterPushdownPass, pushesFilterIntoBothUnionAllBranches) {
    // outer filter (true) + branch filter (false/true) + scan filter (true)
    EXPECT_EQ(left_scan->filter->toString(), "And(true & false & true)");
    EXPECT_EQ(right_scan->filter->toString(), "And(true & true & true)");
+}
+
+// --- Filter(predicate on Map-produced col) → Map(produces col) → Scan ---
+//
+// The filter predicate references `seq`, which is the OUTPUT column of the MapNode
+// (the MapNode produces `seq` by decompressing the same-named compressed column).
+// FilterPushdownPass must NOT push this predicate below the Map: doing so would move
+// the predicate to the TableScan where `seq` is still the raw compressed column, making
+// the filter semantically wrong.
+//
+// This test is expected to FAIL until FilterPushdownPass is guarded with freeIUs().
+TEST(FilterPushdownPass, doesNotPushFilterThroughMapWhenFilterReferencesProducedColumn) {
+   using silo::schema::ColumnIdentifier;
+   using silo::schema::ColumnType;
+
+   // Map produces `seq` (STRING) by decompressing the compressed `seq` column.
+   const ColumnIdentifier compressed_col{.name = "seq", .type = ColumnType::ZSTD_COMPRESSED_STRING};
+   std::vector<operators::MapNode::Assignment> assignments;
+   assignments.push_back(
+      {.output_column = {.name = "seq", .type = ColumnType::STRING},
+       .expression =
+          std::make_unique<expressions::ZstdDecompressScalar>(compressed_col, "dictionary")}
+   );
+   auto map_node = std::make_unique<operators::MapNode>(makeScan(), std::move(assignments));
+
+   // Filter references `seq` — the Map-produced column (not the compressed source).
+   auto filter_node = std::make_unique<operators::FilterNode>(
+      std::move(map_node),
+      std::make_unique<expressions::StringEquals>("seq", std::optional<std::string>{"ACGT"})
+   );
+
+   auto result = FilterPushdownPass::run(std::move(filter_node));
+
+   // The Map-produced column `seq` is referenced by the filter predicate, so the filter
+   // must NOT be pushed through the MapNode. The FilterNode must survive above the Map.
+   // Currently FAILS: FilterPushdownPass pushes all filters past MapNodes unconditionally,
+   // sinking seq='ACGT' into the TableScan where `seq` is still the compressed column.
+   ASSERT_EQ(result->kind(), operators::NodeKind::FILTER)
+      << "FilterPushdownPass incorrectly pushed a filter referencing a Map-produced column "
+         "below the MapNode (bug: filter now runs against the compressed column, not the "
+         "decompressed one)";
+   // Additionally: the scan must NOT have `seq = 'ACGT'` in its filter (it was incorrectly
+   // pushed there by the current buggy implementation).
+   const auto* filter_result = dynamic_cast<operators::FilterNode*>(result.get());
+   ASSERT_NE(filter_result, nullptr);
+   ASSERT_EQ(filter_result->child->kind(), operators::NodeKind::MAP);
+   const auto* map = dynamic_cast<operators::MapNode*>(filter_result->child.get());
+   ASSERT_NE(map, nullptr);
+   ASSERT_EQ(map->child->kind(), operators::NodeKind::TABLE_SCAN);
+   const auto* scan = dynamic_cast<operators::TableScanNode*>(map->child.get());
+   ASSERT_NE(scan, nullptr);
+   EXPECT_EQ(scan->filter->toString(), "And(true)")
+      << "seq='ACGT' was incorrectly pushed into the TableScan past the MapNode";
 }
 
 }  // namespace

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.test.cpp
@@ -87,6 +87,9 @@ TEST(FilterPushdownPass, eliminatesStackedFilterNodesAboveTableScan) {
 
 // --- MapNode(FilterNode(TableScanNode)) ---
 
+// The filter references no column the MapNode produces (the Map adds an independent
+// column `x := 3`), so the filter is independent and is pushed through the Map into the
+// TableScan.
 TEST(FilterPushdownPass, pushesFilterThroughMapIntoTableScan) {
    auto table = makeTable();
    auto scan = std::make_unique<operators::TableScanNode>(
@@ -195,16 +198,15 @@ TEST(FilterPushdownPass, doesNotPushFilterThroughMapWhenFilterReferencesProduced
 
    auto result = FilterPushdownPass::run(std::move(filter_node));
 
-   // The Map-produced column `seq` is referenced by the filter predicate, so the filter
-   // must NOT be pushed through the MapNode. The FilterNode must survive above the Map.
-   // Currently FAILS: FilterPushdownPass pushes all filters past MapNodes unconditionally,
-   // sinking seq='ACGT' into the TableScan where `seq` is still the compressed column.
+   // The Map-produced column `seq` is referenced by the filter predicate (a StringEquals on
+   // the decompressed STRING), so the filter must NOT be pushed through the MapNode. The
+   // FilterNode must survive above the Map.
    ASSERT_EQ(result->kind(), operators::NodeKind::FILTER)
       << "FilterPushdownPass incorrectly pushed a filter referencing a Map-produced column "
-         "below the MapNode (bug: filter now runs against the compressed column, not the "
+         "below the MapNode (bug: filter would run against the compressed column, not the "
          "decompressed one)";
-   // Additionally: the scan must NOT have `seq = 'ACGT'` in its filter (it was incorrectly
-   // pushed there by the current buggy implementation).
+   // Additionally: the scan must NOT have `seq = 'ACGT'` in its filter (it must not be
+   // pushed past the MapNode).
    const auto* filter_result = dynamic_cast<operators::FilterNode*>(result.get());
    ASSERT_NE(filter_result, nullptr);
    ASSERT_EQ(filter_result->child->kind(), operators::NodeKind::MAP);
@@ -215,6 +217,76 @@ TEST(FilterPushdownPass, doesNotPushFilterThroughMapWhenFilterReferencesProduced
    ASSERT_NE(scan, nullptr);
    EXPECT_EQ(scan->filter->toString(), "And(true)")
       << "seq='ACGT' was incorrectly pushed into the TableScan past the MapNode";
+}
+
+// Helper: a MapNode that decompresses `seq` (sequence → STRING, same name).
+operators::QueryNodePtr makeDecompressMapOverScan() {
+   using silo::schema::ColumnIdentifier;
+   using silo::schema::ColumnType;
+   const ColumnIdentifier compressed_col{.name = "seq", .type = ColumnType::ZSTD_COMPRESSED_STRING};
+   std::vector<operators::MapNode::Assignment> assignments;
+   assignments.push_back(
+      {.output_column = {.name = "seq", .type = ColumnType::STRING},
+       .expression =
+          std::make_unique<expressions::ZstdDecompressScalar>(compressed_col, "dictionary")}
+   );
+   return std::make_unique<operators::MapNode>(makeScan(), std::move(assignments));
+}
+
+// Two stacked filters above a decompression Map: one references the produced column `seq`
+// (dependent → must stay above the Map), the other references an unrelated column (`country`,
+// independent → must be pushed through into the scan). The pass must SPLIT them.
+TEST(FilterPushdownPass, splitsFiltersKeepingProducedColumnFilterAboveMap) {
+   auto map_node = makeDecompressMapOverScan();
+   auto inner_filter = std::make_unique<operators::FilterNode>(
+      std::move(map_node),
+      std::make_unique<expressions::StringEquals>("country", std::optional<std::string>{"CH"})
+   );
+   auto outer_filter = std::make_unique<operators::FilterNode>(
+      std::move(inner_filter),
+      std::make_unique<expressions::StringEquals>("seq", std::optional<std::string>{"ACGT"})
+   );
+
+   auto result = FilterPushdownPass::run(std::move(outer_filter));
+
+   // Result: Filter(seq='ACGT') → Map(seq) → Scan{filter includes country='CH'}.
+   ASSERT_EQ(result->kind(), operators::NodeKind::FILTER);
+   const auto* filter = dynamic_cast<operators::FilterNode*>(result.get());
+   ASSERT_NE(filter, nullptr);
+   EXPECT_EQ(filter->filter->toString(), "seq = 'ACGT'");
+   ASSERT_EQ(filter->child->kind(), operators::NodeKind::MAP);
+   const auto* map = dynamic_cast<operators::MapNode*>(filter->child.get());
+   ASSERT_NE(map, nullptr);
+   ASSERT_EQ(map->child->kind(), operators::NodeKind::TABLE_SCAN);
+   const auto* scan = dynamic_cast<operators::TableScanNode*>(map->child.get());
+   ASSERT_NE(scan, nullptr);
+   EXPECT_EQ(scan->filter->toString(), "And(country = 'CH' & true)");
+}
+
+TEST(FilterPushdownPass, mergesMultipleDependentFiltersAboveMap) {
+   auto map_node = makeDecompressMapOverScan();
+
+   auto inner_filter = std::make_unique<operators::FilterNode>(
+      std::move(map_node),
+      std::make_unique<expressions::StringEquals>("seq", std::optional<std::string>{"ACGT"})
+   );
+   auto outer_filter = std::make_unique<operators::FilterNode>(
+      std::move(inner_filter),
+      std::make_unique<expressions::StringEquals>("seq", std::optional<std::string>{"TTTT"})
+   );
+
+   auto result = FilterPushdownPass::run(std::move(outer_filter));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::FILTER);
+   const auto* filter = dynamic_cast<operators::FilterNode*>(result.get());
+   ASSERT_NE(filter, nullptr);
+   EXPECT_EQ(filter->filter->toString(), "And(seq = 'TTTT' & seq = 'ACGT')");
+   ASSERT_EQ(filter->child->kind(), operators::NodeKind::MAP);
+   const auto* map = dynamic_cast<operators::MapNode*>(filter->child.get());
+   ASSERT_NE(map, nullptr);
+   const auto* scan = dynamic_cast<operators::TableScanNode*>(map->child.get());
+   ASSERT_NE(scan, nullptr);
+   EXPECT_EQ(scan->filter->toString(), "And(true)");
 }
 
 }  // namespace

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.test.cpp
@@ -174,8 +174,6 @@ TEST(FilterPushdownPass, pushesFilterIntoBothUnionAllBranches) {
 // FilterPushdownPass must NOT push this predicate below the Map: doing so would move
 // the predicate to the TableScan where `seq` is still the raw compressed column, making
 // the filter semantically wrong.
-//
-// This test is expected to FAIL until FilterPushdownPass is guarded with freeIUs().
 TEST(FilterPushdownPass, doesNotPushFilterThroughMapWhenFilterReferencesProducedColumn) {
    using silo::schema::ColumnIdentifier;
    using silo::schema::ColumnType;


### PR DESCRIPTION

resolves #1343

### Summary

Fixes a correctness bug where a filter on a decompressed column produced wrong results, by teaching the optimizer which columns a filter predicate references.

The auto-inserted decompression `MapNode` produces a `STRING` column with the same name as its compressed source (e.g. `seq` → `seq`). `FilterPushdownPass` pushed every filter down past `MapNode`s, so `default.filter(seq = 'ACGT')` ran the filter against the still-compressed column.

Changes:

- **Complete `Expression::freeIUs()`** on all predicate types (previously only `FieldRef`/`At`/`ZstdDecompressScalar`). It reports the columns a predicate references. For filter predicates only `.name` is reliable; `.type` is a placeholder, except sequence predicates which carry their sequence type.
- **`FilterPushdownPass`** no longer pushes a filter below a `Map` that produces a column the filter consumes. Such filters stay above the `Map`; independent filters still push down. Sequence predicates (e.g. `hasMutation`) consume the Map's sequence-typed *input*, so they keep pushing down to the scan.
- **`ColumnNarrowingPass`** now keeps `Map` assignments alive when a surviving filter above the `Map` references the produced column.

Pass order is unchanged (`ColumnNarrowing → FilterPushdown → MapPullup → NodeResolution`).

## PR Checklist

~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [x] The implemented feature is covered by an appropriate test.
