### PR TITLE
fix(silo): null sequences should not match N symbol queries

### DIFF
--- a/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolExactN.json
+++ b/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolExactN.json
@@ -3,7 +3,7 @@
   "query": "default.filter(exact(nucleotideEquals(position:=2, symbol:='N', sequenceName:='testSecondSequence'))).groupBy({count:=count()})",
   "expectedQueryResult": [
     {
-      "count": 5
+      "count": 2
     }
   ]
 }

--- a/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeA.json
+++ b/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeA.json
@@ -3,7 +3,7 @@
   "query": "default.filter(maybe(nucleotideEquals(position:=2, symbol:='A', sequenceName:='testSecondSequence'))).groupBy({count:=count()})",
   "expectedQueryResult": [
     {
-      "count": 9
+      "count": 6
     }
   ]
 }

--- a/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeC.json
+++ b/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeC.json
@@ -3,7 +3,7 @@
   "query": "default.filter(maybe(nucleotideEquals(position:=2, symbol:='C', sequenceName:='testSecondSequence'))).groupBy({count:=count()})",
   "expectedQueryResult": [
     {
-      "count": 94
+      "count": 91
     }
   ]
 }

--- a/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeG.json
+++ b/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeG.json
@@ -3,7 +3,7 @@
   "query": "default.filter(maybe(nucleotideEquals(position:=2, symbol:='G', sequenceName:='testSecondSequence'))).groupBy({count:=count()})",
   "expectedQueryResult": [
     {
-      "count": 7
+      "count": 4
     }
   ]
 }

--- a/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeGAP.json
+++ b/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeGAP.json
@@ -3,7 +3,7 @@
   "query": "default.filter(maybe(nucleotideEquals(position:=2, symbol:='-', sequenceName:='testSecondSequence'))).groupBy({count:=count()})",
   "expectedQueryResult": [
     {
-      "count": 6
+      "count": 3
     }
   ]
 }

--- a/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeN.json
+++ b/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeN.json
@@ -3,7 +3,7 @@
   "query": "default.filter(maybe(nucleotideEquals(position:=2, symbol:='N', sequenceName:='testSecondSequence'))).groupBy({count:=count()})",
   "expectedQueryResult": [
     {
-      "count": 5
+      "count": 2
     }
   ]
 }

--- a/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeR.json
+++ b/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeR.json
@@ -3,7 +3,7 @@
   "query": "default.filter(maybe(nucleotideEquals(position:=2, symbol:='R', sequenceName:='testSecondSequence'))).groupBy({count:=count()})",
   "expectedQueryResult": [
     {
-      "count": 7
+      "count": 4
     }
   ]
 }

--- a/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeT.json
+++ b/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeT.json
@@ -3,7 +3,7 @@
   "query": "default.filter(maybe(nucleotideEquals(position:=2, symbol:='T', sequenceName:='testSecondSequence'))).groupBy({count:=count()})",
   "expectedQueryResult": [
     {
-      "count": 7
+      "count": 4
     }
   ]
 }

--- a/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeY.json
+++ b/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolMaybeY.json
@@ -3,7 +3,7 @@
   "query": "default.filter(maybe(nucleotideEquals(position:=2, symbol:='Y', sequenceName:='testSecondSequence'))).groupBy({count:=count()})",
   "expectedQueryResult": [
     {
-      "count": 6
+      "count": 3
     }
   ]
 }

--- a/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolN.json
+++ b/endToEndTests/test/queries/symbolEquals/testSeqPos2SymbolN.json
@@ -3,7 +3,7 @@
   "query": "default.filter(nucleotideEquals(position:=2, symbol:='N', sequenceName:='testSecondSequence')).groupBy({count:=count()})",
   "expectedQueryResult": [
     {
-      "count": 5
+      "count": 2
     }
   ]
 }

--- a/src/silo/query_engine/expressions/symbol_equals.test.cpp
+++ b/src/silo/query_engine/expressions/symbol_equals.test.cpp
@@ -26,10 +26,27 @@ nlohmann::json createDataWithNucleotideSequence(const std::string& nucleotideSeq
    };
 }
 
+nlohmann::json createDataWithoutNucleotideSequence() {
+   random_generator generator;
+   const auto primary_key = generator();
+
+   return {
+      {"primaryKey", "id_" + to_string(primary_key)},
+      {"float_value", nullptr},
+      {"segment1", nullptr},
+      {"unaligned_segment1", {}},
+      {"gene1", {}}
+   };
+}
+
 const nlohmann::json DATA_SAME_AS_REFERENCE = createDataWithNucleotideSequence("ATGCN");
 const nlohmann::json DATA_SAME_AS_REFERENCE2 = createDataWithNucleotideSequence("ATGCN");
 const nlohmann::json DATA_WITH_ALL_N = createDataWithNucleotideSequence("NNNNN");
 const nlohmann::json DATA_WITH_ALL_MUTATED = createDataWithNucleotideSequence("CATTT");
+// A row without any sequence. It carries no symbol at any position, so it must not be matched by
+// any symbol, in particular not by the missing symbol N: a null sequence is stored with an empty
+// covered region, which makes it look like a row that is merely not covered at this position.
+const nlohmann::json DATA_WITHOUT_SEQUENCE = createDataWithoutNucleotideSequence();
 
 const auto DATABASE_CONFIG =
    R"(
@@ -49,7 +66,11 @@ const auto REFERENCE_GENOMES = ReferenceGenomes{
 
 const QueryTestData TEST_DATA{
    .ndjson_input_data =
-      {DATA_SAME_AS_REFERENCE, DATA_SAME_AS_REFERENCE2, DATA_WITH_ALL_N, DATA_WITH_ALL_MUTATED},
+      {DATA_SAME_AS_REFERENCE,
+       DATA_SAME_AS_REFERENCE2,
+       DATA_WITH_ALL_N,
+       DATA_WITH_ALL_MUTATED,
+       DATA_WITHOUT_SEQUENCE},
    .database_config = DATABASE_CONFIG,
    .reference_genomes = REFERENCE_GENOMES
 };
@@ -189,6 +210,33 @@ const QueryTestScenario NUCLEOTIDE_EQUALS_WITH_SYMBOL_T_AT_5 = {
    .expected_query_result = nlohmann::json::parse(R"([{"count": 1}])")
 };
 
+// The missing symbol is matched via the rows that are not covered at this position. The row without
+// a sequence is not covered anywhere, but it has no symbol at all, so only the all-N row matches.
+const QueryTestScenario NUCLEOTIDE_EQUALS_WITH_SYMBOL_N_AT_1 = {
+   .name = "NUCLEOTIDE_EQUALS_WITH_SYMBOL_N_AT_1",
+   .query = createNucleotideSymbolEqualsQuery("N", 1),
+   .expected_query_result = nlohmann::json::parse(R"([{"count": 1}])")
+};
+
+// Position 5 is N in the reference, so this takes the compilation for the case where the queried
+// symbols contain both the missing and the reference symbol. The two rows equal to the reference
+// and the all-N row match, the row without a sequence still does not.
+const QueryTestScenario NUCLEOTIDE_EQUALS_WITH_SYMBOL_N_AT_5 = {
+   .name = "NUCLEOTIDE_EQUALS_WITH_SYMBOL_N_AT_5",
+   .query = createNucleotideSymbolEqualsQuery("N", 5),
+   .expected_query_result = nlohmann::json::parse(R"([{"count": 3}])")
+};
+
+// Every row of this dataset is without an amino acid sequence, so nothing matches the missing
+// symbol X.
+const QueryTestScenario AMINO_ACID_EQUALS_MISSING_SYMBOL_WITHOUT_SEQUENCES = {
+   .name = "AMINO_ACID_EQUALS_MISSING_SYMBOL_WITHOUT_SEQUENCES",
+   .query =
+      "default.filter(aminoAcidEquals(position:=1, symbol:='X', sequenceName:='gene1'))"
+      ".groupBy({count:=count()})",
+   .expected_query_result = nlohmann::json::parse(R"([{"count": 0}])")
+};
+
 const QueryTestScenario NUCLEOTIDE_EQUALS_SYMBOL_OUT_OF_RANGE = {
    .name = "NUCLEOTIDE_EQUALS_SYMBOL_OUT_OF_RANGE",
    .query = createNucleotideSymbolEqualsQuery("C", 1000),
@@ -290,7 +338,10 @@ QUERY_TEST(
       nucleotide::NUCLEOTIDE_EQUALS_WITH_SYMBOL_T_AT_2,
       nucleotide::NUCLEOTIDE_EQUALS_WITH_SYMBOL_T_AT_3,
       nucleotide::NUCLEOTIDE_EQUALS_WITH_SYMBOL_T_AT_4,
-      nucleotide::NUCLEOTIDE_EQUALS_WITH_SYMBOL_T_AT_5
+      nucleotide::NUCLEOTIDE_EQUALS_WITH_SYMBOL_T_AT_5,
+      nucleotide::NUCLEOTIDE_EQUALS_WITH_SYMBOL_N_AT_1,
+      nucleotide::NUCLEOTIDE_EQUALS_WITH_SYMBOL_N_AT_5,
+      nucleotide::AMINO_ACID_EQUALS_MISSING_SYMBOL_WITHOUT_SEQUENCES
    )
 );
 

--- a/src/silo/query_engine/expressions/symbol_in_set.cpp
+++ b/src/silo/query_engine/expressions/symbol_in_set.cpp
@@ -100,6 +100,29 @@ std::unique_ptr<filter::operators::Operator> makeDifference(
    );
 }
 
+// A row without a sequence has no value at any position, so it must not match a symbol filter. It
+// is stored with an empty covered region, which makes it indistinguishable from a row that is
+// merely not covered at this position, i.e. it would otherwise be matched by the missing symbol.
+// Only the compilations that start from the not-covered rows need this; the ones that start from
+// the covered rows or from the mutation index never see a null row in the first place.
+template <typename SymbolType>
+std::unique_ptr<filter::operators::Operator> excludeNullSequences(
+   std::unique_ptr<filter::operators::Operator> operator_,
+   const SequenceColumn<SymbolType>& sequence_column,
+   const storage::column::RowLayout& row_layout
+) {
+   if (sequence_column.null_bitmap.isEmpty()) {
+      return operator_;
+   }
+   return makeDifference(
+      std::move(operator_),
+      std::make_unique<filter::operators::IndexScan>(
+         CopyOnWriteBitmap{&sequence_column.null_bitmap}, row_layout
+      ),
+      row_layout
+   );
+}
+
 template <typename SymbolType>
 std::unique_ptr<filter::operators::Operator> compileWithMissingSymbolAndReference(
    const SequenceColumn<SymbolType>& sequence_column,
@@ -113,10 +136,14 @@ std::unique_ptr<filter::operators::Operator> compileWithMissingSymbolAndReferenc
    auto bitmap = sequence_column.vertical_sequence_index.getMatchingContainersAsBitmap(
       position_idx, negated_symbols
    );
-   return std::make_unique<filter::operators::Complement>(
-      std::make_unique<filter::operators::IndexScan>(
-         CopyOnWriteBitmap{std::move(bitmap)}, row_layout
+   return excludeNullSequences(
+      std::make_unique<filter::operators::Complement>(
+         std::make_unique<filter::operators::IndexScan>(
+            CopyOnWriteBitmap{std::move(bitmap)}, row_layout
+         ),
+         row_layout
       ),
+      sequence_column,
       row_layout
    );
 }
@@ -145,7 +172,11 @@ std::unique_ptr<filter::operators::Operator> compileWithMissingSymbol(
    operators_for_union.push_back(std::make_unique<filter::operators::IndexScan>(
       CopyOnWriteBitmap{std::move(bitmap)}, row_layout
    ));
-   return std::make_unique<filter::operators::Union>(std::move(operators_for_union), row_layout);
+   return excludeNullSequences(
+      std::make_unique<filter::operators::Union>(std::move(operators_for_union), row_layout),
+      sequence_column,
+      row_layout
+   );
 }
 
 template <typename SymbolType>


### PR DESCRIPTION
### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

We interpreted `null` sequences as equivalent to full N sequences. 

Since https://github.com/GenSpectrum/LAPIS-SILO/pull/1125, we return `null` for sequences that were null in the input. We should also not match null sequences in filters for `N`.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [X] The implemented feature is covered by an appropriate test.
