### PR TITLE
feat(SaneQL): add `isoWeek` scalar function

### DIFF
--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -394,7 +394,9 @@ so nucleotide and amino acid sequences cannot be distinguished from ordinary str
 
 ## Scalar Functions
 
-Most scalar functions are boolean predicates used inside `.filter(...)`. Functions that return a non-boolean value (currently [`at`](#atcolumn-position)) cannot be used as a filter predicate and are instead used as `map()` assignments.
+Most scalar functions are boolean predicates used inside `.filter(...)`.
+Functions that return a non-boolean value (like [`at`](#atcolumn-position) and [`isoWeek`](#isoweekcolumn))
+cannot be used as a filter predicate and are instead used as `map()` assignments.
 
 ### `at(column, position)`
 
@@ -402,6 +404,16 @@ Extracts the single character of a string `column` at the 1-based `position`, re
 
 ```
 default.map({second_char := primary_key.at(2)})
+```
+
+### `isoWeek(column)`
+
+Maps a date `column` to its ISO 8601 week number (1–53) as an integer.
+`column` must be a date column. A `null` date yields `null`.
+Use it inside [`map()`](#mapexpressions).
+
+```
+default.map({week := date.isoWeek()})
 ```
 
 ### `between(column, from, to)`

--- a/src/silo/query_engine/expressions/expression.h
+++ b/src/silo/query_engine/expressions/expression.h
@@ -28,6 +28,7 @@ class Expression {
       AND,
       OR,
       AT,
+      ISO_WEEK,
       N_OF,
       NEGATION,
       MAYBE,

--- a/src/silo/query_engine/expressions/iso_week.cpp
+++ b/src/silo/query_engine/expressions/iso_week.cpp
@@ -1,0 +1,37 @@
+#include "silo/query_engine/expressions/iso_week.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "silo/common/panic.h"
+#include "silo/query_engine/filter/operators/operator.h"
+
+namespace silo::query_engine::expressions {
+
+IsoWeek::IsoWeek(schema::ColumnIdentifier input_column)
+    : input_column(std::move(input_column)) {}
+
+std::string IsoWeek::toString() const {
+   return fmt::format("{}.isoWeek()", input_column.name);
+}
+
+std::vector<schema::ColumnIdentifier> IsoWeek::freeIUs() const {
+   return {input_column};
+}
+
+std::unique_ptr<Expression> IsoWeek::
+   rewrite(const storage::Table& /*table*/, AmbiguityMode /*mode*/) const {
+   return std::make_unique<IsoWeek>(input_column);
+}
+
+std::unique_ptr<filter::operators::Operator> IsoWeek::compile(const storage::Table& /*table*/)
+   const {
+   // `isoWeek` yields an int scalar value, not a filter predicate.
+   SILO_UNIMPLEMENTED();
+}
+
+}  // namespace silo::query_engine::expressions

--- a/src/silo/query_engine/expressions/iso_week.h
+++ b/src/silo/query_engine/expressions/iso_week.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "silo/query_engine/expressions/expression.h"
+#include "silo/query_engine/filter/operators/operator.h"
+#include "silo/schema/database_schema.h"
+
+namespace silo::query_engine::expressions {
+
+/// A scalar expression that evaluates to the ISO week number (int) of a date-valued
+/// column, e.g. `myDate.isoWeek()`. Its value is an int, so it is not a filter predicate;
+/// compile() is unimplemented and it is only meaningful as a scalar expression (e.g. in a
+/// map() assignment).
+class IsoWeek : public Expression {
+  public:
+   schema::ColumnIdentifier input_column;
+
+   explicit IsoWeek(schema::ColumnIdentifier input_column);
+
+   [[nodiscard]] schema::ColumnType type() const override { return schema::ColumnType::INT64; }
+
+   static constexpr Kind KIND = Kind::ISO_WEEK;
+   [[nodiscard]] Kind kind() const override { return KIND; }
+
+   [[nodiscard]] std::string toString() const override;
+
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> freeIUs() const override;
+
+   [[nodiscard]] std::unique_ptr<Expression> rewrite(
+      const storage::Table& table,
+      AmbiguityMode mode
+   ) const override;
+
+   [[nodiscard]] std::unique_ptr<Expression> clone() const override {
+      return std::make_unique<IsoWeek>(input_column);
+   }
+
+   [[nodiscard]] std::unique_ptr<filter::operators::Operator> compile(const storage::Table& table
+   ) const override;
+};
+
+}  // namespace silo::query_engine::expressions

--- a/src/silo/query_engine/operators/map_node.cpp
+++ b/src/silo/query_engine/operators/map_node.cpp
@@ -18,6 +18,7 @@
 #include "silo/query_engine/exec_node/zstd_decompress_expression.h"
 #include "silo/query_engine/expressions/at.h"
 #include "silo/query_engine/expressions/field_ref.h"
+#include "silo/query_engine/expressions/iso_week.h"
 #include "silo/query_engine/expressions/literal.h"
 #include "silo/query_engine/expressions/zstd_decompress_scalar.h"
 
@@ -60,6 +61,11 @@ arrow::Result<arrow::compute::Expression> scalarToArrowExpression(
          "utf8_slice_codeunits",
          {arrow::compute::field_ref(at_function->input_column.name)},
          arrow::compute::SliceOptions(start, stop)
+      );
+   }
+   if (const auto* iso_week = dynamic_cast<const expressions::IsoWeek*>(&expression)) {
+      return arrow::compute::call(
+         "iso_week", {arrow::compute::field_ref(iso_week->input_column.name)}
       );
    }
    return arrow::Status::NotImplemented(

--- a/src/silo/query_engine/operators/map_node.test.cpp
+++ b/src/silo/query_engine/operators/map_node.test.cpp
@@ -12,7 +12,8 @@ nlohmann::json createData(
    int value,
    const std::string& str_value,
    const nlohmann::json& segment1 = nullptr,
-   const nlohmann::json& unaligned_segment1 = nullptr
+   const nlohmann::json& unaligned_segment1 = nullptr,
+   const std::string& date_value = ""
 ) {
    return {
       {"primaryKey", primaryKey},
@@ -20,7 +21,8 @@ nlohmann::json createData(
       {"str_value", str_value},
       {"segment1", segment1},
       {"gene1", nullptr},
-      {"unaligned_segment1", unaligned_segment1}
+      {"unaligned_segment1", unaligned_segment1},
+      {"date", date_value.empty() ? nlohmann::json(nullptr) : nlohmann::json(date_value)}
    };
 }
 
@@ -35,8 +37,8 @@ nlohmann::json alignedSequence(const std::string& sequence) {
 // unaligned_segment1 carries the (zstd-compressed) unaligned sequence used by the
 // decompression scenarios.
 const std::vector<nlohmann::json> DATA = {
-   createData("id_0", 1, "short", alignedSequence("ACGT"), "ACGT"),
-   createData("id_1", 2, "longlonglong")
+   createData("id_0", 1, "short", alignedSequence("ACGT"), "ACGT", "2023-01-05"),
+   createData("id_1", 2, "longlonglong", nullptr, nullptr, "2023-12-31")
 };
 
 const auto DATABASE_CONFIG =
@@ -51,6 +53,8 @@ schema:
       type: "int"
     - name: "str_value"
       type: "string"
+    - name: "date"
+      type: "date"
   primaryKey: "primaryKey"
 )";
 
@@ -213,6 +217,15 @@ const QueryTestScenario MAP_WITH_LIMIT_TRIGGERS_PULLUP_SCENARIO = {
    .expected_query_result = nlohmann::json({{{"a", 3}, {"b", 7}}})
 };
 
+// `isoWeek` maps a date column to its ISO 8601 week number as an integer.
+const QueryTestScenario MAP_ISO_WEEK_SCENARIO = {
+   .name = "MAP_ISO_WEEK",
+   .query = "default.map({week := date.isoWeek()}).project({primaryKey, week})",
+   .expected_query_result =
+      nlohmann::json({{{"primaryKey", "id_0"}, {"week", 1}}, {{"primaryKey", "id_1"}, {"week", 52}}}
+      )
+};
+
 }  // namespace
 
 QUERY_TEST(
@@ -233,6 +246,36 @@ QUERY_TEST(
       DECOMPRESS_SEQUENCE_SCENARIO,
       DECOMPRESS_WITH_USER_MAP_SCENARIO,
       DECOMPRESS_SEQUENCE_WITH_LIMIT_SCENARIO,
-      MAP_WITH_LIMIT_TRIGGERS_PULLUP_SCENARIO
+      MAP_WITH_LIMIT_TRIGGERS_PULLUP_SCENARIO,
+      MAP_ISO_WEEK_SCENARIO
    )
+);
+
+namespace {
+
+const std::vector<nlohmann::json> ISO_WEEK_NULL_DATA = {
+   createData("id_0", 1, "short"),
+   createData("id_1", 2, "short", nullptr, nullptr, "2020-12-31")
+};
+
+const QueryTestData ISO_WEEK_NULL_TEST_DATA{
+   .ndjson_input_data = ISO_WEEK_NULL_DATA,
+   .database_config = DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES
+};
+
+const QueryTestScenario MAP_ISO_WEEK_NULL_SCENARIO = {
+   .name = "MAP_ISO_WEEK_NULL",
+   .query = "default.map({week := date.isoWeek()}).project({primaryKey, week})",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"week", nullptr}}, {{"primaryKey", "id_1"}, {"week", 53}}}
+   )
+};
+
+}  // namespace
+
+QUERY_TEST(
+   MapIsoWeekNullTest,
+   ISO_WEEK_NULL_TEST_DATA,
+   ::testing::Values(MAP_ISO_WEEK_NULL_SCENARIO)
 );

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -30,6 +30,7 @@
 #include "silo/query_engine/expressions/int_between.h"
 #include "silo/query_engine/expressions/int_equals.h"
 #include "silo/query_engine/expressions/is_null.h"
+#include "silo/query_engine/expressions/iso_week.h"
 #include "silo/query_engine/expressions/lineage_filter.h"
 #include "silo/query_engine/expressions/literal.h"
 #include "silo/query_engine/expressions/maybe.h"
@@ -477,6 +478,26 @@ ScalarExpressionPtr handleAt(
       found != schema.end(), "at(): the field {} is not found in the current context", input_column
    );
    return std::make_unique<expressions::At>(*found, position);
+}
+
+ScalarExpressionPtr handleIsoWeek(
+   const BoundArguments& args,
+   const std::vector<schema::ColumnIdentifier>& schema
+) {
+   auto input_column = extractIdentifierName(args.at("input"));
+   const auto found =
+      std::ranges::find_if(schema, [&](const auto& col) { return col.name == input_column; });
+   CHECK_SILO_QUERY(
+      found != schema.end(),
+      "isoWeek(): the field {} is not found in the current context",
+      input_column
+   );
+   CHECK_SILO_QUERY(
+      found->type == schema::ColumnType::DATE32,
+      "isoWeek(): the field {} must be a date column",
+      input_column
+   );
+   return std::make_unique<expressions::IsoWeek>(*found);
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
@@ -1496,6 +1517,7 @@ ScalarFunctionRegistry::ScalarFunctionRegistry() {
    registerFunction("like", {{pos("column"), pos("pattern")}}, handleLike);
 
    registerFunction("at", {{pos("input"), pos("position")}}, handleAt);
+   registerFunction("isoWeek", {{pos("input")}}, handleIsoWeek);
 
    auto symbol_equals_sig =
       FunctionSignature{{named("position"), named("symbol"), named("sequenceName", false)}};

--- a/src/silo/query_engine/saneql/ast_to_query.test.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.test.cpp
@@ -1,5 +1,6 @@
 #include "silo/query_engine/saneql/ast_to_query.h"
 
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <string_view>
@@ -39,8 +40,10 @@ Tables makeTablesWithDefault() {
    using silo::storage::column::StringColumnMetadata;
 
    ColumnIdentifier primary_key{.name = "id", .type = ColumnType::STRING};
+   ColumnIdentifier date_column{.name = "date", .type = ColumnType::DATE32};
    std::map<ColumnIdentifier, std::shared_ptr<ColumnMetadata>> col_meta{
-      {primary_key, std::make_shared<StringColumnMetadata>(primary_key.name)}
+      {primary_key, std::make_shared<StringColumnMetadata>(primary_key.name)},
+      {date_column, std::make_shared<ColumnMetadata>(date_column.name)}
    };
    auto schema = std::make_shared<silo::schema::TableSchema>(std::move(col_meta), primary_key);
    Tables tables;
@@ -427,6 +430,38 @@ TEST(AstToQueryMap, atWithPositionZeroThrows) {
       [&tables]() { (void)parseAndConvertToQueryTree("default.map({c := id.at(0)})", tables); },
       ThrowsMessage<IllegalQueryException>(
          ::testing::HasSubstr("at(): the field 'position' is 1-indexed. Value of 0 not allowed.")
+      )
+   );
+}
+
+TEST(AstToQueryMap, isoWeekResolvesToWeekOfDateColumn) {
+   auto tables = makeTablesWithDefault();
+   const auto query_tree = parseAndConvertToQueryTree("default.map({w := date.isoWeek()})", tables);
+   const auto output_schema = query_tree->getOutputSchema();
+   const auto found =
+      std::ranges::find_if(output_schema, [](const auto& col) { return col.name == "w"; });
+   ASSERT_NE(found, output_schema.end());
+   EXPECT_EQ(found->type, silo::schema::ColumnType::INT64);
+}
+
+TEST(AstToQueryMap, isoWeekOnUnknownColumnThrows) {
+   auto tables = makeTablesWithDefault();
+   EXPECT_THAT(
+      [&tables]() {
+         (void)parseAndConvertToQueryTree("default.map({w := nope.isoWeek()})", tables);
+      },
+      ThrowsMessage<IllegalQueryException>(
+         ::testing::HasSubstr("isoWeek(): the field nope is not found in the current context")
+      )
+   );
+}
+
+TEST(AstToQueryMap, isoWeekOnNonDateColumnThrows) {
+   auto tables = makeTablesWithDefault();
+   EXPECT_THAT(
+      [&tables]() { (void)parseAndConvertToQueryTree("default.map({w := id.isoWeek()})", tables); },
+      ThrowsMessage<IllegalQueryException>(
+         ::testing::HasSubstr("isoWeek(): the field id must be a date column")
       )
    );
 }


### PR DESCRIPTION
resolves #1351

### Summary

Adds a new SaneQL scalar function `isoWeek()` that maps a date column to its ISO 8601 week number (1–53). Usable inside `map()`, e.g. `default.map({week := date.isoWeek()})`.

- **New `isoWeek(column)` scalar function** — takes a date column, returns its ISO week as an integer; a `null` date yields `null`. Like `at()`, it is a value-producing (non-boolean) function, so it can only be used in `map()`, not as a `filter()` predicate.
- **Validation** — errors if the referenced column is missing or is not a date column.
- **Execution** — translates to Arrow's `iso_week` compute kernel over the `date32` column in the projection.

## PR Checklist

- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
