### PR TITLE
perf(silo): when adapting references, compute the coverage bitmaps only when necessary

### DIFF
--- a/src/silo/storage/column/horizontal_coverage_index.cpp
+++ b/src/silo/storage/column/horizontal_coverage_index.cpp
@@ -49,6 +49,35 @@ void HorizontalCoverageIndex::insertNullSequence(RowId row_id) {
    insertCoverage(row_id, Coverage{.start = 0, .end = 0, .missing_positions = {}});
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+std::vector<uint64_t> HorizontalCoverageIndex::computeCoverageCardinalities(size_t genome_length
+) const {
+   std::vector<int64_t> coverage_changes(genome_length + 1, 0);
+   for (const auto& chunk : start_end) {
+      for (const auto& [start, end] : chunk) {
+         SILO_ASSERT_LE(end, genome_length);
+         coverage_changes[start] += 1;
+         coverage_changes[end] -= 1;
+      }
+   }
+   for (const auto& [_row_id, missing_positions] : horizontal_bitmaps) {
+      for (const uint32_t position_idx : missing_positions) {
+         SILO_ASSERT_LT(position_idx, genome_length);
+         coverage_changes[position_idx] -= 1;
+         coverage_changes[position_idx + 1] += 1;
+      }
+   }
+
+   std::vector<uint64_t> cardinalities(genome_length);
+   uint64_t cardinality = 0;
+   for (size_t position_idx = 0; position_idx < genome_length; ++position_idx) {
+      cardinality += coverage_changes[position_idx];
+      SILO_ASSERT_GE(cardinality, 0UL);
+      cardinalities[position_idx] = static_cast<uint32_t>(cardinality);
+   }
+   return cardinalities;
+}
+
 template <typename SymbolType>
 void HorizontalCoverageIndex::overwriteCoverageInSequence(
    std::vector<std::string>& sequences,

--- a/src/silo/storage/column/horizontal_coverage_index.h
+++ b/src/silo/storage/column/horizontal_coverage_index.h
@@ -38,6 +38,9 @@ class HorizontalCoverageIndex {
 
    void insertNullSequence(RowId row_id);
 
+   /// The number of rows covering each position
+   [[nodiscard]] std::vector<uint64_t> computeCoverageCardinalities(size_t genome_length) const;
+
    [[nodiscard]] size_t numChunks() const { return start_end.size(); }
 
    [[nodiscard]] uint32_t chunkSize(uint16_t chunk_id) const {

--- a/src/silo/storage/column/horizontal_coverage_index.test.cpp
+++ b/src/silo/storage/column/horizontal_coverage_index.test.cpp
@@ -463,4 +463,54 @@ TEST_F(HorizontalCoverageIndexTest, EmptySequenceIsAlwaysUncovered) {
    EXPECT_EQ(index->getCoverageBitmapForPositions<1>(10).at(0), roaring::Roaring{});
 }
 
+// computeCoverageCardinalities must return, for every position, the cardinality of the bitmap
+// that getCoverageBitmapForPositions produces there - that equivalence is what lets finalize skip
+// materializing the bitmaps.
+TEST_F(HorizontalCoverageIndexTest, CoverageCardinalitiesMatchBitmapCardinalities) {
+   // A mix of ranges, an internal N run (populating the horizontal bitmaps), leading/trailing N,
+   // a fully missing sequence and an empty one, so every branch contributes.
+   insertSequenceCoverage(std::string(GENOME_LENGTH, 'A'), 0);
+   insertSequenceCoverage("ACGTACGT", 10);
+   insertSequenceCoverage("ACGTNNNNNNACGT", 20);  // internal N run
+   insertSequenceCoverage("NNNACGTNNN", 40);      // leading and trailing N
+   insertSequenceCoverage(std::string(15, 'N'), 5);
+   insertNullCoverage();
+   insertSequenceCoverage("", 30);
+
+   const std::vector<uint64_t> cardinalities = index->computeCoverageCardinalities(GENOME_LENGTH);
+
+   ASSERT_EQ(cardinalities.size(), GENOME_LENGTH);
+   for (uint32_t position_idx = 0; position_idx < GENOME_LENGTH; ++position_idx) {
+      EXPECT_EQ(
+         cardinalities.at(position_idx),
+         index->getCoverageBitmapForPositions<1>(position_idx).at(0).cardinality()
+      ) << "at position "
+        << position_idx;
+   }
+}
+
+TEST_F(HorizontalCoverageIndexTest, CoverageCardinalitiesAcrossMultipleChunks) {
+   // Spread rows across three chunks so the per-chunk iteration in computeCoverageCardinalities is
+   // exercised, with a gap chunk boundary that carries N runs.
+   for (size_t chunk_id = 0; chunk_id < 3; ++chunk_id) {
+      index->insertCoverage(
+         RowId{.chunk_id = static_cast<uint16_t>(chunk_id), .row_in_chunk = 0},
+         extractCoverageAndMutationsFromSequence<Nucleotide>("ACGTNNACGT", chunk_id * 5, REFERENCE)
+            .value()
+            .coverage
+      );
+   }
+
+   const std::vector<uint64_t> cardinalities = index->computeCoverageCardinalities(GENOME_LENGTH);
+
+   ASSERT_EQ(cardinalities.size(), GENOME_LENGTH);
+   for (uint32_t position_idx = 0; position_idx < GENOME_LENGTH; ++position_idx) {
+      EXPECT_EQ(
+         cardinalities.at(position_idx),
+         index->getCoverageBitmapForPositions<1>(position_idx).at(0).cardinality()
+      ) << "at position "
+        << position_idx;
+   }
+}
+
 }  // namespace silo::storage::column

--- a/src/silo/storage/column/sequence_column.cpp
+++ b/src/silo/storage/column/sequence_column.cpp
@@ -164,33 +164,34 @@ void SequenceColumn<SymbolType>::finalize() {
    const SequenceColumnInfo info_after_filling = calculateInfo();
 
    SPDLOG_DEBUG("Adapting local reference");
-   constexpr size_t BATCH_SIZE = 1024;
-   for (uint32_t position_range_start = 0; position_range_start < genome_length;
-        position_range_start += BATCH_SIZE) {
-      auto coverage_bitmaps =
-         horizontal_coverage_index.getCoverageBitmapForPositions<BATCH_SIZE>(position_range_start);
-
-      const size_t range_size = std::min(BATCH_SIZE, genome_length - position_range_start);
-      for (size_t position_idx = position_range_start;
-           position_idx < position_range_start + range_size;
-           ++position_idx) {
-         const roaring::Roaring& coverage_bitmap =
-            coverage_bitmaps[position_idx - position_range_start];
-         auto new_reference_symbol = vertical_sequence_index.adaptLocalReference(
-            coverage_bitmap,
-            position_idx,
-            SymbolType::charToSymbol(local_reference_sequence_string.at(position_idx)).value()
-         );
-         if (new_reference_symbol.has_value()) {
-            SPDLOG_DEBUG(
-               "At position {} adapted local reference symbol to '{}'",
-               position_idx,
-               SymbolType::symbolToChar(new_reference_symbol.value())
-            );
-            local_reference_sequence_string.at(position_idx) =
-               SymbolType::symbolToChar(new_reference_symbol.value());
-         }
+   // We only need the number of rows covering a position to decide reference symbol adaptation
+   const std::vector<uint64_t> coverage_cardinalities =
+      horizontal_coverage_index.computeCoverageCardinalities(genome_length);
+   for (uint32_t position_idx = 0; position_idx < genome_length; ++position_idx) {
+      const auto current_reference_symbol =
+         SymbolType::charToSymbol(local_reference_sequence_string.at(position_idx)).value();
+      if (!vertical_sequence_index
+              .findBetterLocalReferenceSymbol(
+                 position_idx, current_reference_symbol, coverage_cardinalities.at(position_idx)
+              )
+              .has_value()) {
+         continue;
       }
+      // Only now compute the coverage bitmap for the position that needs to be adapted
+      const auto coverage_bitmaps =
+         horizontal_coverage_index.getCoverageBitmapForPositions<1>(position_idx);
+      const roaring::Roaring& coverage_bitmap = coverage_bitmaps[0];
+      const auto new_reference_symbol = vertical_sequence_index.adaptLocalReference(
+         coverage_bitmap, position_idx, current_reference_symbol
+      );
+      SILO_ASSERT(new_reference_symbol.has_value());
+      SPDLOG_DEBUG(
+         "At position {} adapted local reference symbol to '{}'",
+         position_idx,
+         SymbolType::symbolToChar(new_reference_symbol.value())
+      );
+      local_reference_sequence_string.at(position_idx) =
+         SymbolType::symbolToChar(new_reference_symbol.value());
    }
 
    const SequenceColumnInfo info_after_adaption = calculateInfo();

--- a/src/silo/storage/column/sequence_column.test.cpp
+++ b/src/silo/storage/column/sequence_column.test.cpp
@@ -152,6 +152,42 @@ TEST(SequenceColumn, validInsertionAtPositionEqualToGenomeLength) {
    EXPECT_NO_THROW(appendSequence(under_test, "A", 0, {"1:G"}));
 }
 
+// finalize decides whether to adapt the local reference from each position's coverage
+// cardinality, which excludes rows whose base there is N. This checks that path end to end: at
+// position 2 the majority of *covered* rows is T even though two rows have N there, so the
+// reference must adapt G -> T.
+TEST(SequenceColumn, adaptsLocalReferenceWhenMajorityOfCoveredRowsDiffers) {
+   SequenceColumnMetadata<Nucleotide> column_metadata{
+      "test_column",
+      {Nucleotide::Symbol::A, Nucleotide::Symbol::C, Nucleotide::Symbol::G, Nucleotide::Symbol::T}
+   };
+   SequenceColumn<Nucleotide> under_test(&column_metadata);
+
+   {
+      SequenceColumn<Nucleotide>::Builder builder(
+         under_test.metadata, under_test.local_reference_sequence_string
+      );
+      builder.insert("ACTT", 0, std::vector<std::string>{});  // T at position 2
+      builder.insert("ACTT", 0, std::vector<std::string>{});  // T at position 2
+      builder.insert("ACTT", 0, std::vector<std::string>{});  // T at position 2
+      builder.insert("ACNT", 0, std::vector<std::string>{});  // N -> uncovered at position 2
+      builder.insert("ACNT", 0, std::vector<std::string>{});  // N -> uncovered at position 2
+      builder.insert("ACGT", 0, std::vector<std::string>{});  // G (== reference) at position 2
+      SILO_ASSERT(under_test.appendChunk(builder.finalize()).has_value());
+   }
+
+   under_test.finalize();
+
+   // Position 2 has coverage cardinality 4 (the two N rows do not count): T occurs 3 times, G once,
+   // so T wins. Every other position stays at the reference symbol.
+   ASSERT_EQ(
+      under_test.getLocalReference(),
+      (std::vector<Nucleotide::Symbol>{
+         Nucleotide::Symbol::A, Nucleotide::Symbol::C, Nucleotide::Symbol::T, Nucleotide::Symbol::T
+      })
+   );
+}
+
 TEST(SequenceColumn, canFinalizeTwice) {
    SequenceColumnMetadata<Nucleotide> column_metadata{
       "test_column",

--- a/src/silo/storage/column/vertical_sequence_index.cpp
+++ b/src/silo/storage/column/vertical_sequence_index.cpp
@@ -105,6 +105,26 @@ SymbolType::Symbol VerticalSequenceIndex<SymbolType>::getSymbolWithHighestCount(
 }
 
 template <typename SymbolType>
+std::optional<typename SymbolType::Symbol> VerticalSequenceIndex<SymbolType>::
+   findBetterLocalReferenceSymbol(
+      uint32_t position_idx,
+      SymbolType::Symbol current_local_reference_symbol,
+      uint64_t coverage_cardinality
+   ) const {
+   auto [start, end] = getRangeForPosition(position_idx);
+
+   const SymbolMap<SymbolType, uint32_t> symbol_counts = computeSymbolCountsForPosition(
+      start, end, current_local_reference_symbol, coverage_cardinality
+   );
+   const typename SymbolType::Symbol best_symbol =
+      getSymbolWithHighestCount(symbol_counts, current_local_reference_symbol);
+   if (best_symbol == current_local_reference_symbol) {
+      return std::nullopt;
+   }
+   return best_symbol;
+}
+
+template <typename SymbolType>
 std::optional<typename SymbolType::Symbol> VerticalSequenceIndex<SymbolType>::adaptLocalReference(
    const roaring::Roaring& coverage_bitmap,
    uint32_t position_idx,
@@ -112,16 +132,13 @@ std::optional<typename SymbolType::Symbol> VerticalSequenceIndex<SymbolType>::ad
 ) {
    auto [start, end] = getRangeForPosition(position_idx);
 
-   const SymbolMap<SymbolType, uint32_t> symbol_counts = computeSymbolCountsForPosition(
-      start, end, current_local_reference_symbol, coverage_bitmap.cardinality()
+   const auto best_symbol = findBetterLocalReferenceSymbol(
+      position_idx, current_local_reference_symbol, coverage_bitmap.cardinality()
    );
-   // Find the symbol with the highest count
-   const typename SymbolType::Symbol best_symbol =
-      getSymbolWithHighestCount(symbol_counts, current_local_reference_symbol);
-   if (best_symbol == current_local_reference_symbol) {
+   if (!best_symbol.has_value()) {
       return std::nullopt;
    }
-   typename SymbolType::Symbol new_reference_symbol = best_symbol;
+   const typename SymbolType::Symbol new_reference_symbol = best_symbol.value();
    roaring::Roaring old_reference_bitmap = coverage_bitmap;
 
    old_reference_bitmap -= getMatchingContainersAsBitmap(

--- a/src/silo/storage/column/vertical_sequence_index.h
+++ b/src/silo/storage/column/vertical_sequence_index.h
@@ -145,6 +145,16 @@ class VerticalSequenceIndex {
       SymbolType::Symbol current_local_reference_symbol
    ) const;
 
+   /// The symbol that should replace the current local reference symbol at this position, or
+   /// nullopt if the current one is already the most common. Only needs the number of rows
+   /// covering the position, not the (expensive to materialize) bitmap of those rows, so it can
+   /// cheaply decide whether adaptLocalReference needs to run at all.
+   [[nodiscard]] std::optional<typename SymbolType::Symbol> findBetterLocalReferenceSymbol(
+      uint32_t position_idx,
+      SymbolType::Symbol current_local_reference_symbol,
+      uint64_t coverage_cardinality
+   ) const;
+
    std::optional<typename SymbolType::Symbol> adaptLocalReference(
       const roaring::Roaring& coverage_bitmap,
       uint32_t position_idx,


### PR DESCRIPTION
insertion benchmark times drop as follows:

before:
```
[2026-07-15 17:50:55.268] [info] [sequence_column_insert.cpp:118] sequences:        100000
[2026-07-15 17:50:55.268] [info] [sequence_column_insert.cpp:119] builder.insert:   3489.8 ms
[2026-07-15 17:50:55.268] [info] [sequence_column_insert.cpp:120] column.appendChunk: 617.9 ms
[2026-07-15 17:50:55.268] [info] [sequence_column_insert.cpp:121] column.finalize:  4486.8 ms
[2026-07-15 17:50:55.268] [info] [sequence_column_insert.cpp:122] total:            8603.3 ms
```

after:
```
[2026-07-15 17:40:52.581] [info] [sequence_column_insert.cpp:118] sequences:        100000
[2026-07-15 17:40:52.581] [info] [sequence_column_insert.cpp:119] builder.insert:   3389.0 ms
[2026-07-15 17:40:52.581] [info] [sequence_column_insert.cpp:120] column.appendChunk: 579.9 ms
[2026-07-15 17:40:52.581] [info] [sequence_column_insert.cpp:121] column.finalize:  71.4 ms
[2026-07-15 17:40:52.581] [info] [sequence_column_insert.cpp:122] total:            4049.8 ms
```
