### PR TITLE
feat(silo): add update function to python bindings

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -5,6 +5,7 @@ High-performance analytical database for sequence alignment data
 ## Sections
 
 - [API Reference](api.md) — HTTP API for querying preprocessed outputs
+- [Python Bindings](python_bindings.md) — Embedding SILO in-process with the `silodb` package
 - [Input Format](input_format.md) — NDJSON input format for genomic sequence data
 - [Query Reference](query_documentation.md) — Filter expressions and query syntax
 - [Maybe Filter](maybe_documentation.md) — Semantics of the `Maybe` filter expression

--- a/documentation/python_bindings.md
+++ b/documentation/python_bindings.md
@@ -1,0 +1,205 @@
+# Python Bindings (`silodb`)
+
+`silodb` is a Python package that embeds SILO in-process, exposing the `Database` class. It lets you build or load a SILO database, run [SaneQL](query_documentation.md) queries, edit scalar values, and persist state — all without running the HTTP API server.
+
+Queries return [Apache Arrow](https://arrow.apache.org/) tables (`pyarrow`), and filter results are returned as [Roaring bitmaps](https://roaringbitmap.org/) (`pyroaring`), so results integrate directly with the scientific Python stack.
+
+## Installation
+
+The package is built from this repository with a C++ toolchain (the same one used to build SILO) and Cython. From the repository root:
+
+```bash
+make python-tests   # builds silodb into a virtualenv and runs the test suite
+```
+
+or build a wheel directly:
+
+```bash
+uv build --wheel
+```
+
+The bindings depend on `pyarrow` and `pyroaring`, which are installed automatically as dependencies.
+
+## Quick Start
+
+```python
+from silodb import Database
+
+# Load a preprocessed database state from a silo-directory
+db = Database("path/to/silo-directory")
+
+# Run a SaneQL query; results come back as a pyarrow.Table
+table = db.query("default.filter(region = 'Europe').project({primaryKey, age})")
+print(table.to_pydict())
+
+# Overwrite a scalar column for the matching rows
+db.update_column("default", "age", "0", filter_expression="age = 4")
+```
+
+## The `Database` Class
+
+`from silodb import Database`
+
+### Constructing and loading
+
+**`Database(file_name=None)`**
+Creates an empty database, or loads an existing one when `file_name` is given.
+
+`file_name` is a **silo-directory**: the directory that holds one or more versioned database states (see [Data Directories](data_directories.md)). The most recent compatible state is loaded automatically.
+
+```python
+empty = Database()                       # in-memory, no tables
+loaded = Database("path/to/silo-dir")    # loads the most recent state
+```
+
+Raises `FileNotFoundError` if the path does not exist, and `RuntimeError` if no valid state can be loaded (for example, an incompatible serialization version).
+
+`Database` is also a context manager:
+
+```python
+with Database("path/to/silo-dir") as db:
+    result = db.query("default")
+```
+
+### Building a database in memory
+
+Two helpers create a table with a primary key, a sequence column, and optional **string** columns. Scalar (int/float/date/bool) columns cannot be created through these helpers; they come from a preprocessed database that you load.
+
+**`create_nucleotide_sequence_table(table_name, primary_key_name, sequence_name, reference_sequence, extra_columns=None)`**
+**`create_gene_table(table_name, primary_key_name, gene_name, reference_sequence, extra_columns=None)`**
+
+```python
+db = Database()
+db.create_nucleotide_sequence_table(
+    table_name="sequences",
+    primary_key_name="primary_key",
+    sequence_name="main",
+    reference_sequence="ACGT...",
+    extra_columns=["country", "lineage"],   # string columns
+)
+```
+
+Data is then appended in [NDJSON format](input_format.md):
+
+**`append_data_from_file(table_name, file_name)`** — append records from an NDJSON file.
+**`append_data_from_string(table_name, json_string)`** — append records from an NDJSON string.
+
+```python
+db.append_data_from_file("sequences", "input.ndjson")
+db.append_data_from_string(
+    "sequences",
+    '{"primary_key": "s1", "main": {"sequence": "ACGT", "insertions": []}, "country": "CH"}',
+)
+```
+
+### Querying
+
+**`query(query_string)`** → `pyarrow.Table`
+Executes a [SaneQL](query_documentation.md) query. The leading identifier is the table name.
+
+```python
+result = db.query("default.filter(age >= 18).project({primaryKey, age, country})")
+data = result.to_pydict()      # dict of columns
+df = result.to_pandas()        # pandas DataFrame
+```
+
+**`get_filtered_bitmap(table_name, filter_expression="")`** → `pyroaring.BitMap`
+Returns the row indices matching a SaneQL filter expression. An empty or `None` filter defaults to `true` (all rows). Useful for cheap counting and set operations.
+
+```python
+matching = db.get_filtered_bitmap("default", "region = 'Europe'")
+print(len(matching))                       # number of matching rows
+```
+
+### Inspecting the database
+
+**`get_tables()`** → `pyarrow.Table` with a single `table_name` column listing all tables.
+**`get_nucleotide_reference_sequence(table_name, sequence_name)`** → `str`.
+**`get_amino_acid_reference_sequence(table_name, sequence_name)`** → `str`.
+**`print_all_data(table_name)`** — prints all rows of a table to stdout (debugging aid).
+
+### Updating scalar columns
+
+**`update_column(table_name, column_name, value, filter_expression="")`**
+
+Assigns a single scalar `value` to `column_name` for every row matched by `filter_expression` (a SaneQL filter, like `get_filtered_bitmap`). An empty or `None` filter defaults to `true`, updating all rows.
+
+`value` is a **SaneQL literal** — parsed by the same parser as queries — and must match the column's type:
+
+| Column type | `value` examples                     |
+| ----------- | ------------------------------------ |
+| int         | `"3"`, `"-1"`                         |
+| float       | `"3.14"`, `"0"`                       |
+| bool        | `"true"`, `"false"`                  |
+| date        | `"'2021-03-15'::date"`               |
+| any of them | `"null"` &nbsp;(clears the rows)     |
+
+Only scalar value columns (int, float, date, bool) can be updated. String and sequence columns are rejected.
+
+```python
+db = Database("path/to/silo-dir")
+
+# Set every row's age to 0
+db.update_column("default", "age", "0")
+
+# Set age to 100 only for rows currently equal to 4
+db.update_column("default", "age", "100", filter_expression="age = 4")
+
+# Assign a date literal
+db.update_column("default", "date", "'2000-01-01'::date")
+
+# Clear a boolean column to null for a subset of rows
+db.update_column("default", "test_boolean_column", "null", filter_expression="region = 'Asia'")
+```
+
+The update mutates only the **in-memory** database. On-disk state is left untouched until you call `save_checkpoint`. Because the update bumps the data version, a subsequently saved checkpoint is written as a new versioned state.
+
+**Not thread-safe.** `update_column` mutates the in-memory database in place with no internal locking.
+
+### Persisting state
+
+**`save_checkpoint(save_directory)`**
+Writes the current database state into `save_directory` as a new versioned state, which can later be reloaded with `Database(save_directory)`.
+
+```python
+db.update_column("default", "age", "0")
+db.save_checkpoint("out/silo-dir")
+reloaded = Database("out/silo-dir")
+```
+
+## Error Handling
+
+The bindings translate C++ exceptions into Python ones:
+
+- **`ValueError`** — invalid query or update: an unknown column, an unsupported column type, a literal that does not match the column type, or a malformed SaneQL expression. Empty required arguments (such as `table_name` or `column_name`) also raise `ValueError`.
+- **`FileNotFoundError`** — a path passed to the loader or `append_data_from_file` does not exist.
+- **`RuntimeError`** — other failures (for example, a failed load or save).
+
+```python
+try:
+    db.update_column("default", "country", "'x'")   # country is a string column
+except ValueError as e:
+    print(e)   # "Updating columns of type '...' is not supported; only INT32, FLOAT, DATE32 and BOOL ..."
+```
+
+## Complete Example
+
+```python
+from silodb import Database
+
+with Database("path/to/silo-dir") as db:
+    # Count the rows we are about to change
+    before = len(db.get_filtered_bitmap("default", "age = 4"))
+
+    # Reset those rows' age to null
+    db.update_column("default", "age", "null", filter_expression="age = 4")
+
+    # Verify via a query
+    remaining = len(db.get_filtered_bitmap("default", "age = 4"))
+    cleared = len(db.get_filtered_bitmap("default", "age = null"))
+    assert remaining == 0
+    assert cleared >= before
+
+    # Persist the edited database as a new state
+    db.save_checkpoint("out/silo-dir")
+```

--- a/python/silodb/database.pxd
+++ b/python/silodb/database.pxd
@@ -25,6 +25,7 @@ cdef extern from "silo/database.h" namespace "silo":
         string getNucleotideReferenceSequence(string table_name, string sequence_name) except +
         string getAminoAcidReferenceSequence(string table_name, string sequence_name) except +
         Roaring getFilteredBitmap(string table_name, string filter) except +handle_silo_exception
+        void updateColumn(string table_name, string column_name, string value, string filter_expression) except +handle_silo_exception
         void saveDatabaseState(string save_directory) except +
         string executeQueryAsArrowIpc(string query_string) except +handle_silo_exception
         string getTablesAsArrowIpc() except +

--- a/python/silodb/database.pyx
+++ b/python/silodb/database.pyx
@@ -367,6 +367,55 @@ cdef class PyDatabase:
         except Exception as e:
             raise RuntimeError(f"Failed to get filtered bitmap: {e}")
 
+    def update_column(self, str table_name, str column_name, str value, str filter_expression=""):
+        """
+        Assign a single scalar value to a column for all rows matching a filter.
+
+        The rows to update are selected by ``filter_expression`` (a SaneQL filter, like
+        ``get_filtered_bitmap``). Every matched row is assigned the same ``value``, a SaneQL
+        literal (parsed by the same parser as queries) matching the column's type, e.g. ``"3"``
+        for an int column, ``"3.14"`` for a float column, ``"true"``/``"false"`` for a bool
+        column, ``"'2021-03-15'::date"`` for a date column. The literal ``"null"`` clears the
+        matched rows.
+
+        Only scalar value columns (int, float, date and bool) can be updated.
+
+        Not thread-safe: this mutates the in-memory database in place with no
+        internal locking.
+
+        Parameters
+        ----------
+        table_name : str
+            Name of the table
+        column_name : str
+            Name of the column to update
+        value : str
+            SaneQL literal assigned to every matched row (``"null"`` clears the rows)
+        filter_expression : str, optional
+            SaneQL filter expression selecting the rows to update
+            (default: 'true' which matches all rows)
+        """
+        if not table_name or not table_name.strip():
+            raise ValueError("table_name cannot be empty")
+        if not column_name or not column_name.strip():
+            raise ValueError("column_name cannot be empty")
+
+        # Default to True filter (updates all rows) if no filter specified
+        if filter_expression is None or filter_expression == "":
+            filter_expression = 'true'
+
+        cdef string cpp_table_name = table_name.encode('utf-8')
+        cdef string cpp_column_name = column_name.encode('utf-8')
+        cdef string cpp_filter = filter_expression.encode('utf-8')
+        cdef string cpp_value = value.encode('utf-8')
+
+        try:
+            self.c_database.updateColumn(cpp_table_name, cpp_column_name, cpp_value, cpp_filter)
+        except ValueError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"Failed to update column '{column_name}': {e}")
+
     def query(self, str query_string):
         """
         Execute a query and return results as a PyArrow Table

--- a/python/tests/test_database.py
+++ b/python/tests/test_database.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import json
+import datetime
 import tempfile
 import shutil
 import pyroaring
@@ -11,6 +12,14 @@ import pyarrow as pa
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'testBaseData', 'exampleDataset')
 REFERENCE_GENOMES_FILE = os.path.join(TEST_DATA_DIR, 'reference_genomes.json')
 INPUT_FILE = os.path.join(TEST_DATA_DIR, 'input_file.ndjson')
+
+# A serialized database (checked into the repo) whose schema has scalar value columns
+# (age:int, qc_value:float, date:date, test_boolean_column:bool). These cannot be created
+# through the Python table-creation API, so loading this state is how the Python tests exercise
+# a real scalar update.
+SERIALIZED_STATE_DIR = os.path.join(
+    os.path.dirname(__file__), '..', '..', 'testBaseData', 'siloSerializedState'
+)
 
 
 @pytest.fixture
@@ -66,6 +75,7 @@ class TestDatabaseCreation:
             'get_tables',
             'print_all_data',
             'save_checkpoint',
+            'update_column',
         ]
         for method in expected_methods:
             assert hasattr(empty_database, method), f"Missing method: {method}"
@@ -773,3 +783,132 @@ class TestQuery:
         # Results should match
         assert result_before.num_rows == result_after.num_rows
         assert result_before.column_names == result_after.column_names
+
+
+class TestUpdateColumn:
+    """Test the update_column binding.
+
+    Scalar value columns (int/float/date/bool) cannot be created through the Python table-creation
+    API (its extra columns are always strings), so these tests exercise the binding layer itself:
+    argument validation, marshalling, and translation of C++ errors into Python exceptions. The
+    successful scalar-update behavior is covered by the C++ unit tests (database.test.cpp).
+    """
+
+    def _database_with_string_column(self, main_reference_sequence):
+        from silodb import Database
+
+        db = Database()
+        db.create_nucleotide_sequence_table(
+            table_name="sequences",
+            primary_key_name="primary_key",
+            sequence_name="main",
+            reference_sequence=main_reference_sequence,
+            extra_columns=["country"]
+        )
+        db.append_data_from_file("sequences", INPUT_FILE)
+        return db
+
+    def test_update_column_empty_table_name_raises(self, empty_database):
+        """Test that an empty table name raises ValueError before reaching C++."""
+        with pytest.raises(ValueError, match="table_name cannot be empty"):
+            empty_database.update_column("", "country", "'x'")
+
+    def test_update_column_empty_column_name_raises(self, empty_database):
+        """Test that an empty column name raises ValueError before reaching C++."""
+        with pytest.raises(ValueError, match="column_name cannot be empty"):
+            empty_database.update_column("sequences", "", "'x'")
+
+    def test_update_column_unknown_column_raises(self, main_reference_sequence):
+        """Test that updating a non-existent column surfaces the C++ query error as ValueError."""
+        db = self._database_with_string_column(main_reference_sequence)
+        with pytest.raises(ValueError, match="does not contain a column"):
+            db.update_column("sequences", "does_not_exist", "1")
+
+    def test_update_column_string_column_not_supported(self, main_reference_sequence):
+        """Test that updating a non-scalar (string) column raises the 'not supported' ValueError."""
+        db = self._database_with_string_column(main_reference_sequence)
+        with pytest.raises(ValueError, match="not supported"):
+            db.update_column("sequences", "country", "'x'")
+
+
+class TestUpdateColumnOnLoadedDatabase:
+    """End-to-end update_column tests against the serialized database checked into the repo.
+
+    That database has real scalar value columns (age:int, qc_value:float, date:date,
+    test_boolean_column:bool), which the Python table-creation API cannot produce. update_column
+    mutates only the in-memory database (the on-disk state is never saved), so every test loads its
+    own fresh copy and the repo files are left untouched.
+    """
+
+    @pytest.fixture
+    def loaded_database(self):
+        from silodb import Database
+        return Database(SERIALIZED_STATE_DIR)
+
+    @staticmethod
+    def _column(database, name):
+        return database.query(f'default.project({{{name}}})').to_pydict()[name]
+
+    @staticmethod
+    def _count(database, filter_expression):
+        return len(database.get_filtered_bitmap("default", filter_expression))
+
+    def test_update_int_column_all_rows(self, loaded_database):
+        """Updating without a filter assigns the value to every row."""
+        total = self._count(loaded_database, "true")
+        assert total > 0
+
+        loaded_database.update_column("default", "age", "42")
+
+        assert self._count(loaded_database, "age = 42") == total
+        assert all(age == 42 for age in self._column(loaded_database, "age"))
+
+    def test_update_int_column_with_filter(self, loaded_database):
+        """Only rows matching the filter are updated; the rest keep their values."""
+        matching = self._count(loaded_database, "age = 4")
+        total = self._count(loaded_database, "true")
+        assert 0 < matching < total
+
+        loaded_database.update_column("default", "age", "100", "age = 4")
+
+        assert self._count(loaded_database, "age = 4") == 0
+        assert self._count(loaded_database, "age = 100") == matching
+        # Rows that did not match still exist and were not turned into 100.
+        assert self._count(loaded_database, "age = 100") < total
+
+    def test_update_float_column(self, loaded_database):
+        """Float literals are assigned to a float column."""
+        loaded_database.update_column("default", "qc_value", "0.5")
+        assert all(abs(value - 0.5) < 1e-9 for value in self._column(loaded_database, "qc_value"))
+
+    def test_update_bool_column(self, loaded_database):
+        """Boolean literals are assigned to a bool column (including rows that were null)."""
+        loaded_database.update_column("default", "test_boolean_column", "false")
+        assert all(value is False for value in self._column(loaded_database, "test_boolean_column"))
+
+    def test_update_date_column(self, loaded_database):
+        """SaneQL date literals are assigned to a date column."""
+        loaded_database.update_column("default", "date", "'2000-01-01'::date")
+        assert all(
+            value == datetime.date(2000, 1, 1) for value in self._column(loaded_database, "date")
+        )
+
+    def test_update_column_clears_rows_to_null(self, loaded_database):
+        """The literal 'null' clears the matched rows."""
+        matching = self._count(loaded_database, "age = 4")
+        nulls_before = self._count(loaded_database, "age = null")
+        assert matching > 0
+
+        loaded_database.update_column("default", "age", "null", "age = 4")
+
+        assert self._count(loaded_database, "age = 4") == 0
+        assert self._count(loaded_database, "age = null") == nulls_before + matching
+
+    def test_update_does_not_persist_to_disk(self, loaded_database):
+        """Updating the in-memory database must not modify the on-disk repo state."""
+        loaded_database.update_column("default", "age", "999")
+        assert self._count(loaded_database, "age = 999") > 0
+
+        from silodb import Database
+        fresh = Database(SERIALIZED_STATE_DIR)
+        assert self._count(fresh, "age = 999") == 0

--- a/src/silo/database.cpp
+++ b/src/silo/database.cpp
@@ -21,6 +21,7 @@
 #include "silo/common/aa_symbols.h"
 #include "silo/common/data_version.h"
 #include "silo/common/nucleotide_symbols.h"
+#include "silo/common/panic.h"
 #include "silo/common/silo_directory.h"
 #include "silo/common/version.h"
 #include "silo/database_info.h"
@@ -33,6 +34,7 @@
 #include "silo/query_engine/planner.h"
 #include "silo/query_engine/saneql/ast_to_query.h"
 #include "silo/query_engine/saneql/parser.h"
+#include "silo/query_engine/scalar_column_update.h"
 #include "silo/query_engine/scalar_expressions/literal.h"
 #include "silo/schema/database_schema.h"
 #include "silo/storage/column/sequence_column.h"
@@ -272,6 +274,36 @@ roaring::Roaring Database::getFilteredBitmap(
    auto filter_operator = rewritten_filter_expression->compile(*table);
    roaring::Roaring bitmap = filter_operator->evaluate().getConstReference();
    return bitmap;
+}
+
+// Currently updates are not thread-safe. An update during concurrent access is not allowed
+void Database::updateColumn(
+   const std::string& table_name,
+   const std::string& column_name,
+   const std::string& value,
+   const std::string& filter_expression
+) {
+   auto maybe_table = tables.find(schema::TableName{table_name});
+   if (maybe_table == tables.end()) {
+      throw query_engine::IllegalQueryException(
+         fmt::format("The database does not contain the table '{}'", table_name)
+      );
+   }
+   auto& table = *maybe_table->second;
+
+   const auto column = table.schema->getColumn(column_name);
+   if (!column.has_value()) {
+      throw query_engine::IllegalQueryException(
+         fmt::format("The table '{}' does not contain a column '{}'", table_name, column_name)
+      );
+   }
+
+   const roaring::Roaring row_ids = getFilteredBitmap(table_name, filter_expression);
+   query_engine::assignScalarLiteralToColumn(table.columns, *column, value, row_ids);
+
+   // The update mutates persisted table data, so bump the data version like appendData does; this
+   // keeps getDataVersionTimestamp() and versioned save directories consistent with the change.
+   updateDataVersion();
 }
 
 namespace {

--- a/src/silo/database.h
+++ b/src/silo/database.h
@@ -70,6 +70,18 @@ class Database {
 
    roaring::Roaring getFilteredBitmap(const std::string& table_name, const std::string& filter);
 
+   /// Assigns the scalar `value` to the column `column_name` of `table_name` for every row matched
+   /// by the SaneQL `filter_expression`. `value` is a single SaneQL literal (parsed by the same
+   /// lexer/parser as queries) matching the column's type, e.g. `3`, `3.14`, `true`, or
+   /// `'2021-03-15'::date`; the literal `null` clears the matched rows. Only scalar value columns
+   /// (INT32, FLOAT, DATE32, BOOL) can be updated; other column types raise an error.
+   void updateColumn(
+      const std::string& table_name,
+      const std::string& column_name,
+      const std::string& value,
+      const std::string& filter_expression
+   );
+
    void saveDatabaseState(const std::filesystem::path& save_directory);
 
    static std::optional<Database> loadDatabaseStateFromPath(

--- a/src/silo/database.test.cpp
+++ b/src/silo/database.test.cpp
@@ -5,6 +5,8 @@
 #include <fstream>
 #include <map>
 
+#include <fmt/format.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "config/source/yaml_file.h"
@@ -12,6 +14,7 @@
 #include "silo/config/preprocessing_config.h"
 #include "silo/database_info.h"
 #include "silo/initialize/initializer.h"
+#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/query_engine/planner.h"
 #include "silo/storage/reference_genomes.h"
 #include "silo/test/query_fixture.test.h"
@@ -121,6 +124,82 @@ TEST(DatabaseTest, shouldReturnCorrectDatabaseInfoAfterAppendingNewSequences) {
 
    EXPECT_EQ(database_info_after_append.sequence_count, 7);
    EXPECT_GT(data_version_after_append, data_version);
+}
+
+namespace {
+// Counts the rows of the default table matching `filter` by running a SaneQL count aggregation.
+int64_t countWhere(silo::Database& database, const std::string& filter) {
+   auto query_plan = silo::query_engine::Planner::planSaneqlQuery(
+      fmt::format("default.filter({}).groupBy({{count:=count()}})", filter),
+      database.tables,
+      silo::config::QueryOptions{},
+      "count_query"
+   );
+   auto result = silo::test::executeQueryToJsonArray(query_plan);
+   if (result.empty()) {
+      return 0;
+   }
+   return result.at(0).at("count").get<int64_t>();
+}
+}  // namespace
+
+TEST(DatabaseTest, updateColumnAssignsScalarValueToMatchingRows) {
+   auto database = buildTestDatabase();
+   const std::string table = silo::schema::TableName::getDefault().getName();
+
+   // Two rows (key1, key4) start with age 4; key3 has a null age.
+   ASSERT_EQ(countWhere(*database, "age = 4"), 2);
+
+   // Assign a scalar int to only the matching rows.
+   database->updateColumn(table, "age", "100", "age = 4");
+   ASSERT_EQ(countWhere(*database, "age = 4"), 0);
+   ASSERT_EQ(countWhere(*database, "age = 100"), 2);
+
+   // A previously-null value can be set to a concrete value.
+   ASSERT_EQ(countWhere(*database, "age = 7"), 0);
+   database->updateColumn(table, "age", "7", "primaryKey = 'key3'");
+   ASSERT_EQ(countWhere(*database, "age = 7"), 1);
+
+   // A SaneQL `null` literal clears the matched rows back to null.
+   database->updateColumn(table, "age", "null", "primaryKey = 'key3'");
+   ASSERT_EQ(countWhere(*database, "age = 7"), 0);
+   ASSERT_EQ(countWhere(*database, "age = null"), 1);
+
+   // Bool values are parsed as the boolean literals 'true'/'false'.
+   database->updateColumn(table, "test_boolean_column", "false", "true");
+   ASSERT_EQ(countWhere(*database, "test_boolean_column = false"), 5);
+
+   // Date values are SaneQL date literals.
+   database->updateColumn(table, "date", "'2000-01-01'::date", "true");
+   ASSERT_EQ(countWhere(*database, "date = '2000-01-01'::date"), 5);
+}
+
+TEST(DatabaseTest, updateColumnRejectsInvalidRequests) {
+   auto database = buildTestDatabase();
+   const std::string table = silo::schema::TableName::getDefault().getName();
+
+   // A literal that does not match the column's type is a query error.
+   EXPECT_THAT(
+      [&]() { database->updateColumn(table, "age", "'not_a_number'", "true"); },
+      ThrowsMessage<silo::query_engine::IllegalQueryException>(
+         ::testing::HasSubstr("expected integer literal")
+      )
+   );
+
+   // String columns cannot be updated by this scalar path.
+   EXPECT_THAT(
+      [&]() { database->updateColumn(table, "division", "Basel", "true"); },
+      ThrowsMessage<silo::query_engine::IllegalQueryException>(::testing::HasSubstr("not supported")
+      )
+   );
+
+   // Unknown columns and tables are reported.
+   EXPECT_THAT(
+      [&]() { database->updateColumn(table, "does_not_exist", "1", "true"); },
+      ThrowsMessage<silo::query_engine::IllegalQueryException>(
+         ::testing::HasSubstr("does not contain a column")
+      )
+   );
 }
 
 using silo::Nucleotide;

--- a/src/silo/query_engine/scalar_column_update.cpp
+++ b/src/silo/query_engine/scalar_column_update.cpp
@@ -1,0 +1,62 @@
+#include "silo/query_engine/scalar_column_update.h"
+
+#include <optional>
+
+#include <fmt/format.h>
+
+#include "silo/query_engine/illegal_query_exception.h"
+#include "silo/query_engine/saneql/ast.h"
+#include "silo/query_engine/saneql/parser.h"
+#include "silo/storage/column_group.h"
+
+namespace silo::query_engine {
+
+void assignScalarLiteralToColumn(
+   storage::ColumnGroup& columns,
+   const schema::ColumnIdentifier& column,
+   const std::string& value,
+   const roaring::Roaring& row_ids
+) {
+   namespace ast = saneql::ast;
+
+   // Parse the new value once, going through the same lexer/parser and literal extractors as
+   // queries, so no type-specific string parsing is duplicated. A SaneQL `null` literal clears the
+   // matched rows; every other literal must match the column's type.
+   const auto literal = saneql::Parser{value}.parse();
+   const bool is_null = ast::isNullLiteral(*literal);
+
+   switch (column.type) {
+      case schema::ColumnType::INT32:
+         columns.int_columns.at(column.name)
+            .update(
+               row_ids, is_null ? std::nullopt : std::optional{ast::extractInt32Literal(*literal)}
+            );
+         return;
+      case schema::ColumnType::FLOAT:
+         columns.float_columns.at(column.name)
+            .update(
+               row_ids,
+               is_null ? std::nullopt : std::optional{ast::extractNumericAsFloatLiteral(*literal)}
+            );
+         return;
+      case schema::ColumnType::DATE32:
+         columns.date32_columns.at(column.name)
+            .update(row_ids, ast::extractOptionalDateValue(*literal));
+         return;
+      case schema::ColumnType::BOOL:
+         columns.bool_columns.at(column.name)
+            .update(
+               row_ids, is_null ? std::nullopt : std::optional{ast::extractBoolLiteral(*literal)}
+            );
+         return;
+      default:
+         throw IllegalQueryException(fmt::format(
+            "Updating columns of type '{}' is not supported; only INT32, FLOAT, DATE32 and BOOL "
+            "columns can be updated (column '{}')",
+            schema::columnTypeToString(column.type),
+            column.name
+         ));
+   }
+}
+
+}  // namespace silo::query_engine

--- a/src/silo/query_engine/scalar_column_update.h
+++ b/src/silo/query_engine/scalar_column_update.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+
+#include <roaring/roaring.hh>
+
+#include "silo/schema/database_schema.h"
+
+namespace silo::storage {
+class ColumnGroup;
+}
+
+namespace silo::query_engine {
+
+/// Parses `value` as a SaneQL scalar literal (using the same lexer/parser as queries) and assigns
+/// it to every row in `row_ids` of the column identified by `column` within `columns`. The literal
+/// must match the column's type, e.g. `3`, `3.14`, `true`, or `'2021-03-15'::date`; the literal
+/// `null` clears the matched rows. Only scalar value columns (INT32, FLOAT, DATE32, BOOL) can be
+/// updated; other column types raise an IllegalQueryException.
+void assignScalarLiteralToColumn(
+   storage::ColumnGroup& columns,
+   const schema::ColumnIdentifier& column,
+   const std::string& value,
+   const roaring::Roaring& row_ids
+);
+
+}  // namespace silo::query_engine

--- a/src/silo/storage/column/bool_column.cpp
+++ b/src/silo/storage/column/bool_column.cpp
@@ -27,4 +27,22 @@ std::expected<void, std::string> BoolColumn::appendChunk(const Buffer& buffer) {
    num_chunks++;
    return {};
 }
+
+void BoolColumn::update(const roaring::Roaring& row_ids, std::optional<bool> value) {
+   if (value == std::nullopt) {
+      null_bitmap |= row_ids;
+   } else {
+      null_bitmap -= row_ids;
+   }
+   if (value == true) {
+      true_bitmap |= row_ids;
+   } else {
+      true_bitmap -= row_ids;
+   }
+   if (value == false) {
+      false_bitmap |= row_ids;
+   } else {
+      false_bitmap -= row_ids;
+   }
+}
 }  // namespace silo::storage::column

--- a/src/silo/storage/column/bool_column.h
+++ b/src/silo/storage/column/bool_column.h
@@ -67,6 +67,12 @@ class BoolColumn {
 
    std::expected<void, std::string> appendChunk(const Buffer& buffer);
 
+   /// Assigns `value` to every row in `row_ids` (physical global row ids). Each row is first
+   /// removed from all three bitmaps and then re-classified into the true, false or null bitmap
+   /// according to `value` (`std::nullopt` marks it null). Rows not in `row_ids` are left
+   /// untouched.
+   void update(const roaring::Roaring& row_ids, std::optional<bool> value);
+
   private:
    friend class boost::serialization::access;
    template <class Archive>

--- a/src/silo/storage/column/chunked_value_buffer.h
+++ b/src/silo/storage/column/chunked_value_buffer.h
@@ -36,6 +36,12 @@ class ChunkedValueBuffer {
       return chunks.at(row_id.chunk_id).at(row_id.row_in_chunk);
    }
 
+   /// Overwrites the value at `row_id` in place. Used by `update` to assign a new scalar value to
+   /// an already ingested row; null handling lives in the owning column's bitmaps.
+   void setValue(RowId row_id, T value) {
+      chunks.at(row_id.chunk_id).at(row_id.row_in_chunk) = value;
+   }
+
    /// The most recently appended value (the last value of the last chunk).
    [[nodiscard]] const T& lastValue() const { return chunks.back().back(); }
 

--- a/src/silo/storage/column/date32_column.cpp
+++ b/src/silo/storage/column/date32_column.cpp
@@ -1,6 +1,9 @@
 #include "silo/storage/column/date32_column.h"
 
+#include <cstdint>
+
 #include "silo/common/date32.h"
+#include "silo/storage/column/row_id.h"
 
 namespace silo::storage::column {
 
@@ -30,6 +33,39 @@ std::expected<void, std::string> Date32Column::appendChunk(const Buffer& buffer)
    }
    values.appendChunk(std::move(chunk));
    return {};
+}
+
+void Date32Column::update(const roaring::Roaring& row_ids, std::optional<common::Date32> value) {
+   if (value.has_value()) {
+      null_bitmap -= row_ids;
+   } else {
+      null_bitmap |= row_ids;
+   }
+   const common::Date32 stored_value = value.value_or(0);
+   for (const uint32_t global_row_id : row_ids) {
+      values.setValue(RowId::fromGlobal(global_row_id), stored_value);
+   }
+
+   // An update can move a value in either direction, so the cheap incremental sortedness tracking
+   // of `appendChunk` no longer applies; recompute it by scanning the whole column. As in
+   // `appendChunk`, any null makes the column unsorted, and `last_appended_value` is the last
+   // non-null value so a subsequent `appendChunk` can keep detecting cross-chunk regressions.
+   is_sorted = true;
+   last_appended_value = std::nullopt;
+
+   if (!null_bitmap.isEmpty()) {
+      is_sorted = false;
+      return;
+   }
+   for (size_t chunk_id = 0; chunk_id < values.numChunks(); ++chunk_id) {
+      const std::vector<common::Date32>& chunk = values.chunk(chunk_id);
+      for (common::Date32 date : chunk) {
+         if (last_appended_value.has_value() && date < *last_appended_value) {
+            is_sorted = false;
+         }
+         last_appended_value = date;
+      }
+   }
 }
 
 }  // namespace silo::storage::column

--- a/src/silo/storage/column/date32_column.h
+++ b/src/silo/storage/column/date32_column.h
@@ -44,6 +44,12 @@ class Date32Column {
 
    std::expected<void, std::string> appendChunk(const Buffer& buffer);
 
+   /// Assigns `value` to every row in `row_ids` (physical global row ids). A `std::nullopt` value
+   /// marks the rows null; a concrete value clears their null flag and overwrites the stored value
+   /// in place. Rows not in `row_ids` are left untouched. Since an update can move a value in
+   /// either direction, the column's sortedness is recomputed by a full scan afterwards.
+   void update(const roaring::Roaring& row_ids, std::optional<common::Date32> value);
+
    /// The per-chunk value buffers. Used by `DateBetween` to binary search a sorted column.
    [[nodiscard]] const ChunkedValueBuffer<common::Date32>& getValueBuffer() const { return values; }
 

--- a/src/silo/storage/column/float_column.cpp
+++ b/src/silo/storage/column/float_column.cpp
@@ -1,5 +1,9 @@
 #include "silo/storage/column/float_column.h"
 
+#include <cstdint>
+
+#include "silo/storage/column/row_id.h"
+
 namespace silo::storage::column {
 
 FloatColumn::FloatColumn(ColumnMetadata* metadata)
@@ -19,6 +23,18 @@ std::expected<void, std::string> FloatColumn::appendChunk(const Buffer& buffer) 
    }
    values.appendChunk(std::move(chunk));
    return {};
+}
+
+void FloatColumn::update(const roaring::Roaring& row_ids, std::optional<double> value) {
+   if (value == std::nullopt) {
+      null_bitmap |= row_ids;
+   } else {
+      null_bitmap -= row_ids;
+   }
+   const double stored_value = value.value_or(0.0);
+   for (const uint32_t global_row_id : row_ids) {
+      values.setValue(RowId::fromGlobal(global_row_id), stored_value);
+   }
 }
 
 }  // namespace silo::storage::column

--- a/src/silo/storage/column/float_column.h
+++ b/src/silo/storage/column/float_column.h
@@ -47,6 +47,11 @@ class FloatColumn {
 
    std::expected<void, std::string> appendChunk(const Buffer& buffer);
 
+   /// Assigns `value` to every row in `row_ids` (physical global row ids). A `std::nullopt` value
+   /// marks the rows null; a concrete value clears their null flag and overwrites the stored value
+   /// in place. Rows not in `row_ids` are left untouched.
+   void update(const roaring::Roaring& row_ids, std::optional<double> value);
+
   private:
    friend class boost::serialization::access;
    template <class Archive>

--- a/src/silo/storage/column/int_column.cpp
+++ b/src/silo/storage/column/int_column.cpp
@@ -1,5 +1,9 @@
 #include "silo/storage/column/int_column.h"
 
+#include <cstdint>
+
+#include "silo/storage/column/row_id.h"
+
 namespace silo::storage::column {
 
 IntColumn::IntColumn(ColumnMetadata* metadata)
@@ -19,6 +23,18 @@ std::expected<void, std::string> IntColumn::appendChunk(const Buffer& buffer) {
    }
    values.appendChunk(std::move(chunk));
    return {};
+}
+
+void IntColumn::update(const roaring::Roaring& row_ids, std::optional<int32_t> value) {
+   if (value == std::nullopt) {
+      null_bitmap |= row_ids;
+   } else {
+      null_bitmap -= row_ids;
+   }
+   const int32_t stored_value = value.value_or(0);
+   for (const uint32_t global_row_id : row_ids) {
+      values.setValue(RowId::fromGlobal(global_row_id), stored_value);
+   }
 }
 
 }  // namespace silo::storage::column

--- a/src/silo/storage/column/int_column.h
+++ b/src/silo/storage/column/int_column.h
@@ -50,6 +50,11 @@ class IntColumn {
 
    std::expected<void, std::string> appendChunk(const Buffer& buffer);
 
+   /// Assigns `value` to every row in `row_ids` (physical global row ids). A `std::nullopt` value
+   /// marks the rows null; a concrete value clears their null flag and overwrites the stored value
+   /// in place. Rows not in `row_ids` are left untouched.
+   void update(const roaring::Roaring& row_ids, std::optional<int32_t> value);
+
   private:
    friend class boost::serialization::access;
    template <class Archive>

--- a/src/silo/storage/column/int_column.test.cpp
+++ b/src/silo/storage/column/int_column.test.cpp
@@ -2,6 +2,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <roaring/roaring.hh>
 
 using silo::storage::column::ColumnMetadata;
 using silo::storage::column::IntColumn;
@@ -19,4 +20,50 @@ TEST(IntColumn, doesNotErrorOnValidInputs) {
    ASSERT_FALSE(column.isNull(RowId(0, 0)));
    ASSERT_EQ(column.getValue(RowId(0, 0)), 123);
    ASSERT_TRUE(column.isNull(RowId(0, 1)));
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST(IntColumn, updateAssignsScalarValueAcrossChunks) {
+   ColumnMetadata column_metadata("int_column1");
+   IntColumn column{&column_metadata};
+
+   IntColumn::Builder chunk0;
+   chunk0.insert(10);
+   chunk0.insertNull();  // (0, 1)
+   chunk0.insert(30);
+   SILO_ASSERT(column.appendChunk(chunk0.finalize()).has_value());
+
+   IntColumn::Builder chunk1;
+   chunk1.insert(40);
+   chunk1.insert(50);
+   SILO_ASSERT(column.appendChunk(chunk1.finalize()).has_value());
+
+   ASSERT_EQ(column.numChunks(), 2);
+
+   // Assign a single scalar to a set of rows spanning both column chunks, including the previously
+   // null row (0, 1), which becomes non-null.
+   roaring::Roaring row_ids;
+   row_ids.add(RowId(0, 1).toGlobal());
+   row_ids.add(RowId(0, 2).toGlobal());
+   row_ids.add(RowId(1, 0).toGlobal());
+   column.update(row_ids, 77);
+
+   ASSERT_FALSE(column.isNull(RowId(0, 0)));
+   ASSERT_EQ(column.getValue(RowId(0, 0)), 10);  // untouched
+   ASSERT_FALSE(column.isNull(RowId(0, 1)));
+   ASSERT_EQ(column.getValue(RowId(0, 1)), 77);  // null -> 77
+   ASSERT_FALSE(column.isNull(RowId(0, 2)));
+   ASSERT_EQ(column.getValue(RowId(0, 2)), 77);
+   ASSERT_FALSE(column.isNull(RowId(1, 0)));
+   ASSERT_EQ(column.getValue(RowId(1, 0)), 77);
+   ASSERT_FALSE(column.isNull(RowId(1, 1)));
+   ASSERT_EQ(column.getValue(RowId(1, 1)), 50);  // untouched
+
+   // A nullopt update clears the rows.
+   roaring::Roaring to_clear;
+   to_clear.add(RowId(0, 2).toGlobal());
+   column.update(to_clear, std::nullopt);
+   ASSERT_TRUE(column.isNull(RowId(0, 2)));
+   ASSERT_FALSE(column.isNull(RowId(1, 0)));
+   ASSERT_EQ(column.getValue(RowId(1, 0)), 77);
 }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1358

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

As a first step this only allows the updating of value columns with _literal_ values.

We already add the functions with the intended interface to the python bindings and use the same saneql parser for parsing the literal values.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
