### PR TITLE
refactor(SaneQL): pipeline optimization: pull up map nodes through order by nodes

### DIFF
--- a/src/silo/query_engine/optimizer/map_pullup_pass.cpp
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.cpp
@@ -1,9 +1,12 @@
 #include "silo/query_engine/optimizer/map_pullup_pass.h"
 
 #include <memory>
+#include <string>
+#include <unordered_set>
 
 #include "silo/query_engine/operators/fetch_node.h"
 #include "silo/query_engine/operators/map_node.h"
+#include "silo/query_engine/operators/order_by_node.h"
 
 namespace silo::query_engine::optimizer {
 
@@ -22,6 +25,38 @@ operators::QueryNodePtr MapPullupPass::operator()(operators::FetchNode& node) {
    auto new_fetch =
       std::make_unique<operators::FetchNode>(std::move(map.child), node.count, node.offset);
    map.child = std::move(new_fetch);
+   return map_owner;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr MapPullupPass::operator()(operators::OrderByNode& node) {
+   propagateToNode(node.child);
+
+   if (node.child->kind() != operators::NodeKind::MAP) {
+      return nullptr;
+   }
+   auto& map = static_cast<operators::MapNode&>(*node.child);
+
+   // The columns the MapNode produces (newly added or replaced in place).
+   std::unordered_set<std::string> produced_columns;
+   for (const auto& assignment : map.assignments) {
+      produced_columns.insert(assignment.output_column.name);
+   }
+
+   // Pulling the MapNode above the OrderBy is only safe when no order-by field references a
+   // produced column. Otherwise the OrderBy below would sort on a different value (a replaced
+   // column) or a column that does not exist yet (a newly added one), changing the result.
+   for (const auto& field : node.fields) {
+      if (produced_columns.contains(field.field.name)) {
+         return nullptr;
+      }
+   }
+
+   operators::QueryNodePtr map_owner = std::move(node.child);
+   auto new_order_by = std::make_unique<operators::OrderByNode>(
+      std::move(map.child), std::move(node.fields), node.randomize_seed
+   );
+   map.child = std::move(new_order_by);
    return map_owner;
 }
 

--- a/src/silo/query_engine/optimizer/map_pullup_pass.h
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.h
@@ -5,6 +5,7 @@
 
 namespace silo::query_engine::operators {
 class FetchNode;
+class OrderByNode;
 }  // namespace silo::query_engine::operators
 
 namespace silo::query_engine::optimizer {
@@ -27,6 +28,7 @@ class MapPullupPass : public PipelinePassBase<MapPullupPass> {
    using PipelinePassBase<MapPullupPass>::operator();
 
    operators::QueryNodePtr operator()(operators::FetchNode& node);
+   operators::QueryNodePtr operator()(operators::OrderByNode& node);
 };
 
 }  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
@@ -215,11 +215,56 @@ TEST(MapPullupPass, doesNotPullMapUpThroughProject) {
    EXPECT_EQ(project_node->child->kind(), operators::NodeKind::MAP);
 }
 
-// --- Blocked: OrderByNode ---
+// --- OrderByNode(MapNode(...)) → MapNode(OrderByNode(...)) when the order-by fields do not
+// reference a produced column ---
 
-TEST(MapPullupPass, doesNotPullMapUpThroughOrderBy) {
+TEST(MapPullupPass, pullsMapUpThroughOrderBy) {
    std::vector<silo::query_engine::OrderByField> fields{
       {.field = {.name = "id", .type = ColumnType::STRING}, .ascending = true}
+   };
+   auto order_by = std::make_unique<operators::OrderByNode>(
+      makeMap(makeScan()), std::move(fields), std::nullopt
+   );
+
+   auto result = MapPullupPass::run(std::move(order_by));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* map = dynamic_cast<operators::MapNode*>(result.get());
+   ASSERT_EQ(map->child->kind(), operators::NodeKind::ORDER_BY);
+   auto* moved_order_by = dynamic_cast<operators::OrderByNode*>(map->child.get());
+   ASSERT_EQ(moved_order_by->fields.size(), 1);
+   EXPECT_EQ(moved_order_by->fields.front().field.name, "id");
+   EXPECT_TRUE(moved_order_by->fields.front().ascending);
+   EXPECT_EQ(moved_order_by->child->kind(), operators::NodeKind::TABLE_SCAN);
+}
+
+// The randomize seed is preserved when the OrderBy moves below the Map.
+
+TEST(MapPullupPass, pullsMapUpThroughOrderByPreservingRandomizeSeed) {
+   std::vector<silo::query_engine::OrderByField> fields{
+      {.field = {.name = "id", .type = ColumnType::STRING}, .ascending = true}
+   };
+   auto order_by = std::make_unique<operators::OrderByNode>(
+      makeMap(makeScan()), std::move(fields), std::optional<uint32_t>{42}
+   );
+
+   auto result = MapPullupPass::run(std::move(order_by));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* map = dynamic_cast<operators::MapNode*>(result.get());
+   ASSERT_EQ(map->child->kind(), operators::NodeKind::ORDER_BY);
+   auto* moved_order_by = dynamic_cast<operators::OrderByNode*>(map->child.get());
+   ASSERT_TRUE(moved_order_by->randomize_seed.has_value());
+   EXPECT_EQ(moved_order_by->randomize_seed.value(), 42);
+}
+
+// --- Blocked: an order-by field references a column the MapNode produces, so swapping would
+// change ordering. The MapNode stays below the OrderBy. ---
+
+TEST(MapPullupPass, doesNotPullMapUpThroughOrderByOnProducedColumn) {
+   // makeMap produces column `x`; ordering by `x` must not be pushed below the Map.
+   std::vector<silo::query_engine::OrderByField> fields{
+      {.field = {.name = "x", .type = ColumnType::INT64}, .ascending = true}
    };
    auto order_by = std::make_unique<operators::OrderByNode>(
       makeMap(makeScan()), std::move(fields), std::nullopt


### PR DESCRIPTION

part of #1336

### Summary

Extends `MapPullupPass` to also pull a `MapNode` up through an `OrderByNode`, so expensive per-row computation (notably zstd decompression) runs after the sort rather than on every input row.

- **Pull Map above OrderBy** — rewrites `OrderBy(Map(child))` into `Map(OrderBy(child))`, preserving the order-by fields and `randomize_seed`.
- **Correctness gate** — the swap is skipped when any order-by field references a column the Map produces (added or replaced in place), since sorting below the Map would otherwise use a different or not-yet-existing value.

Scoped to `OrderBy` only: `Project` is left out (column narrowing already removes most Projects) and `Aggregate` is postponed, per the issue discussion.

## PR Checklist

- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
