### PR TITLE
perf(silo): always prime Selection with most-selective predicate

### DIFF
--- a/performance/many_short_read_filters.cpp
+++ b/performance/many_short_read_filters.cpp
@@ -115,14 +115,12 @@ void run() {
 
    auto [database, reference_length] = setupTestDatabase();
 
-   while (true) {
-      SPDLOG_INFO("Starting full query set benchmark ({} queries):", DEFAULT_QUERY_COUNT);
-      auto start = std::chrono::high_resolution_clock::now();
-      executeAllQueries(database, reference_length);
-      auto end = std::chrono::high_resolution_clock::now();
-      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-      SPDLOG_INFO("Finished full query set in {}.{:03} seconds", duration / 1000, duration % 1000);
-   }
+   SPDLOG_INFO("Starting full query set benchmark ({} queries):", DEFAULT_QUERY_COUNT);
+   auto start = std::chrono::high_resolution_clock::now();
+   executeAllQueries(database, reference_length);
+   auto end = std::chrono::high_resolution_clock::now();
+   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+   SPDLOG_INFO("Finished full query set in {}.{:03} seconds", duration / 1000, duration % 1000);
 }
 
 }  // namespace

--- a/src/silo/query_engine/filter/operators/selection.cpp
+++ b/src/silo/query_engine/filter/operators/selection.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <compare>
 #include <iterator>
+#include <ranges>
 #include <utility>
 #include <vector>
 
@@ -89,53 +90,41 @@ Type Selection::type() const {
    return SELECTION;
 }
 
-bool Selection::matchesPredicates(const PredicateVector& predicates, uint32_t row) {
-   return std::ranges::all_of(predicates, [&](const auto& predicate) {
-      return predicate->match(row);
-   });
-}
-
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 CopyOnWriteBitmap Selection::evaluate() const {
    EVOBENCH_SCOPE("Selection", "evaluate");
+   SILO_ASSERT(!predicates.empty());
+
+   // Build the candidate rows that already satisfy the most selective predicate. Predicates are
+   // sorted most-selective-first at construction
+   roaring::Roaring candidates;
    if (child_operator.has_value()) {
       CopyOnWriteBitmap child_result = (*child_operator)->evaluate();
-      // Do not iterate over bitmap, if child result is larger than 10%
-      if (child_result.getConstReference().cardinality() > row_layout.numRows() / 10) {
-         SILO_ASSERT(!predicates.empty());
-         auto most_selective_predicate_bitmap = predicates.front()->makeBitmap(row_layout);
-         child_result.getMutable() &= most_selective_predicate_bitmap;
-
-         if (predicates.size() == 1) {
-            return CopyOnWriteBitmap{std::move(child_result)};
-         }
-
-         // Apply all remaining predicates as before `matchesPredicates`
-         PredicateVector remaining_predicates;
-         remaining_predicates.reserve(predicates.size() - 1);
-         for (size_t i = 1; i < predicates.size(); ++i) {
-            remaining_predicates.push_back(predicates.at(i)->copy());
-         }
+      // For a small child, matching each of its rows against every predicate is cheaper than
+      // materializing the first predicate over the whole partition.
+      if (child_result.getConstReference().cardinality() <= row_layout.numRows() / 10) {
          roaring::Roaring result;
          for (const uint32_t row : child_result.getConstReference()) {
-            if (matchesPredicates(remaining_predicates, row)) {
+            if (matchesPredicates(predicates, row)) {
                result.add(row);
             }
          }
          return CopyOnWriteBitmap{std::move(result)};
       }
-      roaring::Roaring result;
-      for (const uint32_t row : child_result.getConstReference()) {
-         if (matchesPredicates(predicates, row)) {
-            result.add(row);
-         }
-      }
-      return CopyOnWriteBitmap{std::move(result)};
+      candidates = std::move(child_result.getMutable());
+      candidates &= predicates.front()->makeBitmap(row_layout);
+   } else {
+      candidates = predicates.front()->makeBitmap(row_layout);
    }
+
+   // `candidates` already satisfies predicates.front(); apply the remaining predicates row by row.
+   if (predicates.size() == 1) {
+      return CopyOnWriteBitmap{std::move(candidates)};
+   }
+   const auto remaining_predicates =
+      std::ranges::subrange(predicates.begin() + 1, predicates.end());
    roaring::Roaring result;
-   for (const storage::column::RowId row_id : row_layout) {
-      const uint32_t row = row_id.toGlobal();
-      if (matchesPredicates(predicates, row)) {
+   for (const uint32_t row : candidates) {
+      if (matchesPredicates(remaining_predicates, row)) {
          result.add(row);
       }
    }

--- a/src/silo/query_engine/filter/operators/selection.h
+++ b/src/silo/query_engine/filter/operators/selection.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -213,7 +215,12 @@ class Selection : public Operator {
    static std::unique_ptr<Operator> negate(std::unique_ptr<Selection>&& selection);
 
   private:
-   [[nodiscard]] static bool matchesPredicates(const PredicateVector& predicates, uint32_t row);
+   template <std::ranges::range PredicateRange>
+   [[nodiscard]] static bool matchesPredicates(const PredicateRange& predicates, uint32_t row) {
+      return std::ranges::all_of(predicates, [row](const auto& predicate) {
+         return predicate->match(row);
+      });
+   }
 };
 
 }  // namespace silo::query_engine::filter::operators

--- a/src/silo/query_engine/filter/operators/selection.test.cpp
+++ b/src/silo/query_engine/filter/operators/selection.test.cpp
@@ -3,10 +3,16 @@
 #include <gtest/gtest.h>
 #include <roaring/roaring.hh>
 
+#include "silo/query_engine/copy_on_write_bitmap.h"
+#include "silo/query_engine/filter/operators/bitmap_producer.h"
 #include "silo/storage/column/int_column.h"
 
+using silo::query_engine::CopyOnWriteBitmap;
+using silo::query_engine::filter::operators::BitmapProducer;
 using silo::query_engine::filter::operators::Comparator;
 using silo::query_engine::filter::operators::CompareToValueSelection;
+using silo::query_engine::filter::operators::Operator;
+using silo::query_engine::filter::operators::Predicate;
 using silo::query_engine::filter::operators::Selection;
 using silo::storage::column::ColumnMetadata;
 using silo::storage::column::IntColumn;
@@ -151,4 +157,78 @@ TEST(OperatorSelection, returnsCorrectTypeInfo) {
    );
 
    ASSERT_EQ(under_test.type(), silo::query_engine::filter::operators::SELECTION);
+}
+
+namespace {
+
+// A column of 100 rows holding value == row index, so global row ids map directly to bitmap bits.
+std::pair<std::shared_ptr<ColumnMetadata>, IntColumn> makeRangeTestColumn() {
+   std::vector<int32_t> values;
+   values.reserve(100);
+   for (int32_t i = 0; i < 100; ++i) {
+      values.push_back(i);
+   }
+   return makeTestColumn(values);
+}
+
+// value >= 10 AND value < 50, as two separate predicates, matching rows [10, 50).
+std::vector<std::unique_ptr<Predicate>> makeRangePredicates(const IntColumn& column) {
+   std::vector<std::unique_ptr<Predicate>> predicates;
+   predicates.push_back(
+      std::make_unique<CompareToValueSelection<IntColumn>>(column, Comparator::HIGHER_OR_EQUALS, 10)
+   );
+   predicates.push_back(
+      std::make_unique<CompareToValueSelection<IntColumn>>(column, Comparator::LESS, 50)
+   );
+   return predicates;
+}
+
+roaring::Roaring rangeBitmap(uint32_t start, uint32_t end) {
+   roaring::Roaring result;
+   result.addRange(start, end);
+   return result;
+}
+
+}  // namespace
+
+TEST(OperatorSelection, multiplePredicatesWithoutChildReturnCorrectValues) {
+   auto [metadata, test_column] = makeRangeTestColumn();
+   const auto row_layout = RowLayout::of(100);
+
+   const Selection under_test(makeRangePredicates(test_column), row_layout);
+
+   ASSERT_EQ(under_test.evaluate().getConstReference(), rangeBitmap(10, 50));
+}
+
+TEST(OperatorSelection, multiplePredicatesWithLargeChildReturnCorrectValues) {
+   auto [metadata, test_column] = makeRangeTestColumn();
+   const auto row_layout = RowLayout::of(100);
+
+   // Child cardinality (75) exceeds numRows / 10 == 10, so the large-child branch primes candidates
+   // from the most-selective predicate.
+   const roaring::Roaring child_bitmap = rangeBitmap(5, 80);
+   std::unique_ptr<Operator> child = std::make_unique<BitmapProducer>(
+      [&]() { return CopyOnWriteBitmap(&child_bitmap); }, row_layout
+   );
+
+   const Selection under_test(std::move(child), makeRangePredicates(test_column), row_layout);
+
+   // child [5, 80) intersected with [10, 50) == [10, 50).
+   ASSERT_EQ(under_test.evaluate().getConstReference(), rangeBitmap(10, 50));
+}
+
+TEST(OperatorSelection, multiplePredicatesWithSmallChildReturnCorrectValues) {
+   auto [metadata, test_column] = makeRangeTestColumn();
+   const auto row_layout = RowLayout::of(100);
+
+   // Child cardinality (5) is <= numRows / 10 == 10, so the small-child branch matches every child
+   // row against all predicates. Rows 5 and 60 and 99 fail the [10, 50) range.
+   const roaring::Roaring child_bitmap({5, 15, 45, 60, 99});
+   std::unique_ptr<Operator> child = std::make_unique<BitmapProducer>(
+      [&]() { return CopyOnWriteBitmap(&child_bitmap); }, row_layout
+   );
+
+   const Selection under_test(std::move(child), makeRangePredicates(test_column), row_layout);
+
+   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({15, 45}));
 }


### PR DESCRIPTION
A large oversight when I added optimizations to the new storage backend for short-reads:

When no child-operator is present in a `Selection` it will iterate and check the predicates of ALL row-ids. It should skip this step with a `makeBitmap` call to its first predicate, which _might_ provide a specialized implementation of the bitmap computation (`IsInCoveredRegion` does provide this)