### PR TITLE
refactor(query_engine): compose scalar expressions and collapse stacked maps

### DIFF
--- a/src/silo/query_engine/operators/map_node.cpp
+++ b/src/silo/query_engine/operators/map_node.cpp
@@ -26,6 +26,7 @@ namespace silo::query_engine::operators {
 
 using scalar_expressions::At;
 using scalar_expressions::BoolLiteral;
+using scalar_expressions::dynCast;
 using scalar_expressions::FieldRef;
 using scalar_expressions::FloatLiteral;
 using scalar_expressions::Int64Literal;
@@ -40,46 +41,59 @@ namespace {
 /// projection.
 arrow::Result<arrow::compute::Expression> scalarToArrowExpression(const ScalarExpression& expression
 ) {
-   if (const auto* literal = dynamic_cast<const Int64Literal*>(&expression)) {
+   if (const auto* literal = dynCast<Int64Literal>(&expression)) {
       return arrow::compute::literal(arrow::Datum(literal->value));
    }
-   if (const auto* literal = dynamic_cast<const FloatLiteral*>(&expression)) {
+   if (const auto* literal = dynCast<FloatLiteral>(&expression)) {
       return arrow::compute::literal(arrow::Datum(literal->value));
    }
-   if (const auto* literal = dynamic_cast<const StringLiteral*>(&expression)) {
+   if (const auto* literal = dynCast<StringLiteral>(&expression)) {
       return arrow::compute::literal(arrow::Datum(literal->value));
    }
-   if (const auto* literal = dynamic_cast<const BoolLiteral*>(&expression)) {
+   if (const auto* literal = dynCast<BoolLiteral>(&expression)) {
       return arrow::compute::literal(arrow::Datum(literal->value));
    }
-   if (const auto* field_ref = dynamic_cast<const FieldRef*>(&expression)) {
+   if (const auto* field_ref = dynCast<FieldRef>(&expression)) {
       return arrow::compute::field_ref(field_ref->column.name);
    }
-   if (const auto* zstd = dynamic_cast<const ZstdDecompressScalar*>(&expression)) {
-      return exec_node::ZstdDecompressExpression::make(
-         arrow::compute::field_ref(zstd->input_column.name), zstd->dictionary_string
-      );
+   if (const auto* zstd = dynCast<ZstdDecompressScalar>(&expression)) {
+      ARROW_ASSIGN_OR_RAISE(auto input, scalarToArrowExpression(*zstd->input));
+      return exec_node::ZstdDecompressExpression::make(input, zstd->dictionary_string);
    }
-   if (const auto* at_function = dynamic_cast<const At*>(&expression)) {
+   if (const auto* at_function = dynCast<At>(&expression)) {
       // `at` is 1-indexed; utf8_slice_codeunits takes a 0-indexed, half-open
       // [start, stop) range of code units, so extract the single character at
       // position-1.
       const int64_t start = static_cast<int64_t>(at_function->position) - 1;
       const auto stop = static_cast<int64_t>(at_function->position);
+      ARROW_ASSIGN_OR_RAISE(auto input, scalarToArrowExpression(*at_function->input));
       return arrow::compute::call(
-         "utf8_slice_codeunits",
-         {arrow::compute::field_ref(at_function->input_column.name)},
-         arrow::compute::SliceOptions(start, stop)
+         "utf8_slice_codeunits", {input}, arrow::compute::SliceOptions(start, stop)
       );
    }
-   if (const auto* iso_week = dynamic_cast<const IsoWeek*>(&expression)) {
-      return arrow::compute::call(
-         "iso_week", {arrow::compute::field_ref(iso_week->input_column.name)}
-      );
+   if (const auto* iso_week = dynCast<IsoWeek>(&expression)) {
+      ARROW_ASSIGN_OR_RAISE(auto input, scalarToArrowExpression(*iso_week->input));
+      return arrow::compute::call("iso_week", {input});
    }
    return arrow::Status::NotImplemented(
       "the scalar expression ", expression.toString(), " is not supported in map() assignments"
    );
+}
+
+/// Sums the dictionary sizes of every `ZstdDecompressScalar` anywhere in `expression`'s tree. A
+/// decompress may be nested inside another scalar expression (e.g. `At(ZstdDecompress(...))` after
+/// a map merge), so the whole tree is traversed rather than just the top node.
+size_t sumDecompressDictionarySizes(const ScalarExpression& expression) {
+   if (const auto* zstd = dynCast<ZstdDecompressScalar>(&expression)) {
+      return zstd->dictionary_string.size() + sumDecompressDictionarySizes(*zstd->input);
+   }
+   if (const auto* at_function = dynCast<At>(&expression)) {
+      return sumDecompressDictionarySizes(*at_function->input);
+   }
+   if (const auto* iso_week = dynCast<IsoWeek>(&expression)) {
+      return sumDecompressDictionarySizes(*iso_week->input);
+   }
+   return 0;
 }
 
 /// When any assignment uses zstd decompression, insert a backpressure sink/source pair into the
@@ -97,10 +111,7 @@ arrow::Result<std::optional<arrow::acero::ExecNode*>> insertBackpressureForDecom
 ) {
    size_t sum_of_reference_genome_sizes = 0;
    for (const auto& assignment : assignment_by_name | std::views::values) {
-      if (const auto* zstd =
-             dynamic_cast<const ZstdDecompressScalar*>(assignment->expression.get())) {
-         sum_of_reference_genome_sizes += zstd->dictionary_string.size();
-      }
+      sum_of_reference_genome_sizes += sumDecompressDictionarySizes(*assignment->expression);
    }
 
    if (sum_of_reference_genome_sizes == 0) {

--- a/src/silo/query_engine/optimizer/column_narrowing_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.test.cpp
@@ -97,7 +97,7 @@ operators::MapNode::Assignment decompressAssignment(const ColumnIdentifier& sequ
    return {
       .output_column = col(sequence_col.name),
       .expression = std::make_unique<silo::query_engine::scalar_expressions::ZstdDecompressScalar>(
-         sequence_col, "A"
+         std::make_unique<silo::query_engine::scalar_expressions::FieldRef>(sequence_col), "A"
       )
    };
 }

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.test.cpp
@@ -11,6 +11,7 @@
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
+#include "silo/query_engine/scalar_expressions/field_ref.h"
 #include "silo/query_engine/scalar_expressions/literal.h"
 #include "silo/query_engine/scalar_expressions/zstd_decompress_scalar.h"
 #include "silo/schema/database_schema.h"
@@ -128,7 +129,9 @@ TEST(FilterPushdownPass, pushesFilterThroughDecompressMapIntoTableScan) {
    std::vector<operators::MapNode::Assignment> assignments;
    assignments.push_back(
       {.output_column = {.name = "seq", .type = ColumnType::STRING},
-       .expression = std::make_unique<scalar_expressions::ZstdDecompressScalar>(seq_column, "A")}
+       .expression = std::make_unique<scalar_expressions::ZstdDecompressScalar>(
+          std::make_unique<scalar_expressions::FieldRef>(seq_column), "A"
+       )}
    );
    auto map_node = std::make_unique<operators::MapNode>(std::move(scan), std::move(assignments));
    auto filter_node =

--- a/src/silo/query_engine/optimizer/map_pullup_pass.cpp
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.cpp
@@ -1,14 +1,84 @@
 #include "silo/query_engine/optimizer/map_pullup_pass.h"
 
+#include <cstddef>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "silo/query_engine/operators/fetch_node.h"
 #include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
+#include "silo/query_engine/scalar_expressions/at.h"
+#include "silo/query_engine/scalar_expressions/field_ref.h"
+#include "silo/query_engine/scalar_expressions/iso_week.h"
+#include "silo/query_engine/scalar_expressions/scalar_expression.h"
+#include "silo/query_engine/scalar_expressions/zstd_decompress_scalar.h"
 
 namespace silo::query_engine::optimizer {
+
+namespace {
+
+using scalar_expressions::ScalarExpression;
+
+/// Rebuilds `expression` with every `FieldRef` to a column in `produced` replaced by a clone of
+/// that column's defining expression, inlining a lower map's assignments into an upper map's
+/// expression.
+///
+/// Returns nullptr when the expression cannot be safely inlined — it references a produced column
+/// through a construct this function does not know how to rewrite (e.g. an `Equals` or another
+/// predicate that stores bare column identifiers) — in which case the caller must decline the
+/// merge. A leaf constant, or any expression that references none of the produced columns, is
+/// cloned unchanged; recognising "references no produced column" via `freeIUs()` keeps this robust
+/// to expression kinds (new literal types, predicates) it has no explicit case for.
+std::unique_ptr<ScalarExpression> substituteColumns(
+   const ScalarExpression& expression,
+   const std::unordered_map<std::string, const ScalarExpression*>& produced
+) {
+   using Kind = ScalarExpression::Kind;
+   switch (expression.kind()) {
+      case Kind::FIELD_REF: {
+         const auto& field_ref = static_cast<const scalar_expressions::FieldRef&>(expression);
+         const auto replacement = produced.find(field_ref.column.name);
+         return replacement != produced.end() ? replacement->second->clone() : expression.clone();
+      }
+      case Kind::AT: {
+         const auto& at = static_cast<const scalar_expressions::At&>(expression);
+         auto input = substituteColumns(*at.input, produced);
+         return input == nullptr
+                   ? nullptr
+                   : std::make_unique<scalar_expressions::At>(std::move(input), at.position);
+      }
+      case Kind::ISO_WEEK: {
+         const auto& iso_week = static_cast<const scalar_expressions::IsoWeek&>(expression);
+         auto input = substituteColumns(*iso_week.input, produced);
+         return input == nullptr ? nullptr
+                                 : std::make_unique<scalar_expressions::IsoWeek>(std::move(input));
+      }
+      case Kind::ZSTD_DECOMPRESS_SCALAR: {
+         const auto& zstd =
+            static_cast<const scalar_expressions::ZstdDecompressScalar&>(expression);
+         auto input = substituteColumns(*zstd.input, produced);
+         return input == nullptr ? nullptr
+                                 : std::make_unique<scalar_expressions::ZstdDecompressScalar>(
+                                      std::move(input), zstd.dictionary_string
+                                   );
+      }
+      default:
+         // Any other expression: we cannot rewrite its column references, so keeping it is only
+         // safe when it references none of the produced columns. Otherwise decline the merge.
+         for (const auto& free_iu : expression.freeIUs()) {
+            if (produced.contains(free_iu.name)) {
+               return nullptr;
+            }
+         }
+         return expression.clone();
+   }
+}
+
+}  // namespace
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr MapPullupPass::operator()(operators::FetchNode& node) {
@@ -58,6 +128,65 @@ operators::QueryNodePtr MapPullupPass::operator()(operators::OrderByNode& node) 
    );
    map.child = std::move(new_order_by);
    return map_owner;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr MapPullupPass::operator()(operators::MapNode& node) {
+   // Merge child-first, so a chain of maps collapses bottom-up into `node`'s child before we merge.
+   propagateToNode(node.child);
+
+   if (node.child->kind() != operators::NodeKind::MAP) {
+      return nullptr;
+   }
+   auto& lower = static_cast<operators::MapNode&>(*node.child);
+
+   // The columns the lower map produces, mapped to their defining expressions: an upper expression
+   // referencing one of these reads the lower map's computed value, so it must be inlined.
+   std::unordered_map<std::string, const ScalarExpression*>
+      lower_produced_expressions_by_output_name;
+   for (const auto& assignment : lower.assignments) {
+      lower_produced_expressions_by_output_name.emplace(
+         assignment.output_column.name, assignment.expression.get()
+      );
+   }
+
+   // Inline lower-produced columns into the upper expressions up front. If any expression cannot be
+   // safely rewritten, decline the merge and leave both maps untouched (nothing has been moved
+   // yet).
+   std::vector<std::unique_ptr<ScalarExpression>> substituted_expressions;
+   substituted_expressions.reserve(node.assignments.size());
+   for (const auto& assignment : node.assignments) {
+      auto expression =
+         substituteColumns(*assignment.expression, lower_produced_expressions_by_output_name);
+      if (expression == nullptr) {
+         return nullptr;
+      }
+      substituted_expressions.push_back(std::move(expression));
+   }
+
+   std::unordered_set<std::string> upper_outputs;
+   for (const auto& assignment : node.assignments) {
+      upper_outputs.insert(assignment.output_column.name);
+   }
+
+   std::vector<operators::MapNode::Assignment> merged;
+   merged.reserve(lower.assignments.size() + node.assignments.size());
+   // Keep the lower map's assignments the upper map does not overwrite: they are lower-produced
+   // columns the upper map passes through, and they read the (now shared) grandchild directly.
+   for (auto& assignment : lower.assignments) {
+      if (!upper_outputs.contains(assignment.output_column.name)) {
+         merged.push_back(std::move(assignment));
+      }
+   }
+   // The upper map's assignments, with references to lower-produced columns now inlined.
+   for (size_t i = 0; i < node.assignments.size(); ++i) {
+      merged.push_back(
+         {.output_column = node.assignments[i].output_column,
+          .expression = std::move(substituted_expressions[i])}
+      );
+   }
+
+   return std::make_unique<operators::MapNode>(std::move(lower.child), std::move(merged));
 }
 
 }  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/map_pullup_pass.h
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.h
@@ -5,6 +5,7 @@
 
 namespace silo::query_engine::operators {
 class FetchNode;
+class MapNode;
 class OrderByNode;
 }  // namespace silo::query_engine::operators
 
@@ -23,12 +24,25 @@ namespace silo::query_engine::optimizer {
 ///
 /// One goal is pulling a MapNode above a FetchNode (limit/offset)
 /// so a `limit` no longer forces every row to be decompressed and then discarded.
+///
+/// The pass also contracts two directly stacked MapNodes into one:
+///
+/// ```
+/// M_upper(M_lower(child))  →  M_merged(child)
+/// ```
+///
+/// by inlining each lower assignment into the upper expressions that reference it (substituting the
+/// referencing `FieldRef` with the lower expression). This turns the decompress + `at` pattern
+/// (`at(x) := main.at(pos)` over `main := zstdDecompress(main)`) into a single map holding the
+/// nested `at(zstdDecompress(main))`, which downstream passes can match as one clear expression
+/// tree.
 class MapPullupPass : public PipelinePassBase<MapPullupPass> {
   public:
    using PipelinePassBase<MapPullupPass>::operator();
 
    operators::QueryNodePtr operator()(operators::FetchNode& node);
    operators::QueryNodePtr operator()(operators::OrderByNode& node);
+   operators::QueryNodePtr operator()(operators::MapNode& node);
 };
 
 }  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/map_pullup_pass.test.cpp
@@ -1,5 +1,6 @@
 #include "silo/query_engine/optimizer/map_pullup_pass.h"
 
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <optional>
@@ -15,6 +16,9 @@
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/order_by_field.h"
+#include "silo/query_engine/scalar_expressions/at.h"
+#include "silo/query_engine/scalar_expressions/equals.h"
+#include "silo/query_engine/scalar_expressions/field_ref.h"
 #include "silo/query_engine/scalar_expressions/literal.h"
 #include "silo/query_engine/scalar_expressions/zstd_decompress_scalar.h"
 #include "silo/schema/database_schema.h"
@@ -118,7 +122,9 @@ TEST(MapPullupPass, pullsDecompressMapUpThroughFetch) {
    std::vector<operators::MapNode::Assignment> assignments;
    assignments.push_back(
       {.output_column = {.name = "seq", .type = ColumnType::STRING},
-       .expression = std::make_unique<scalar_expressions::ZstdDecompressScalar>(seq_column, "A")}
+       .expression = std::make_unique<scalar_expressions::ZstdDecompressScalar>(
+          std::make_unique<scalar_expressions::FieldRef>(seq_column), "A"
+       )}
    );
    auto map = std::make_unique<operators::MapNode>(
       std::make_unique<operators::TableScanNode>(
@@ -171,23 +177,125 @@ TEST(MapPullupPass, leavesFetchOverNonMapInPlace) {
    EXPECT_EQ(fetch_node->child->kind(), operators::NodeKind::TABLE_SCAN);
 }
 
-// --- MapNode(FetchNode(MapNode(...))): the inner map is pulled above the fetch and comes to
-// rest directly under the (blocked) root map, giving Map(Map(Fetch(scan))). The root map is
-// not itself moved (it is the root). ---
+// --- MapNode(FetchNode(MapNode(...))): the inner map is pulled above the fetch, which brings it
+// directly under the root map; the two adjacent maps are then merged into one, giving
+// Map(Fetch(scan)). Both maps produce `x := 3`, so the merged map keeps a single `x` assignment.
+// ---
 
-TEST(MapPullupPass, pullsInnerMapUpUnderRootMap) {
+TEST(MapPullupPass, pullsInnerMapUpUnderRootMapAndMerges) {
    auto inner_fetch = std::make_unique<operators::FetchNode>(makeMap(makeScan()), 5, std::nullopt);
    auto root_map = makeMap(std::move(inner_fetch));
 
    auto result = MapPullupPass::run(std::move(root_map));
 
    ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
-   auto* outer_map = dynamic_cast<operators::MapNode*>(result.get());
-   ASSERT_EQ(outer_map->child->kind(), operators::NodeKind::MAP);
-   auto* inner_map = dynamic_cast<operators::MapNode*>(outer_map->child.get());
-   ASSERT_EQ(inner_map->child->kind(), operators::NodeKind::FETCH);
-   auto* fetch = dynamic_cast<operators::FetchNode*>(inner_map->child.get());
+   auto* merged_map = dynamic_cast<operators::MapNode*>(result.get());
+   ASSERT_EQ(merged_map->assignments.size(), 1);
+   EXPECT_EQ(merged_map->assignments.front().output_column.name, "x");
+   ASSERT_EQ(merged_map->child->kind(), operators::NodeKind::FETCH);
+   auto* fetch = dynamic_cast<operators::FetchNode*>(merged_map->child.get());
    EXPECT_EQ(fetch->child->kind(), operators::NodeKind::TABLE_SCAN);
+}
+
+// --- Two stacked maps are contracted into one: the upper `at` over the lower in-place decompress
+// becomes a single map whose `symbol` assignment holds the nested at(zstdDecompress(seq)). The
+// lower `seq` decompression is kept as a passthrough (the upper map does not overwrite it). ---
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST(MapPullupPass, mergesAtOverDecompressIntoOneMap) {
+   const auto seq_column = ColumnIdentifier{.name = "seq", .type = ColumnType::NUCLEOTIDE_SEQUENCE};
+
+   std::vector<operators::MapNode::Assignment> lower_assignments;
+   lower_assignments.push_back(
+      {.output_column = {.name = "seq", .type = ColumnType::STRING},
+       .expression = std::make_unique<scalar_expressions::ZstdDecompressScalar>(
+          std::make_unique<scalar_expressions::FieldRef>(seq_column), "A"
+       )}
+   );
+   auto lower_map = std::make_unique<operators::MapNode>(
+      std::make_unique<operators::TableScanNode>(
+         makeTable(), trueFilter(), std::vector<ColumnIdentifier>{seq_column}
+      ),
+      std::move(lower_assignments)
+   );
+
+   std::vector<operators::MapNode::Assignment> upper_assignments;
+   upper_assignments.push_back(
+      {.output_column = {.name = "symbol", .type = ColumnType::STRING},
+       .expression = std::make_unique<scalar_expressions::At>(
+          std::make_unique<scalar_expressions::FieldRef>(
+             ColumnIdentifier{.name = "seq", .type = ColumnType::STRING}
+          ),
+          3
+       )}
+   );
+   auto upper_map =
+      std::make_unique<operators::MapNode>(std::move(lower_map), std::move(upper_assignments));
+
+   auto result = MapPullupPass::run(std::move(upper_map));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* merged = dynamic_cast<operators::MapNode*>(result.get());
+   EXPECT_EQ(merged->child->kind(), operators::NodeKind::TABLE_SCAN);
+
+   const auto symbol = std::ranges::find_if(merged->assignments, [](const auto& assignment) {
+      return assignment.output_column.name == "symbol";
+   });
+   ASSERT_NE(symbol, merged->assignments.end());
+   const auto* at_expression =
+      scalar_expressions::dynCast<scalar_expressions::At>(symbol->expression.get());
+   ASSERT_NE(at_expression, nullptr);
+   EXPECT_EQ(at_expression->position, 3);
+   const auto* decompress = scalar_expressions::dynCast<scalar_expressions::ZstdDecompressScalar>(
+      at_expression->input.get()
+   );
+   ASSERT_NE(decompress, nullptr);
+   EXPECT_TRUE(scalar_expressions::isA<scalar_expressions::FieldRef>(decompress->input.get()));
+}
+
+// --- The merge safely declines when an upper expression references a lower-produced column through
+// a construct it cannot rewrite (here an Equals predicate): inlining would be needed to avoid a
+// dangling reference, and since the merge cannot inline into an Equals, both maps are left in
+// place. ---
+
+TEST(MapPullupPass, doesNotMergeWhenUpperReferencesProducedColumnUnsubstitutably) {
+   const auto seq_column = ColumnIdentifier{.name = "seq", .type = ColumnType::NUCLEOTIDE_SEQUENCE};
+
+   std::vector<operators::MapNode::Assignment> lower_assignments;
+   lower_assignments.push_back(
+      {.output_column = {.name = "seq", .type = ColumnType::STRING},
+       .expression = std::make_unique<scalar_expressions::ZstdDecompressScalar>(
+          std::make_unique<scalar_expressions::FieldRef>(seq_column), "A"
+       )}
+   );
+   auto lower_map = std::make_unique<operators::MapNode>(
+      std::make_unique<operators::TableScanNode>(
+         makeTable(), trueFilter(), std::vector<ColumnIdentifier>{seq_column}
+      ),
+      std::move(lower_assignments)
+   );
+
+   // `flag := (seq = "AAAA")` reads the lower-produced `seq` through an Equals the merge cannot
+   // rewrite, so it must decline rather than leave a reference to a column the merged map no longer
+   // produces.
+   std::vector<operators::MapNode::Assignment> upper_assignments;
+   upper_assignments.push_back(
+      {.output_column = {.name = "flag", .type = ColumnType::BOOL},
+       .expression = std::make_unique<scalar_expressions::Equals>(
+          std::make_unique<scalar_expressions::FieldRef>(
+             ColumnIdentifier{.name = "seq", .type = ColumnType::STRING}
+          ),
+          std::make_unique<scalar_expressions::StringLiteral>("AAAA")
+       )}
+   );
+   auto upper_map =
+      std::make_unique<operators::MapNode>(std::move(lower_map), std::move(upper_assignments));
+
+   auto result = MapPullupPass::run(std::move(upper_map));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* upper = dynamic_cast<operators::MapNode*>(result.get());
+   EXPECT_EQ(upper->child->kind(), operators::NodeKind::MAP);
 }
 
 // Blocked: FilterNode. Should be handled by the filter pushdown

--- a/src/silo/query_engine/saneql/ast_to_query.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.cpp
@@ -501,7 +501,9 @@ ScalarExpressionPtr handleAt(
    CHECK_SILO_QUERY(
       found != schema.end(), "at(): the field {} is not found in the current context", input_column
    );
-   return std::make_unique<scalar_expressions::At>(*found, position);
+   return std::make_unique<scalar_expressions::At>(
+      std::make_unique<scalar_expressions::FieldRef>(*found), position
+   );
 }
 
 ScalarExpressionPtr handleIsoWeek(
@@ -521,7 +523,9 @@ ScalarExpressionPtr handleIsoWeek(
       "isoWeek(): the field {} must be a date column",
       input_column
    );
-   return std::make_unique<scalar_expressions::IsoWeek>(*found);
+   return std::make_unique<scalar_expressions::IsoWeek>(
+      std::make_unique<scalar_expressions::FieldRef>(*found)
+   );
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
@@ -971,7 +975,7 @@ operators::QueryNodePtr wrapWithDecompressIfNeeded(
          assignments.push_back(
             {.output_column = {.name = col.name, .type = schema::ColumnType::STRING},
              .expression = std::make_unique<scalar_expressions::ZstdDecompressScalar>(
-                col, std::move(reference).value()
+                std::make_unique<scalar_expressions::FieldRef>(col), std::move(reference).value()
              )}
          );
       }

--- a/src/silo/query_engine/scalar_expressions/at.cpp
+++ b/src/silo/query_engine/scalar_expressions/at.cpp
@@ -12,21 +12,23 @@
 
 namespace silo::query_engine::scalar_expressions {
 
-At::At(schema::ColumnIdentifier input_column, uint32_t position)
-    : input_column(std::move(input_column)),
-      position(position) {}
+At::At(std::unique_ptr<ScalarExpression> input, uint32_t position)
+    : input(std::move(input)),
+      position(position) {
+   SILO_ASSERT(this->input != nullptr);
+}
 
 std::string At::toString() const {
-   return fmt::format("{}.at({})", input_column.name, position);
+   return fmt::format("{}.at({})", input->toString(), position);
 }
 
 std::vector<schema::ColumnIdentifier> At::freeIUs() const {
-   return {input_column};
+   return input->freeIUs();
 }
 
-std::unique_ptr<ScalarExpression> At::
-   rewrite(const storage::Table& /*table*/, AmbiguityMode /*mode*/) const {
-   return std::make_unique<At>(input_column, position);
+std::unique_ptr<ScalarExpression> At::rewrite(const storage::Table& table, AmbiguityMode mode)
+   const {
+   return std::make_unique<At>(input->rewrite(table, mode), position);
 }
 
 std::unique_ptr<filter::operators::Operator> At::compile(const storage::Table& /*table*/) const {

--- a/src/silo/query_engine/scalar_expressions/at.h
+++ b/src/silo/query_engine/scalar_expressions/at.h
@@ -11,17 +11,18 @@
 
 namespace silo::query_engine::scalar_expressions {
 
-/// A scalar expression that evaluates to the single character of a string-valued
-/// column at a given 1-indexed position, e.g. `seq.at(3)`. Its value is a string
-/// (the character), so it is not a filter predicate; compile() is unimplemented and
-/// it is only meaningful as a scalar expression (e.g. in a map() assignment).
+/// A scalar expression that evaluates to the single character at a given 1-indexed position of the
+/// string its child expression evaluates to, e.g. `seq.at(3)`. The child is usually a `FieldRef` to
+/// a string column, but may be any string-valued expression (e.g. a `ZstdDecompressScalar` after a
+/// map merge). Its value is a string (the character), so it is not a filter predicate; compile() is
+/// unimplemented and it is only meaningful as a scalar expression (e.g. in a map() assignment).
 class At : public ScalarExpression {
   public:
-   schema::ColumnIdentifier input_column;
+   std::unique_ptr<ScalarExpression> input;
    /// 1-indexed position of the character to extract.
    uint32_t position;
 
-   At(schema::ColumnIdentifier input_column, uint32_t position);
+   At(std::unique_ptr<ScalarExpression> input, uint32_t position);
 
    [[nodiscard]] schema::ColumnType type() const override { return schema::ColumnType::STRING; }
 
@@ -38,7 +39,7 @@ class At : public ScalarExpression {
    ) const override;
 
    [[nodiscard]] std::unique_ptr<ScalarExpression> clone() const override {
-      return std::make_unique<At>(input_column, position);
+      return std::make_unique<At>(input->clone(), position);
    }
 
    [[nodiscard]] std::unique_ptr<filter::operators::Operator> compile(const storage::Table& table

--- a/src/silo/query_engine/scalar_expressions/iso_week.cpp
+++ b/src/silo/query_engine/scalar_expressions/iso_week.cpp
@@ -12,20 +12,22 @@
 
 namespace silo::query_engine::scalar_expressions {
 
-IsoWeek::IsoWeek(schema::ColumnIdentifier input_column)
-    : input_column(std::move(input_column)) {}
+IsoWeek::IsoWeek(std::unique_ptr<ScalarExpression> input)
+    : input(std::move(input)) {
+   SILO_ASSERT(this->input != nullptr);
+}
 
 std::string IsoWeek::toString() const {
-   return fmt::format("{}.isoWeek()", input_column.name);
+   return fmt::format("{}.isoWeek()", input->toString());
 }
 
 std::vector<schema::ColumnIdentifier> IsoWeek::freeIUs() const {
-   return {input_column};
+   return input->freeIUs();
 }
 
-std::unique_ptr<ScalarExpression> IsoWeek::
-   rewrite(const storage::Table& /*table*/, AmbiguityMode /*mode*/) const {
-   return std::make_unique<IsoWeek>(input_column);
+std::unique_ptr<ScalarExpression> IsoWeek::rewrite(const storage::Table& table, AmbiguityMode mode)
+   const {
+   return std::make_unique<IsoWeek>(input->rewrite(table, mode));
 }
 
 std::unique_ptr<filter::operators::Operator> IsoWeek::compile(const storage::Table& /*table*/)

--- a/src/silo/query_engine/scalar_expressions/iso_week.h
+++ b/src/silo/query_engine/scalar_expressions/iso_week.h
@@ -10,15 +10,15 @@
 
 namespace silo::query_engine::scalar_expressions {
 
-/// A scalar expression that evaluates to the ISO week number (int) of a date-valued
-/// column, e.g. `myDate.isoWeek()`. Its value is an int, so it is not a filter predicate;
-/// compile() is unimplemented and it is only meaningful as a scalar expression (e.g. in a
-/// map() assignment).
+/// A scalar expression that evaluates to the ISO week number (int) of the date its child expression
+/// evaluates to, e.g. `myDate.isoWeek()`. The child is usually a `FieldRef` to a date column. Its
+/// value is an int, so it is not a filter predicate; compile() is unimplemented and it is only
+/// meaningful as a scalar expression (e.g. in a map() assignment).
 class IsoWeek : public ScalarExpression {
   public:
-   schema::ColumnIdentifier input_column;
+   std::unique_ptr<ScalarExpression> input;
 
-   explicit IsoWeek(schema::ColumnIdentifier input_column);
+   explicit IsoWeek(std::unique_ptr<ScalarExpression> input);
 
    [[nodiscard]] schema::ColumnType type() const override { return schema::ColumnType::INT64; }
 
@@ -35,7 +35,7 @@ class IsoWeek : public ScalarExpression {
    ) const override;
 
    [[nodiscard]] std::unique_ptr<ScalarExpression> clone() const override {
-      return std::make_unique<IsoWeek>(input_column);
+      return std::make_unique<IsoWeek>(input->clone());
    }
 
    [[nodiscard]] std::unique_ptr<filter::operators::Operator> compile(const storage::Table& table

--- a/src/silo/query_engine/scalar_expressions/zstd_decompress_scalar.cpp
+++ b/src/silo/query_engine/scalar_expressions/zstd_decompress_scalar.cpp
@@ -14,31 +14,32 @@
 namespace silo::query_engine::scalar_expressions {
 
 ZstdDecompressScalar::ZstdDecompressScalar(
-   schema::ColumnIdentifier input_column,
+   std::unique_ptr<ScalarExpression> input,
    std::string dictionary_string
 )
-    : input_column(std::move(input_column)),
+    : input(std::move(input)),
       dictionary_string(std::move(dictionary_string)) {
+   SILO_ASSERT(this->input != nullptr);
    SILO_ASSERT(!this->dictionary_string.empty());
 }
 
 std::unique_ptr<ScalarExpression> ZstdDecompressScalar::clone() const {
-   return std::make_unique<ZstdDecompressScalar>(input_column, dictionary_string);
+   return std::make_unique<ZstdDecompressScalar>(input->clone(), dictionary_string);
 }
 
 std::string ZstdDecompressScalar::toString() const {
-   return fmt::format("zstd_decompress({})", input_column.name);
+   return fmt::format("zstd_decompress({})", input->toString());
 }
 
 std::vector<schema::ColumnIdentifier> ZstdDecompressScalar::freeIUs() const {
-   return {input_column};
+   return input->freeIUs();
 }
 
 std::unique_ptr<ScalarExpression> ZstdDecompressScalar::rewrite(
-   const storage::Table& /*table*/,
-   AmbiguityMode /*mode*/
+   const storage::Table& table,
+   AmbiguityMode mode
 ) const {
-   return clone();
+   return std::make_unique<ZstdDecompressScalar>(input->rewrite(table, mode), dictionary_string);
 }
 
 std::unique_ptr<filter::operators::Operator> ZstdDecompressScalar::compile(

--- a/src/silo/query_engine/scalar_expressions/zstd_decompress_scalar.h
+++ b/src/silo/query_engine/scalar_expressions/zstd_decompress_scalar.h
@@ -10,17 +10,18 @@
 
 namespace silo::query_engine::scalar_expressions {
 
-/// A scalar expression that zstd-decompresses a single sequence-typed column into the
-/// STRING value it encodes. The output is a STRING-typed column with the same name as
-/// the input. Used to expand the compressed columns of a table scan on demand.
+/// A scalar expression that zstd-decompresses the sequence-typed value its child expression
+/// evaluates to into the STRING value it encodes. The child is usually a `FieldRef` to a compressed
+/// column produced by the table scan. Used to expand the compressed columns of a table scan on
+/// demand.
 class ZstdDecompressScalar : public ScalarExpression {
   public:
-   /// The compressed input column produced by the child node.
-   const schema::ColumnIdentifier input_column;
+   /// The expression producing the compressed input, usually a `FieldRef` to a scan column.
+   std::unique_ptr<ScalarExpression> input;
 
    const std::string dictionary_string;
 
-   ZstdDecompressScalar(schema::ColumnIdentifier input_column, std::string dictionary_string);
+   ZstdDecompressScalar(std::unique_ptr<ScalarExpression> input, std::string dictionary_string);
 
    [[nodiscard]] schema::ColumnType type() const override { return schema::ColumnType::STRING; }
 


### PR DESCRIPTION
A refactoring commit that makes the optimization step in #1384 easier.

We first collapse multiple Map-nodes that follow one another, so that the optimization step does not need to look at more than one Map node