### PR TITLE
ci: commitlint should apply to PR title and also contain scope

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,4 +1,29 @@
+import { execFileSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { RuleConfigSeverity } from "@commitlint/types";
+
+const repositoryRoot = dirname(fileURLToPath(import.meta.url));
+
+// Only git-tracked directories are valid scopes, so that gitignored local
+// directories (build/, node_modules/, ...) don't make lint results
+// machine-dependent.
+const trackedRootDirectories = execFileSync(
+  "git",
+  ["ls-tree", "-d", "--name-only", "HEAD"],
+  { cwd: repositoryRoot, encoding: "utf8" },
+)
+  .split("\n")
+  .filter((name) => name !== "" && !name.startsWith("."));
+
+const siloSubdirectories = execFileSync(
+  "git",
+  ["ls-tree", "-d", "--name-only", "HEAD:src/silo"],
+  { cwd: repositoryRoot, encoding: "utf8" },
+)
+  .split("\n")
+  .filter((name) => name !== "" && !name.startsWith("."));
 
 /**
  * @type {import('@commitlint/types').UserConfig}
@@ -9,6 +34,11 @@ const Configuration = {
     "body-max-line-length": [RuleConfigSeverity.Disabled],
     "header-max-length": [RuleConfigSeverity.Error, "always", 200],
     "footer-max-line-length": [RuleConfigSeverity.Disabled],
+    "scope-enum": [
+      RuleConfigSeverity.Error,
+      "always",
+      [...trackedRootDirectories, ...siloSubdirectories, "silo"],
+    ],
   },
 };
 

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -7,6 +7,7 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+      - edited
 
 jobs:
   commitlint:
@@ -32,3 +33,27 @@ jobs:
 
       - name: Validate PR commits with commitlint
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --verbose
+
+  pr-title-lint:
+    name: Lint PR title
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+
+      - uses: actions/cache@v6
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+
+      - name: Install npm packages
+        run: npm ci
+
+      - name: Validate PR title with commitlint
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s\n' "$PR_TITLE" | npx commitlint --verbose

--- a/documentation/developer/contributing.md
+++ b/documentation/developer/contributing.md
@@ -249,7 +249,25 @@ resolves #123
   (useful for smaller changes that don't have a corresponding issue).
 
 We use [commitlint](https://commitlint.js.org/) to enforce the commit message format.
-To use it locally, run `npm install`.
+The configuration lives in `.commitlintrc.js`.
+CI checks all commit messages of a pull request and additionally the pull request title itself
+(see `.github/workflows/commitlint.yml`), so the title must also be a valid conventional commit header.
+
+If a scope is given, it must be one of the allowed scopes:
+
+- any git-tracked top-level directory of the repository (e.g. `app`, `performance`, `python`, `wasm`),
+- any subdirectory of `src/silo/` (e.g. `query_engine`, `storage`, `preprocessing`),
+- or the literal value `silo`.
+
+Both directory lists are determined when commitlint runs (via `git ls-tree`, see `.commitlintrc.js`),
+so new directories are picked up automatically and results are consistent between local runs and CI.
+Gitignored directories such as `build/` are not valid scopes.
+A commit message without a scope (e.g. `feat: my fancy new feature`) is also allowed.
+
+Pick the most specific scope that covers the change:
+if the change is restricted to a single subsystem or subdirectory, use that directory as the scope
+(e.g. `fix(query_engine): ...` for a change confined to `src/silo/query_engine/`).
+If the change spans multiple subsystems, use `silo`.
 
 The last commit message can be checked with
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -441,6 +441,18 @@
         }
       }
     },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@commitlint/resolve-extends": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",


### PR DESCRIPTION
### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This changes the commitlint job to also lint PR titles. Additionally, the scope of the change is now also being linted. It must be either `silo`, a subdirectory of `src/silo/`, or a root-level directory in the repository (e.g. `wasm`, `python`, `app`, `tools`)

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
~~- [ ] The implemented feature is covered by an appropriate test.~~
