### PR TITLE
refactor(silo): remove deprecated flag from tests

### DIFF
--- a/performance/co_occurrence_benchmark.cpp
+++ b/performance/co_occurrence_benchmark.cpp
@@ -57,7 +57,6 @@ std::string makeRandomReference(std::mt19937& rng) {
 
 std::shared_ptr<Database> setupDatabase(const std::string& reference) {
    auto database_config = silo::config::DatabaseConfig::getValidatedConfig(R"(
-defaultNucleotideSequence: "main"
 schema:
   instanceName: co_occurrence_benchmark
   metadata:

--- a/src/silo/query_engine/operators/bitmap_aggregation_node.test.cpp
+++ b/src/silo/query_engine/operators/bitmap_aggregation_node.test.cpp
@@ -42,7 +42,6 @@ const nlohmann::json ROW_CA = createDataWithSequences("CATTT", "X*", "Europe");
 
 const auto DATABASE_CONFIG =
    R"(
-defaultNucleotideSequence: "segment1"
 schema:
   instanceName: "dummy name"
   metadata:

--- a/src/silo/query_engine/operators/order_by_node.test.cpp
+++ b/src/silo/query_engine/operators/order_by_node.test.cpp
@@ -40,7 +40,6 @@ const std::vector<nlohmann::json> DATA = {
 
 const auto DATABASE_CONFIG =
    R"(
-defaultNucleotideSequence: "segment1"
 schema:
   instanceName: "dummy name"
   metadata:


### PR DESCRIPTION
remove
`defaultNucleotideSequence: "segment1"`

from more test files
