### PR TITLE
feat(query_engine): add a specialized OrderByWithLimit node

### DIFF
--- a/src/silo/query_engine/operator_visitor.h
+++ b/src/silo/query_engine/operator_visitor.h
@@ -13,6 +13,7 @@
 #include "silo/query_engine/operators/most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/mutations_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
+#include "silo/query_engine/operators/order_by_with_limit_node.h"
 #include "silo/query_engine/operators/phylo_subtree_node.h"
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/schema_node.h"
@@ -37,6 +38,8 @@ decltype(auto) visit(QueryNode& node, Func&& func) {
          return std::forward<Func>(func)(static_cast<MapNode&>(node));
       case NodeKind::ORDER_BY:
          return std::forward<Func>(func)(static_cast<OrderByNode&>(node));
+      case NodeKind::ORDER_BY_WITH_LIMIT:
+         return std::forward<Func>(func)(static_cast<OrderByWithLimitNode&>(node));
       case NodeKind::FETCH:
          return std::forward<Func>(func)(static_cast<FetchNode&>(node));
       case NodeKind::FILTER:

--- a/src/silo/query_engine/operators/order_by_node.cpp
+++ b/src/silo/query_engine/operators/order_by_node.cpp
@@ -12,124 +12,23 @@
 
 #include <arrow/acero/exec_plan.h>
 #include <arrow/acero/options.h>
-#include <arrow/builder.h>
 #include <arrow/compute/api.h>
 #include <arrow/compute/ordering.h>
 #include <arrow/util/async_generator_fwd.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
-#include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
 
 #include "silo/common/panic.h"
 #include "silo/query_engine/exec_node/arrow_util.h"
 #include "silo/query_engine/illegal_query_exception.h"
+#include "silo/query_engine/operators/order_by_randomize.h"
 #include "silo/schema/database_schema.h"
 #include "silo/storage/table.h"
 
 namespace silo::query_engine::operators {
 
 namespace {
-
-const std::string RANDOMIZE_HASH_FIELD_NAME{"__SILO_RANDOMIZE_HASH"};
-
-uint64_t hash64(uint64_t value, uint64_t seed) {
-   value ^= seed;
-   value ^= value >> 33;
-   value *= 0xff51afd7ed558ccdULL;
-   value ^= value >> 33;
-   value *= 0xc4ceb9fe1a85ec53ULL;
-   value ^= value >> 33;
-   return value;
-}
-
-arrow::Result<arrow::acero::ExecNode*> removeRandomizeColumn(
-   arrow::acero::ExecPlan& plan,
-   arrow::acero::ExecNode* top_node
-) {
-   std::vector<arrow::Expression> field_refs;
-   for (const auto& field : top_node->output_schema()->fields()) {
-      if (field->name() != RANDOMIZE_HASH_FIELD_NAME) {
-         field_refs.push_back(arrow::compute::field_ref(field->name()));
-      }
-   }
-   auto options = arrow::acero::ProjectNodeOptions(field_refs);
-   return arrow::acero::MakeExecNode("project", &plan, {top_node}, options);
-}
-
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
-arrow::Result<arrow::acero::ExecNode*> addRandomizeColumn(
-   arrow::acero::ExecPlan& plan,
-   arrow::acero::ExecNode* top_node,
-   size_t randomize_seed
-) {
-   arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> sequenced_batches;
-   std::shared_ptr<arrow::Schema> schema_of_sequence_batches;
-   ARROW_ASSIGN_OR_RAISE(
-      top_node,
-      arrow::acero::MakeExecNode(
-         "sink",
-         &plan,
-         {top_node},
-         arrow::acero::SinkNodeOptions{&sequenced_batches, &schema_of_sequence_batches}
-      )
-   );
-   top_node->SetLabel("input to randomize column projection");
-   auto output_schema_fields = schema_of_sequence_batches->fields();
-   output_schema_fields.emplace_back(
-      std::make_shared<arrow::Field>(RANDOMIZE_HASH_FIELD_NAME, arrow::uint64())
-   );
-   auto output_schema = arrow::schema(output_schema_fields);
-   size_t start_of_batch = 0;
-   arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> sequenced_batches_with_hash_id =
-      // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-      [sequenced_batches, start_of_batch, randomize_seed](
-      ) mutable -> arrow::Future<std::optional<arrow::ExecBatch>> {
-      SPDLOG_TRACE("randomize column projection awaits the next batch");
-      auto future = sequenced_batches();
-
-      return future.Then(
-         [&](std::optional<arrow::ExecBatch> maybe_input_batch
-         ) mutable -> arrow::Result<std::optional<arrow::ExecBatch>> {
-            SPDLOG_TRACE("randomize column projection received next batch");
-
-            if (!maybe_input_batch.has_value()) {
-               return std::nullopt;
-            }
-
-            const auto& input_batch = maybe_input_batch.value();
-            SILO_ASSERT(!input_batch.values.empty());
-            auto rows_in_batch = input_batch.values.at(0).length();
-            SILO_ASSERT_NE(rows_in_batch, arrow::Datum::kUnknownLength);
-
-            arrow::UInt64Builder randomize_column_builder;
-            for (int64_t i = 0; i < rows_in_batch; ++i) {
-               const uint64_t hash_val = hash64(start_of_batch + i, randomize_seed);
-               ARROW_RETURN_NOT_OK(randomize_column_builder.Append(hash_val));
-            }
-
-            ARROW_ASSIGN_OR_RAISE(auto randomize_column, randomize_column_builder.Finish());
-            start_of_batch += rows_in_batch;
-
-            auto output_columns = input_batch.values;
-            output_columns.emplace_back(randomize_column);
-            auto output_batch = arrow::ExecBatch::Make(output_columns);
-            return output_batch;
-         }
-      );
-   };
-   ARROW_ASSIGN_OR_RAISE(
-      top_node,
-      arrow::acero::MakeExecNode(
-         "source",
-         &plan,
-         {},
-         arrow::acero::SourceNodeOptions{output_schema, std::move(sequenced_batches_with_hash_id)}
-      )
-   );
-   top_node->SetLabel("output of randomize column projection");
-   return top_node;
-}
 
 arrow::Result<arrow::acero::ExecNode*> addSortNode(
    arrow::acero::ExecPlan& plan,

--- a/src/silo/query_engine/operators/order_by_randomize.cpp
+++ b/src/silo/query_engine/operators/order_by_randomize.cpp
@@ -1,0 +1,125 @@
+#include "silo/query_engine/operators/order_by_randomize.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/acero/options.h>
+#include <arrow/builder.h>
+#include <arrow/compute/api.h>
+#include <arrow/util/async_generator_fwd.h>
+#include <spdlog/spdlog.h>
+
+#include "silo/common/panic.h"
+
+namespace silo::query_engine::operators {
+
+const std::string RANDOMIZE_HASH_FIELD_NAME{"__SILO_RANDOMIZE_HASH"};
+
+namespace {
+
+uint64_t hash64(uint64_t value, uint64_t seed) {
+   value ^= seed;
+   value ^= value >> 33;
+   value *= 0xff51afd7ed558ccdULL;
+   value ^= value >> 33;
+   value *= 0xc4ceb9fe1a85ec53ULL;
+   value ^= value >> 33;
+   return value;
+}
+
+}  // namespace
+
+arrow::Result<arrow::acero::ExecNode*> removeRandomizeColumn(
+   arrow::acero::ExecPlan& plan,
+   arrow::acero::ExecNode* top_node
+) {
+   std::vector<arrow::Expression> field_refs;
+   for (const auto& field : top_node->output_schema()->fields()) {
+      if (field->name() != RANDOMIZE_HASH_FIELD_NAME) {
+         field_refs.push_back(arrow::compute::field_ref(field->name()));
+      }
+   }
+   auto options = arrow::acero::ProjectNodeOptions(field_refs);
+   return arrow::acero::MakeExecNode("project", &plan, {top_node}, options);
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+arrow::Result<arrow::acero::ExecNode*> addRandomizeColumn(
+   arrow::acero::ExecPlan& plan,
+   arrow::acero::ExecNode* top_node,
+   size_t randomize_seed
+) {
+   arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> sequenced_batches;
+   std::shared_ptr<arrow::Schema> schema_of_sequence_batches;
+   ARROW_ASSIGN_OR_RAISE(
+      top_node,
+      arrow::acero::MakeExecNode(
+         "sink",
+         &plan,
+         {top_node},
+         arrow::acero::SinkNodeOptions{&sequenced_batches, &schema_of_sequence_batches}
+      )
+   );
+   top_node->SetLabel("input to randomize column projection");
+   auto output_schema_fields = schema_of_sequence_batches->fields();
+   output_schema_fields.emplace_back(
+      std::make_shared<arrow::Field>(RANDOMIZE_HASH_FIELD_NAME, arrow::uint64())
+   );
+   auto output_schema = arrow::schema(output_schema_fields);
+   size_t start_of_batch = 0;
+   arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> sequenced_batches_with_hash_id =
+      // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+      [sequenced_batches, start_of_batch, randomize_seed](
+      ) mutable -> arrow::Future<std::optional<arrow::ExecBatch>> {
+      SPDLOG_TRACE("randomize column projection awaits the next batch");
+      auto future = sequenced_batches();
+
+      return future.Then(
+         [&](std::optional<arrow::ExecBatch> maybe_input_batch
+         ) mutable -> arrow::Result<std::optional<arrow::ExecBatch>> {
+            SPDLOG_TRACE("randomize column projection received next batch");
+
+            if (!maybe_input_batch.has_value()) {
+               return std::nullopt;
+            }
+
+            const auto& input_batch = maybe_input_batch.value();
+            SILO_ASSERT(!input_batch.values.empty());
+            auto rows_in_batch = input_batch.values.at(0).length();
+            SILO_ASSERT_NE(rows_in_batch, arrow::Datum::kUnknownLength);
+
+            arrow::UInt64Builder randomize_column_builder;
+            for (int64_t i = 0; i < rows_in_batch; ++i) {
+               const uint64_t hash_val = hash64(start_of_batch + i, randomize_seed);
+               ARROW_RETURN_NOT_OK(randomize_column_builder.Append(hash_val));
+            }
+
+            ARROW_ASSIGN_OR_RAISE(auto randomize_column, randomize_column_builder.Finish());
+            start_of_batch += rows_in_batch;
+
+            auto output_columns = input_batch.values;
+            output_columns.emplace_back(randomize_column);
+            auto output_batch = arrow::ExecBatch::Make(output_columns);
+            return output_batch;
+         }
+      );
+   };
+   ARROW_ASSIGN_OR_RAISE(
+      top_node,
+      arrow::acero::MakeExecNode(
+         "source",
+         &plan,
+         {},
+         arrow::acero::SourceNodeOptions{output_schema, std::move(sequenced_batches_with_hash_id)}
+      )
+   );
+   top_node->SetLabel("output of randomize column projection");
+   return top_node;
+}
+
+}  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/order_by_randomize.h
+++ b/src/silo/query_engine/operators/order_by_randomize.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/result.h>
+
+namespace silo::query_engine::operators {
+
+/// Name of the transient uint64 column that carries the per-row random hash used to implement
+/// `randomize`. It is appended to the stream, sorted on, and projected back out again, so it is
+/// never visible in a query result.
+extern const std::string RANDOMIZE_HASH_FIELD_NAME;
+
+/// Appends a `RANDOMIZE_HASH_FIELD_NAME` column holding `hash64(row_index, randomize_seed)` to the
+/// stream, so a subsequent sort/select on that column yields a deterministic pseudo-random order.
+arrow::Result<arrow::acero::ExecNode*> addRandomizeColumn(
+   arrow::acero::ExecPlan& plan,
+   arrow::acero::ExecNode* top_node,
+   size_t randomize_seed
+);
+
+/// Projects the `RANDOMIZE_HASH_FIELD_NAME` column back out of the stream, undoing
+/// `addRandomizeColumn` once the random order has been applied.
+arrow::Result<arrow::acero::ExecNode*> removeRandomizeColumn(
+   arrow::acero::ExecPlan& plan,
+   arrow::acero::ExecNode* top_node
+);
+
+}  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/order_by_with_limit_node.cpp
+++ b/src/silo/query_engine/operators/order_by_with_limit_node.cpp
@@ -1,0 +1,164 @@
+#include "silo/query_engine/operators/order_by_with_limit_node.h"
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/acero/options.h>
+#include <arrow/compute/api.h>
+#include <arrow/compute/ordering.h>
+#include <arrow/type.h>
+#include <arrow/util/async_generator_fwd.h>
+#include <nlohmann/json.hpp>
+
+#include "silo/common/panic.h"
+#include "silo/query_engine/exec_node/arrow_util.h"
+#include "silo/query_engine/operators/order_by_randomize.h"
+#include "silo/schema/database_schema.h"
+#include "silo/storage/table.h"
+
+namespace silo::query_engine::operators {
+
+OrderByWithLimitNode::OrderByWithLimitNode(
+   QueryNodePtr child,
+   std::vector<OrderByField> fields,
+   uint32_t limit,
+   std::optional<uint32_t> offset,
+   std::optional<uint32_t> randomize_seed
+)
+    : child(std::move(child)),
+      fields(std::move(fields)),
+      limit(limit),
+      offset(offset),
+      randomize_seed(randomize_seed) {}
+
+std::vector<schema::ColumnIdentifier> OrderByWithLimitNode::getOutputSchema() const {
+   return child->getOutputSchema();
+}
+
+arrow::Result<arrow::acero::ExecNode*> OrderByWithLimitNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
+   const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
+   const config::QueryOptions& query_options
+) const {
+   // The rewrite pass only produces this node when there is something to order by: sort fields, a
+   // randomize seed, or both.
+   SILO_ASSERT(!fields.empty() || randomize_seed.has_value());
+
+   ARROW_ASSIGN_OR_RAISE(auto* top_node, child->addToExecPlan(plan, tables, query_options));
+
+   using arrow::compute::NullPlacement;
+   using arrow::compute::SortOrder;
+
+   // Build the sort keys exactly as OrderByNode does, so a rewritten query orders identically to
+   // the `order_by | limit` it replaces. Nulls sort as the smallest element.
+   std::vector<arrow::compute::SortKey> sort_keys;
+   sort_keys.reserve(fields.size() + (randomize_seed.has_value() ? 1 : 0));
+   for (const auto& order_by_field : fields) {
+      const auto sort_order =
+         order_by_field.ascending ? SortOrder::Ascending : SortOrder::Descending;
+      const auto null_placement =
+         order_by_field.ascending ? NullPlacement::AtStart : NullPlacement::AtEnd;
+      sort_keys.emplace_back(order_by_field.field.name, sort_order, null_placement);
+   }
+   // A randomize seed adds the per-row random hash as the lowest-priority (tie-breaking) sort key,
+   // matching OrderByNode; with no explicit fields it becomes the sole key, yielding a random
+   // order.
+   if (randomize_seed.has_value()) {
+      sort_keys.emplace_back(RANDOMIZE_HASH_FIELD_NAME);
+   }
+
+   // select_k returns the `k` smallest rows in sorted order. To honor an offset we select the whole
+   // window that starts at row 0 and covers up to `offset + limit`, then skip the offset below.
+   const int64_t select_k = static_cast<int64_t>(offset.value_or(0)) + static_cast<int64_t>(limit);
+
+   const arrow::Ordering ordering{sort_keys};
+
+   if (randomize_seed.has_value()) {
+      ARROW_ASSIGN_OR_RAISE(top_node, addRandomizeColumn(plan, top_node, randomize_seed.value()));
+   }
+
+   arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> generator;
+   ARROW_ASSIGN_OR_RAISE(
+      top_node,
+      arrow::acero::MakeExecNode(
+         "select_k_sink",
+         &plan,
+         {top_node},
+         arrow::acero::SelectKSinkNodeOptions{
+            arrow::compute::SelectKOptions{select_k, sort_keys}, &generator
+         }
+      )
+   );
+   top_node->SetLabel("order by with limit");
+
+   // The batches produced by select_k still carry the random-hash column (when randomizing), so the
+   // re-source schema must include it; `removeRandomizeColumn` projects it back out afterwards.
+   auto output_fields = exec_node::columnsToArrowSchema(getOutputSchema())->fields();
+   if (randomize_seed.has_value()) {
+      output_fields.emplace_back(
+         std::make_shared<arrow::Field>(RANDOMIZE_HASH_FIELD_NAME, arrow::uint64())
+      );
+   }
+   ARROW_ASSIGN_OR_RAISE(
+      top_node,
+      arrow::acero::MakeExecNode(
+         "source",
+         &plan,
+         {},
+         arrow::acero::SourceNodeOptions{
+            arrow::schema(output_fields), std::move(generator), ordering
+         }
+      )
+   );
+
+   // select_k already caps the output at the window size; only a non-zero offset still needs a
+   // fetch to skip the leading rows. The fetch runs before the random-hash column is projected out,
+   // while the stream still carries the ordering the fetch requires.
+   if (offset.value_or(0) > 0) {
+      ARROW_ASSIGN_OR_RAISE(
+         top_node,
+         arrow::acero::MakeExecNode(
+            std::string{arrow::acero::FetchNodeOptions::kName},
+            &plan,
+            {top_node},
+            arrow::acero::FetchNodeOptions(offset.value(), limit)
+         )
+      );
+   }
+
+   if (randomize_seed.has_value()) {
+      ARROW_ASSIGN_OR_RAISE(top_node, removeRandomizeColumn(plan, top_node));
+   }
+
+   return top_node;
+}
+
+nlohmann::json OrderByWithLimitNode::toJson() const {
+   nlohmann::json fields_json = nlohmann::json::array();
+   for (const auto& order_by_field : fields) {
+      fields_json.push_back({
+         {"field", columnToJson(order_by_field.field)},
+         {"ascending", order_by_field.ascending},
+      });
+   }
+   nlohmann::json result{
+      {"type", nodeKindToString(kind())},
+      {"fields", std::move(fields_json)},
+      {"limit", limit},
+      {"child", child->toJson()},
+   };
+   if (offset.has_value()) {
+      result["offset"] = offset.value();
+   }
+   if (randomize_seed.has_value()) {
+      result["randomizeSeed"] = randomize_seed.value();
+   }
+   return result;
+}
+
+}  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/order_by_with_limit_node.h
+++ b/src/silo/query_engine/operators/order_by_with_limit_node.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <vector>
+
+#include <arrow/result.h>
+
+#include "silo/query_engine/operators/query_node.h"
+#include "silo/query_engine/order_by_field.h"
+#include "silo/schema/database_schema.h"
+#include "silo/storage/table.h"
+
+namespace silo::query_engine::operators {
+
+/// Sorts output rows by the specified fields and keeps only the `offset + limit` smallest of them.
+///
+/// This is the combined equivalent of an `OrderByNode` directly below a `FetchNode`: instead of
+/// sorting the entire input and then discarding all but a small window, it uses Arrow's `select_k`
+/// (top-k) implementation, which only ever keeps the `offset + limit` best rows seen so far. The
+/// `SelectKRewritePass` rewrites `Fetch(OrderBy(...))` into this node.
+///
+/// Like `OrderByNode`, a `randomize_seed` orders rows by a per-row random hash (as an extra,
+/// lowest-priority sort key when `fields` are also present), so a randomized query followed by a
+/// limit selects a random sample via the same top-k path.
+class OrderByWithLimitNode final : public QueryNode {
+  public:
+   QueryNodePtr child;
+   std::vector<OrderByField> fields;
+   uint32_t limit;
+   std::optional<uint32_t> offset;
+   std::optional<uint32_t> randomize_seed;
+
+   OrderByWithLimitNode(
+      QueryNodePtr child,
+      std::vector<OrderByField> fields,
+      uint32_t limit,
+      std::optional<uint32_t> offset,
+      std::optional<uint32_t> randomize_seed
+   );
+
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
+
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
+      const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
+      const config::QueryOptions& query_options
+   ) const override;
+
+   [[nodiscard]] NodeKind kind() const override { return NodeKind::ORDER_BY_WITH_LIMIT; }
+
+   [[nodiscard]] nlohmann::json toJson() const override;
+};
+
+}  // namespace silo::query_engine::operators

--- a/src/silo/query_engine/operators/order_by_with_limit_node.test.cpp
+++ b/src/silo/query_engine/operators/order_by_with_limit_node.test.cpp
@@ -1,0 +1,110 @@
+#include <nlohmann/json.hpp>
+
+#include "silo/test/query_fixture.test.h"
+
+namespace {
+using silo::ReferenceGenomes;
+using silo::test::QueryTestData;
+using silo::test::QueryTestScenario;
+
+nlohmann::json createData(
+   const std::string& primaryKey,
+   const nlohmann::json& int_value,
+   const nlohmann::json& date_value
+) {
+   return {
+      {"primaryKey", primaryKey},
+      {"int_value", int_value},
+      {"segment1", nullptr},
+      {"gene1", nullptr},
+      {"unaligned_segment1", nullptr},
+      {"date", date_value}
+   };
+}
+
+// Same data as the OrderByNode test: both sort columns contain nulls so that top-k selection can
+// be checked to place null/missing as the smallest element, just like the full-sort path it
+// replaces.
+const std::vector<nlohmann::json> DATA = {
+   createData("id_0", nullptr, nullptr),
+   createData("id_1", nullptr, "2023-01-01"),
+   createData("id_2", 1, nullptr),
+   createData("id_3", 1, "2023-01-01"),
+   createData("id_4", 2, nullptr),
+   createData("id_5", 2, "2023-01-01")
+};
+
+const auto DATABASE_CONFIG =
+   R"(
+schema:
+  instanceName: "dummy name"
+  metadata:
+    - name: "primaryKey"
+      type: "string"
+    - name: "int_value"
+      type: "int"
+    - name: "date"
+      type: "date"
+  primaryKey: "primaryKey"
+)";
+
+const auto REFERENCE_GENOMES = ReferenceGenomes{
+   {{"segment1", "ACGT"}},
+   {{"gene1", "*"}},
+};
+
+const QueryTestData TEST_DATA{
+   .ndjson_input_data = DATA,
+   .database_config = DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES
+};
+
+// orderBy ascending + limit: the three smallest rows, nulls (smallest) first.
+const QueryTestScenario ASC_LIMIT_SCENARIO = {
+   .name = "ORDER_BY_WITH_LIMIT_ASC",
+   .query =
+      "default.project({primaryKey, int_value, date}).orderBy({int_value.asc(), "
+      "date.asc()}).limit(3)",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"int_value", nullptr}, {"date", nullptr}},
+       {{"primaryKey", "id_1"}, {"int_value", nullptr}, {"date", "2023-01-01"}},
+       {{"primaryKey", "id_2"}, {"int_value", 1}, {"date", nullptr}}}
+   )
+};
+
+// orderBy descending + limit: the three largest rows, nulls (smallest) sort last so they do not
+// appear in the top-k at all.
+const QueryTestScenario DESC_LIMIT_SCENARIO = {
+   .name = "ORDER_BY_WITH_LIMIT_DESC",
+   .query =
+      "default.project({primaryKey, int_value, date}).orderBy({int_value.desc(), "
+      "date.desc()}).limit(3)",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_5"}, {"int_value", 2}, {"date", "2023-01-01"}},
+       {{"primaryKey", "id_4"}, {"int_value", 2}, {"date", nullptr}},
+       {{"primaryKey", "id_3"}, {"int_value", 1}, {"date", "2023-01-01"}}}
+   )
+};
+
+// A limit larger than the input returns every row, still fully ordered.
+const QueryTestScenario LIMIT_LARGER_THAN_INPUT_SCENARIO = {
+   .name = "ORDER_BY_WITH_LIMIT_LARGER_THAN_INPUT",
+   .query =
+      "default.project({primaryKey, date}).orderBy({date.asc(), primaryKey.asc()}).limit(100)",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"date", nullptr}},
+       {{"primaryKey", "id_2"}, {"date", nullptr}},
+       {{"primaryKey", "id_4"}, {"date", nullptr}},
+       {{"primaryKey", "id_1"}, {"date", "2023-01-01"}},
+       {{"primaryKey", "id_3"}, {"date", "2023-01-01"}},
+       {{"primaryKey", "id_5"}, {"date", "2023-01-01"}}}
+   )
+};
+
+}  // namespace
+
+QUERY_TEST(
+   OrderByWithLimitNodeTest,
+   TEST_DATA,
+   ::testing::Values(ASC_LIMIT_SCENARIO, DESC_LIMIT_SCENARIO, LIMIT_LARGER_THAN_INPUT_SCENARIO)
+);

--- a/src/silo/query_engine/operators/query_node.cpp
+++ b/src/silo/query_engine/operators/query_node.cpp
@@ -18,6 +18,8 @@ std::string_view nodeKindToString(NodeKind kind) {
          return "Project";
       case NodeKind::ORDER_BY:
          return "OrderBy";
+      case NodeKind::ORDER_BY_WITH_LIMIT:
+         return "OrderByWithLimit";
       case NodeKind::FETCH:
          return "Fetch";
       case NodeKind::FILTER:

--- a/src/silo/query_engine/operators/query_node.h
+++ b/src/silo/query_engine/operators/query_node.h
@@ -20,6 +20,7 @@ enum class NodeKind : uint8_t {
    PROJECT,
    MAP,
    ORDER_BY,
+   ORDER_BY_WITH_LIMIT,
    FETCH,
    FILTER,
    UNRESOLVED_MUTATIONS_NUCLEOTIDE,

--- a/src/silo/query_engine/operators/randomize.test.cpp
+++ b/src/silo/query_engine/operators/randomize.test.cpp
@@ -200,6 +200,19 @@ const QueryTestScenario LIMIT_3_RANDOMIZE = {
    )
 };
 
+// A randomize directly followed by a limit is combined into an OrderByWithLimitNode that uses the
+// top-k (select_k) path. The result must still be the prefix of the full randomized order for this
+// seed (see RANDOMIZE_SEED: id5, id1, id4, ...).
+const QueryTestScenario RANDOMIZE_WITH_LIMIT = {
+   .name = "RANDOMIZE_WITH_LIMIT",
+   .query = "default.project(key).randomize(seed:=1231).limit(3)",
+   .expected_query_result = json::parse(
+      R"([{"key": "id5"},
+          {"key": "id1"},
+          {"key": "id4"}])"
+   )
+};
+
 const QueryTestScenario AGGREGATE_LIMIT_RANDOMIZE = {
    .name = "AGGREGATE_LIMIT_RANDOMIZE",
    .query = "default.groupBy({count:=count()},{key}).randomize(seed:=12321).offset(1).limit(2)",
@@ -225,6 +238,7 @@ QUERY_TEST(
       ORDER_BY_AGGREGATE_RANDOMIZE,
       LIMIT_2_RANDOMIZE,
       LIMIT_3_RANDOMIZE,
+      RANDOMIZE_WITH_LIMIT,
       AGGREGATE_LIMIT_RANDOMIZE
    )
 );

--- a/src/silo/query_engine/optimizer/pipeline_pass_base.h
+++ b/src/silo/query_engine/optimizer/pipeline_pass_base.h
@@ -8,6 +8,7 @@
 #include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
+#include "silo/query_engine/operators/order_by_with_limit_node.h"
 #include "silo/query_engine/operators/project_node.h"
 #include "silo/query_engine/operators/query_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
@@ -82,6 +83,11 @@ class PipelinePassBase {
    }
    // NOLINTNEXTLINE(misc-no-recursion)
    operators::QueryNodePtr operator()(operators::OrderByNode& node) {
+      propagateToNode(node.child);
+      return nullptr;
+   }
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::OrderByWithLimitNode& node) {
       propagateToNode(node.child);
       return nullptr;
    }

--- a/src/silo/query_engine/optimizer/select_k_rewrite_pass.cpp
+++ b/src/silo/query_engine/optimizer/select_k_rewrite_pass.cpp
@@ -1,0 +1,42 @@
+#include "silo/query_engine/optimizer/select_k_rewrite_pass.h"
+
+#include <memory>
+#include <utility>
+
+#include "silo/query_engine/operators/fetch_node.h"
+#include "silo/query_engine/operators/order_by_node.h"
+#include "silo/query_engine/operators/order_by_with_limit_node.h"
+#include "silo/query_engine/operators/query_node.h"
+
+namespace silo::query_engine::optimizer {
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr SelectKRewritePass::operator()(operators::FetchNode& node) {
+   propagateToNode(node.child);
+
+   // select_k needs a bounded number of rows to keep; an offset-only fetch has none.
+   if (!node.count.has_value()) {
+      return nullptr;
+   }
+   if (node.child->kind() != operators::NodeKind::ORDER_BY) {
+      return nullptr;
+   }
+   auto& order_by = static_cast<operators::OrderByNode&>(*node.child);
+
+   // An order-by with neither sort fields nor a randomize seed performs no ordering at all, so
+   // there is nothing to combine. A randomize seed (with or without fields) is fine: the combined
+   // node applies the same random-hash top-k.
+   if (order_by.fields.empty() && !order_by.randomize_seed.has_value()) {
+      return nullptr;
+   }
+
+   return std::make_unique<operators::OrderByWithLimitNode>(
+      std::move(order_by.child),
+      std::move(order_by.fields),
+      node.count.value(),
+      node.offset,
+      order_by.randomize_seed
+   );
+}
+
+}  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/select_k_rewrite_pass.h
+++ b/src/silo/query_engine/optimizer/select_k_rewrite_pass.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "silo/query_engine/operators/query_node.h"
+#include "silo/query_engine/optimizer/pipeline_pass_base.h"
+
+namespace silo::query_engine::operators {
+class FetchNode;
+}  // namespace silo::query_engine::operators
+
+namespace silo::query_engine::optimizer {
+
+/// Optimization pass that combines a `FetchNode` with a finite limit sitting directly above an
+/// `OrderByNode` into a single `OrderByWithLimitNode`:
+///
+/// ```
+/// Fetch(count, offset)(OrderBy(fields))  →  OrderByWithLimit(fields, count, offset)
+/// ```
+///
+/// The combined node uses Arrow's `select_k` (top-k) implementation, which keeps only the
+/// `offset + count` smallest rows instead of fully sorting the input and then discarding all but a
+/// small window.
+class SelectKRewritePass : public PipelinePassBase<SelectKRewritePass> {
+  public:
+   using PipelinePassBase<SelectKRewritePass>::operator();
+
+   operators::QueryNodePtr operator()(operators::FetchNode& node);
+};
+
+}  // namespace silo::query_engine::optimizer

--- a/src/silo/query_engine/optimizer/select_k_rewrite_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/select_k_rewrite_pass.test.cpp
@@ -1,0 +1,130 @@
+#include "silo/query_engine/optimizer/select_k_rewrite_pass.h"
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "silo/query_engine/operators/fetch_node.h"
+#include "silo/query_engine/operators/order_by_node.h"
+#include "silo/query_engine/operators/order_by_with_limit_node.h"
+#include "silo/query_engine/operators/table_scan_node.h"
+#include "silo/query_engine/order_by_field.h"
+#include "silo/query_engine/scalar_expressions/literal.h"
+#include "silo/query_engine/scalar_expressions/scalar_expression.h"
+#include "silo/schema/database_schema.h"
+#include "silo/storage/column/string_column.h"
+#include "silo/storage/table.h"
+
+using silo::query_engine::OrderByField;
+using silo::query_engine::optimizer::SelectKRewritePass;
+namespace operators = silo::query_engine::operators;
+namespace scalar_expressions = silo::query_engine::scalar_expressions;
+
+using silo::schema::ColumnIdentifier;
+using silo::schema::ColumnType;
+
+namespace {
+
+std::shared_ptr<silo::storage::Table> makeTable() {
+   using silo::storage::column::ColumnMetadata;
+   using silo::storage::column::StringColumnMetadata;
+
+   ColumnIdentifier primary_key{.name = "id", .type = ColumnType::STRING};
+   std::map<ColumnIdentifier, std::shared_ptr<ColumnMetadata>> col_meta{
+      {primary_key, std::make_shared<StringColumnMetadata>(primary_key.name)}
+   };
+   auto schema = std::make_shared<silo::schema::TableSchema>(std::move(col_meta), primary_key);
+   return std::make_shared<silo::storage::Table>(silo::schema::TableName("default"), schema);
+}
+
+operators::QueryNodePtr makeScan() {
+   return std::make_unique<operators::TableScanNode>(
+      makeTable(),
+      std::make_unique<scalar_expressions::BoolLiteral>(true),
+      std::vector<ColumnIdentifier>{}
+   );
+}
+
+std::vector<OrderByField> idAscending() {
+   return {OrderByField{.field = {.name = "id", .type = ColumnType::STRING}, .ascending = true}};
+}
+
+operators::QueryNodePtr makeOrderBy(
+   std::vector<OrderByField> fields,
+   std::optional<uint32_t> randomize_seed = std::nullopt
+) {
+   return std::make_unique<operators::OrderByNode>(makeScan(), std::move(fields), randomize_seed);
+}
+
+}  // namespace
+
+TEST(SelectKRewritePass, combinesFetchAboveOrderByIntoOrderByWithLimit) {
+   auto fetch = std::make_unique<operators::FetchNode>(makeOrderBy(idAscending()), 5, 2);
+
+   auto result = SelectKRewritePass::run(std::move(fetch));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::ORDER_BY_WITH_LIMIT);
+   auto* combined = dynamic_cast<operators::OrderByWithLimitNode*>(result.get());
+   ASSERT_NE(combined, nullptr);
+   EXPECT_EQ(combined->limit, 5);
+   EXPECT_EQ(combined->offset, 2);
+   ASSERT_EQ(combined->fields.size(), 1);
+   EXPECT_EQ(combined->fields.at(0).field.name, "id");
+   EXPECT_TRUE(combined->fields.at(0).ascending);
+   EXPECT_EQ(combined->child->kind(), operators::NodeKind::TABLE_SCAN);
+}
+
+TEST(SelectKRewritePass, combinesFetchWithoutOffset) {
+   auto fetch = std::make_unique<operators::FetchNode>(makeOrderBy(idAscending()), 5, std::nullopt);
+
+   auto result = SelectKRewritePass::run(std::move(fetch));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::ORDER_BY_WITH_LIMIT);
+   auto* combined = dynamic_cast<operators::OrderByWithLimitNode*>(result.get());
+   EXPECT_EQ(combined->limit, 5);
+   EXPECT_EQ(combined->offset, std::nullopt);
+}
+
+TEST(SelectKRewritePass, doesNotCombineOffsetOnlyFetch) {
+   auto fetch = std::make_unique<operators::FetchNode>(makeOrderBy(idAscending()), std::nullopt, 3);
+
+   auto result = SelectKRewritePass::run(std::move(fetch));
+
+   EXPECT_EQ(result->kind(), operators::NodeKind::FETCH);
+}
+
+TEST(SelectKRewritePass, combinesRandomizeOrderBy) {
+   auto fetch = std::make_unique<operators::FetchNode>(
+      makeOrderBy(std::vector<OrderByField>{}, /*randomize_seed=*/42U), 5, std::nullopt
+   );
+
+   auto result = SelectKRewritePass::run(std::move(fetch));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::ORDER_BY_WITH_LIMIT);
+   auto* combined = dynamic_cast<operators::OrderByWithLimitNode*>(result.get());
+   ASSERT_NE(combined, nullptr);
+   EXPECT_EQ(combined->limit, 5);
+   EXPECT_TRUE(combined->fields.empty());
+   EXPECT_EQ(combined->randomize_seed, 42U);
+}
+
+TEST(SelectKRewritePass, doesNotCombineOrderByWithoutFields) {
+   auto fetch = std::make_unique<operators::FetchNode>(
+      makeOrderBy(std::vector<OrderByField>{}), 5, std::nullopt
+   );
+
+   auto result = SelectKRewritePass::run(std::move(fetch));
+
+   EXPECT_EQ(result->kind(), operators::NodeKind::FETCH);
+}
+
+TEST(SelectKRewritePass, doesNotCombineFetchAboveNonOrderBy) {
+   auto fetch = std::make_unique<operators::FetchNode>(makeScan(), 5, std::nullopt);
+
+   auto result = SelectKRewritePass::run(std::move(fetch));
+
+   EXPECT_EQ(result->kind(), operators::NodeKind::FETCH);
+}

--- a/src/silo/query_engine/planner.cpp
+++ b/src/silo/query_engine/planner.cpp
@@ -11,6 +11,7 @@
 #include "silo/query_engine/optimizer/filter_pushdown_pass.h"
 #include "silo/query_engine/optimizer/map_pullup_pass.h"
 #include "silo/query_engine/optimizer/node_resolution_pass.h"
+#include "silo/query_engine/optimizer/select_k_rewrite_pass.h"
 #include "silo/query_engine/saneql/ast_to_query.h"
 #include "silo/schema/database_schema.h"
 
@@ -23,6 +24,7 @@ using optimizer::ColumnNarrowingPass;
 using optimizer::FilterPushdownPass;
 using optimizer::MapPullupPass;
 using optimizer::NodeResolutionPass;
+using optimizer::SelectKRewritePass;
 
 arrow::Result<QueryPlan> planQueryOrError(
    const operators::QueryNode& node,
@@ -55,6 +57,8 @@ QueryPlan Planner::planQuery(
    log_plan("after FilterPushdownPass");
    node = MapPullupPass::run(std::move(node));
    log_plan("after MapPullupPass");
+   node = SelectKRewritePass::run(std::move(node));
+   log_plan("after SelectKRewritePass");
    node = BitmapAggregationRewritePass::run(std::move(node));
    log_plan("after BitmapAggregationRewritePass");
    node = NodeResolutionPass::run(std::move(node));


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1056

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This adds another rewrite-pass that removes `limit(orderBy(..))` patterns with a specialized node, which will map to an `OrderByWithLimit` node instead. This new node can map to a selectK implementation instead of doing a full sort of the input data

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [X] The implemented feature is covered by an appropriate test.
