### PR TITLE
feat(silo): remove `insertion` and `mutation` field from responses

### DIFF
--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -191,7 +191,6 @@ default.mutations(minProportion:=0.9, sequenceNames:={main, S})
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `mutation` | string | Substitution formatted as `<from><position><to>`, e.g. `A23403G`, `E156-` |
 | `mutationFrom` | string | Reference symbol at this position |
 | `mutationTo` | string | Observed symbol (`-` for a deletion) |
 | `position` | integer | 1-based position in the sequence |
@@ -201,7 +200,7 @@ default.mutations(minProportion:=0.9, sequenceNames:={main, S})
 | `count` | integer | Number of sequences carrying this mutation |
 
 ```json
-{"mutation": "N501Y", "mutationFrom": "N", "mutationTo": "Y", "position": 501, "sequenceName": "S", "proportion": 0.44086021505376344, "coverage": 93, "count": 41}
+{"mutationFrom": "N", "mutationTo": "Y", "position": 501, "sequenceName": "S", "proportion": 0.44086021505376344, "coverage": 93, "count": 41}
 ```
 
 ### `aminoAcidMutations(minProportion:=p [, sequenceNames:={...}] [, fields:={...}])`
@@ -225,14 +224,13 @@ default.insertions(sequenceNames:={main})
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `insertion` | string | Formatted as `ins_<position>:<symbols>`, e.g. `ins_22204:CAGAA` |
 | `insertedSymbols` | string | The inserted nucleotide sequence |
 | `position` | integer | 1-based position after which the insertion occurs (0 = before position 1) |
 | `sequenceName` | string | Name of the sequence |
 | `count` | integer | Number of sequences carrying this exact insertion |
 
 ```json
-{"insertion": "ins_22204:CAGAA", "insertedSymbols": "CAGAA", "position": 22204, "sequenceName": "main", "count": 1}
+{"insertedSymbols": "CAGAA", "position": 22204, "sequenceName": "main", "count": 1}
 ```
 
 ### `aminoAcidInsertions([sequenceNames:={...}])`

--- a/endToEndTests/test/queries/aaInsertionsAction.json
+++ b/endToEndTests/test/queries/aaInsertionsAction.json
@@ -1,46 +1,40 @@
 {
   "testCaseName": "amino acid insertions action",
-  "query": "default.aminoAcidInsertions().orderBy({insertion, position})",
+  "query": "default.aminoAcidInsertions().orderBy({sequenceName, position, insertedSymbols})",
   "expectedQueryResult": [
     {
       "count": 1,
       "insertedSymbols": "F",
-      "insertion": "ins_ORF1a:3602:F",
       "position": 3602,
       "sequenceName": "ORF1a"
     },
     {
       "count": 1,
       "insertedSymbols": "T",
-      "insertion": "ins_S:143:T",
       "position": 143,
       "sequenceName": "S"
     },
     {
       "count": 1,
       "insertedSymbols": "IV",
-      "insertion": "ins_S:210:IV",
       "position": 210,
       "sequenceName": "S"
     },
     {
       "count": 1,
       "insertedSymbols": "*EPE",
-      "insertion": "ins_S:214:*EPE",
       "position": 214,
       "sequenceName": "S"
     },
     {
       "count": 4,
       "insertedSymbols": "EPE",
-      "insertion": "ins_S:214:EPE",
       "position": 214,
       "sequenceName": "S"
     },
     {
       "count": 1,
       "insertedSymbols": "SGE",
-      "insertion": "ins_S:247:SGE",
       "position": 247,
       "sequenceName": "S"
     }

--- a/endToEndTests/test/queries/aaInsertionsActionAndFilter.json
+++ b/endToEndTests/test/queries/aaInsertionsActionAndFilter.json
@@ -5,14 +5,12 @@
     {
       "count": 1,
       "insertedSymbols": "*EPE",
-      "insertion": "ins_S:214:*EPE",
       "position": 214,
       "sequenceName": "S"
     },
     {
       "count": 4,
       "insertedSymbols": "EPE",
-      "insertion": "ins_S:214:EPE",
       "position": 214,
       "sequenceName": "S"
     }

--- a/endToEndTests/test/queries/aaInsertionsActionOneSequence.json
+++ b/endToEndTests/test/queries/aaInsertionsActionOneSequence.json
@@ -5,35 +5,30 @@
     {
       "count": 1,
       "insertedSymbols": "*EPE",
-      "insertion": "ins_S:214:*EPE",
       "position": 214,
       "sequenceName": "S"
     },
     {
       "count": 4,
       "insertedSymbols": "EPE",
-      "insertion": "ins_S:214:EPE",
       "position": 214,
       "sequenceName": "S"
     },
     {
       "count": 1,
       "insertedSymbols": "IV",
-      "insertion": "ins_S:210:IV",
       "position": 210,
       "sequenceName": "S"
     },
     {
       "count": 1,
       "insertedSymbols": "SGE",
-      "insertion": "ins_S:247:SGE",
       "position": 247,
       "sequenceName": "S"
     },
     {
       "count": 1,
       "insertedSymbols": "T",
-      "insertion": "ins_S:143:T",
       "position": 143,
       "sequenceName": "S"
     }

--- a/endToEndTests/test/queries/aaMutDistribution.json
+++ b/endToEndTests/test/queries/aaMutDistribution.json
@@ -5,7 +5,6 @@
     {
       "count": 37,
       "coverage": 97,
-      "mutation": "T19R",
       "mutationFrom": "T",
       "mutationTo": "R",
       "position": 19,
@@ -15,7 +14,6 @@
     {
       "count": 37,
       "coverage": 91,
-      "mutation": "G142D",
       "mutationFrom": "G",
       "mutationTo": "D",
       "position": 142,
@@ -25,7 +23,6 @@
     {
       "count": 35,
       "coverage": 94,
-      "mutation": "E156-",
       "mutationFrom": "E",
       "mutationTo": "-",
       "position": 156,
@@ -35,7 +32,6 @@
     {
       "count": 35,
       "coverage": 94,
-      "mutation": "F157-",
       "mutationFrom": "F",
       "mutationTo": "-",
       "position": 157,
@@ -45,7 +41,6 @@
     {
       "count": 34,
       "coverage": 94,
-      "mutation": "R158G",
       "mutationFrom": "R",
       "mutationTo": "G",
       "position": 158,
@@ -55,7 +50,6 @@
     {
       "count": 34,
       "coverage": 99,
-      "mutation": "G339D",
       "mutationFrom": "G",
       "mutationTo": "D",
       "position": 339,
@@ -65,7 +59,6 @@
     {
       "count": 33,
       "coverage": 98,
-      "mutation": "S373P",
       "mutationFrom": "S",
       "mutationTo": "P",
       "position": 373,
@@ -75,7 +68,6 @@
     {
       "count": 33,
       "coverage": 99,
-      "mutation": "S375F",
       "mutationFrom": "S",
       "mutationTo": "F",
       "position": 375,
@@ -85,7 +77,6 @@
     {
       "count": 38,
       "coverage": 88,
-      "mutation": "L452R",
       "mutationFrom": "L",
       "mutationTo": "R",
       "position": 452,
@@ -95,7 +86,6 @@
     {
       "count": 32,
       "coverage": 93,
-      "mutation": "S477N",
       "mutationFrom": "S",
       "mutationTo": "N",
       "position": 477,
@@ -105,7 +95,6 @@
     {
       "count": 69,
       "coverage": 94,
-      "mutation": "T478K",
       "mutationFrom": "T",
       "mutationTo": "K",
       "position": 478,
@@ -115,7 +104,6 @@
     {
       "count": 31,
       "coverage": 93,
-      "mutation": "E484A",
       "mutationFrom": "E",
       "mutationTo": "A",
       "position": 484,
@@ -125,7 +113,6 @@
     {
       "count": 31,
       "coverage": 93,
-      "mutation": "Q493R",
       "mutationFrom": "Q",
       "mutationTo": "R",
       "position": 493,
@@ -135,7 +122,6 @@
     {
       "count": 30,
       "coverage": 93,
-      "mutation": "Q498R",
       "mutationFrom": "Q",
       "mutationTo": "R",
       "position": 498,
@@ -145,7 +131,6 @@
     {
       "count": 41,
       "coverage": 93,
-      "mutation": "N501Y",
       "mutationFrom": "N",
       "mutationTo": "Y",
       "position": 501,
@@ -155,7 +140,6 @@
     {
       "count": 30,
       "coverage": 93,
-      "mutation": "Y505H",
       "mutationFrom": "Y",
       "mutationTo": "H",
       "position": 505,
@@ -165,7 +149,6 @@
     {
       "count": 98,
       "coverage": 99,
-      "mutation": "D614G",
       "mutationFrom": "D",
       "mutationTo": "G",
       "position": 614,
@@ -175,7 +158,6 @@
     {
       "count": 37,
       "coverage": 99,
-      "mutation": "H655Y",
       "mutationFrom": "H",
       "mutationTo": "Y",
       "position": 655,
@@ -185,7 +167,6 @@
     {
       "count": 34,
       "coverage": 100,
-      "mutation": "N679K",
       "mutationFrom": "N",
       "mutationTo": "K",
       "position": 679,
@@ -195,7 +176,6 @@
     {
       "count": 42,
       "coverage": 100,
-      "mutation": "P681H",
       "mutationFrom": "P",
       "mutationTo": "H",
       "position": 681,
@@ -205,7 +185,6 @@
     {
       "count": 38,
       "coverage": 100,
-      "mutation": "P681R",
       "mutationFrom": "P",
       "mutationTo": "R",
       "position": 681,
@@ -215,7 +194,6 @@
     {
       "count": 31,
       "coverage": 95,
-      "mutation": "N764K",
       "mutationFrom": "N",
       "mutationTo": "K",
       "position": 764,
@@ -225,7 +203,6 @@
     {
       "count": 34,
       "coverage": 99,
-      "mutation": "D796Y",
       "mutationFrom": "D",
       "mutationTo": "Y",
       "position": 796,
@@ -235,7 +212,6 @@
     {
       "count": 34,
       "coverage": 97,
-      "mutation": "D950N",
       "mutationFrom": "D",
       "mutationTo": "N",
       "position": 950,
@@ -245,7 +221,6 @@
     {
       "count": 33,
       "coverage": 98,
-      "mutation": "Q954H",
       "mutationFrom": "Q",
       "mutationTo": "H",
       "position": 954,
@@ -255,7 +230,6 @@
     {
       "count": 34,
       "coverage": 99,
-      "mutation": "N969K",
       "mutationFrom": "N",
       "mutationTo": "K",
       "position": 969,

--- a/endToEndTests/test/queries/aaMutDistribution_all.json
+++ b/endToEndTests/test/queries/aaMutDistribution_all.json
@@ -5,7 +5,6 @@
     {
       "count": 37,
       "coverage": 91,
-      "mutation": "G142D",
       "mutationFrom": "G",
       "mutationTo": "D",
       "position": 142,
@@ -15,7 +14,6 @@
     {
       "count": 46,
       "coverage": 100,
-      "mutation": "R203K",
       "mutationFrom": "R",
       "mutationTo": "K",
       "position": 203,
@@ -25,7 +23,6 @@
     {
       "count": 46,
       "coverage": 100,
-      "mutation": "G204R",
       "mutationFrom": "G",
       "mutationTo": "R",
       "position": 204,
@@ -35,7 +32,6 @@
     {
       "count": 98,
       "coverage": 100,
-      "mutation": "P314L",
       "mutationFrom": "P",
       "mutationTo": "L",
       "position": 314,
@@ -45,7 +41,6 @@
     {
       "count": 38,
       "coverage": 88,
-      "mutation": "L452R",
       "mutationFrom": "L",
       "mutationTo": "R",
       "position": 452,
@@ -55,7 +50,6 @@
     {
       "count": 69,
       "coverage": 94,
-      "mutation": "T478K",
       "mutationFrom": "T",
       "mutationTo": "K",
       "position": 478,
@@ -65,7 +59,6 @@
     {
       "count": 41,
       "coverage": 93,
-      "mutation": "N501Y",
       "mutationFrom": "N",
       "mutationTo": "Y",
       "position": 501,
@@ -75,7 +68,6 @@
     {
       "count": 98,
       "coverage": 99,
-      "mutation": "D614G",
       "mutationFrom": "D",
       "mutationTo": "G",
       "position": 614,
@@ -85,7 +77,6 @@
     {
       "count": 42,
       "coverage": 100,
-      "mutation": "P681H",
       "mutationFrom": "P",
       "mutationTo": "H",
       "position": 681,
@@ -95,7 +86,6 @@
     {
       "count": 64,
       "coverage": 99,
-      "mutation": "T3255I",
       "mutationFrom": "T",
       "mutationTo": "I",
       "position": 3255,
@@ -105,7 +95,6 @@
     {
       "count": 44,
       "coverage": 98,
-      "mutation": "S3675-",
       "mutationFrom": "S",
       "mutationTo": "-",
       "position": 3675,
@@ -115,7 +104,6 @@
     {
       "count": 44,
       "coverage": 99,
-      "mutation": "G3676-",
       "mutationFrom": "G",
       "mutationTo": "-",
       "position": 3676,

--- a/endToEndTests/test/queries/aaMutDistribution_min0.json
+++ b/endToEndTests/test/queries/aaMutDistribution_min0.json
@@ -1,21 +1,19 @@
 {
   "testCaseName": "The distribution of Amino Acid Mutations action with minProportion 0",
-  "query": "default.aminoAcidMutations(minProportion:=0.0, sequenceNames:={E}).orderBy({mutation})",
+  "query": "default.aminoAcidMutations(minProportion:=0.0, sequenceNames:={E}).orderBy({sequenceName, position, mutationTo})",
   "expectedQueryResult": [
     {
-      "count": 1,
-      "coverage": 99,
-      "mutation": "F20L",
-      "mutationFrom": "F",
-      "mutationTo": "L",
-      "position": 20,
-      "proportion": 0.010101010101010102,
+      "count": 34,
+      "coverage": 98,
+      "mutationFrom": "T",
+      "mutationTo": "I",
+      "position": 9,
+      "proportion": 0.3469387755102041,
       "sequenceName": "E"
     },
     {
       "count": 1,
       "coverage": 99,
-      "mutation": "L18I",
       "mutationFrom": "L",
       "mutationTo": "I",
       "position": 18,
@@ -23,13 +21,12 @@
       "sequenceName": "E"
     },
     {
-      "count": 34,
-      "coverage": 98,
-      "mutation": "T9I",
-      "mutationFrom": "T",
-      "mutationTo": "I",
-      "position": 9,
-      "proportion": 0.3469387755102041,
+      "count": 1,
+      "coverage": 99,
+      "mutationFrom": "F",
+      "mutationTo": "L",
+      "position": 20,
+      "proportion": 0.010101010101010102,
       "sequenceName": "E"
     }
   ]

--- a/endToEndTests/test/queries/aaMutDistribution_multiple.json
+++ b/endToEndTests/test/queries/aaMutDistribution_multiple.json
@@ -5,7 +5,6 @@
     {
       "count": 37,
       "coverage": 97,
-      "mutation": "T19R",
       "mutationFrom": "T",
       "mutationTo": "R",
       "position": 19,
@@ -15,7 +14,6 @@
     {
       "count": 37,
       "coverage": 91,
-      "mutation": "G142D",
       "mutationFrom": "G",
       "mutationTo": "D",
       "position": 142,
@@ -25,7 +23,6 @@
     {
       "count": 35,
       "coverage": 94,
-      "mutation": "E156-",
       "mutationFrom": "E",
       "mutationTo": "-",
       "position": 156,
@@ -35,7 +32,6 @@
     {
       "count": 35,
       "coverage": 94,
-      "mutation": "F157-",
       "mutationFrom": "F",
       "mutationTo": "-",
       "position": 157,
@@ -45,7 +41,6 @@
     {
       "count": 34,
       "coverage": 94,
-      "mutation": "R158G",
       "mutationFrom": "R",
       "mutationTo": "G",
       "position": 158,
@@ -55,7 +50,6 @@
     {
       "count": 34,
       "coverage": 99,
-      "mutation": "G339D",
       "mutationFrom": "G",
       "mutationTo": "D",
       "position": 339,
@@ -65,7 +59,6 @@
     {
       "count": 33,
       "coverage": 98,
-      "mutation": "S373P",
       "mutationFrom": "S",
       "mutationTo": "P",
       "position": 373,
@@ -75,7 +68,6 @@
     {
       "count": 33,
       "coverage": 99,
-      "mutation": "S375F",
       "mutationFrom": "S",
       "mutationTo": "F",
       "position": 375,
@@ -85,7 +77,6 @@
     {
       "count": 38,
       "coverage": 88,
-      "mutation": "L452R",
       "mutationFrom": "L",
       "mutationTo": "R",
       "position": 452,
@@ -95,7 +86,6 @@
     {
       "count": 32,
       "coverage": 93,
-      "mutation": "S477N",
       "mutationFrom": "S",
       "mutationTo": "N",
       "position": 477,
@@ -105,7 +95,6 @@
     {
       "count": 69,
       "coverage": 94,
-      "mutation": "T478K",
       "mutationFrom": "T",
       "mutationTo": "K",
       "position": 478,
@@ -115,7 +104,6 @@
     {
       "count": 31,
       "coverage": 93,
-      "mutation": "E484A",
       "mutationFrom": "E",
       "mutationTo": "A",
       "position": 484,
@@ -125,7 +113,6 @@
     {
       "count": 31,
       "coverage": 93,
-      "mutation": "Q493R",
       "mutationFrom": "Q",
       "mutationTo": "R",
       "position": 493,
@@ -135,7 +122,6 @@
     {
       "count": 30,
       "coverage": 93,
-      "mutation": "Q498R",
       "mutationFrom": "Q",
       "mutationTo": "R",
       "position": 498,
@@ -145,7 +131,6 @@
     {
       "count": 41,
       "coverage": 93,
-      "mutation": "N501Y",
       "mutationFrom": "N",
       "mutationTo": "Y",
       "position": 501,
@@ -155,7 +140,6 @@
     {
       "count": 30,
       "coverage": 93,
-      "mutation": "Y505H",
       "mutationFrom": "Y",
       "mutationTo": "H",
       "position": 505,
@@ -165,7 +149,6 @@
     {
       "count": 98,
       "coverage": 99,
-      "mutation": "D614G",
       "mutationFrom": "D",
       "mutationTo": "G",
       "position": 614,
@@ -175,7 +158,6 @@
     {
       "count": 37,
       "coverage": 99,
-      "mutation": "H655Y",
       "mutationFrom": "H",
       "mutationTo": "Y",
       "position": 655,
@@ -185,7 +167,6 @@
     {
       "count": 34,
       "coverage": 100,
-      "mutation": "N679K",
       "mutationFrom": "N",
       "mutationTo": "K",
       "position": 679,
@@ -195,7 +176,6 @@
     {
       "count": 42,
       "coverage": 100,
-      "mutation": "P681H",
       "mutationFrom": "P",
       "mutationTo": "H",
       "position": 681,
@@ -205,7 +185,6 @@
     {
       "count": 38,
       "coverage": 100,
-      "mutation": "P681R",
       "mutationFrom": "P",
       "mutationTo": "R",
       "position": 681,
@@ -215,7 +194,6 @@
     {
       "count": 31,
       "coverage": 95,
-      "mutation": "N764K",
       "mutationFrom": "N",
       "mutationTo": "K",
       "position": 764,
@@ -225,7 +203,6 @@
     {
       "count": 34,
       "coverage": 99,
-      "mutation": "D796Y",
       "mutationFrom": "D",
       "mutationTo": "Y",
       "position": 796,
@@ -235,7 +212,6 @@
     {
       "count": 34,
       "coverage": 97,
-      "mutation": "D950N",
       "mutationFrom": "D",
       "mutationTo": "N",
       "position": 950,
@@ -245,7 +221,6 @@
     {
       "count": 33,
       "coverage": 98,
-      "mutation": "Q954H",
       "mutationFrom": "Q",
       "mutationTo": "H",
       "position": 954,
@@ -255,7 +230,6 @@
     {
       "count": 34,
       "coverage": 99,
-      "mutation": "N969K",
       "mutationFrom": "N",
       "mutationTo": "K",
       "position": 969,
@@ -265,7 +239,6 @@
     {
       "count": 34,
       "coverage": 98,
-      "mutation": "P13L",
       "mutationFrom": "P",
       "mutationTo": "L",
       "position": 13,
@@ -275,7 +248,6 @@
     {
       "count": 34,
       "coverage": 98,
-      "mutation": "E31-",
       "mutationFrom": "E",
       "mutationTo": "-",
       "position": 31,
@@ -285,7 +257,6 @@
     {
       "count": 34,
       "coverage": 98,
-      "mutation": "R32-",
       "mutationFrom": "R",
       "mutationTo": "-",
       "position": 32,
@@ -295,7 +266,6 @@
     {
       "count": 34,
       "coverage": 98,
-      "mutation": "S33-",
       "mutationFrom": "S",
       "mutationTo": "-",
       "position": 33,
@@ -305,7 +275,6 @@
     {
       "count": 36,
       "coverage": 98,
-      "mutation": "D63G",
       "mutationFrom": "D",
       "mutationTo": "G",
       "position": 63,
@@ -315,7 +284,6 @@
     {
       "count": 46,
       "coverage": 100,
-      "mutation": "R203K",
       "mutationFrom": "R",
       "mutationTo": "K",
       "position": 203,
@@ -325,7 +293,6 @@
     {
       "count": 38,
       "coverage": 100,
-      "mutation": "R203M",
       "mutationFrom": "R",
       "mutationTo": "M",
       "position": 203,
@@ -335,7 +302,6 @@
     {
       "count": 46,
       "coverage": 100,
-      "mutation": "G204R",
       "mutationFrom": "G",
       "mutationTo": "R",
       "position": 204,
@@ -345,7 +311,6 @@
     {
       "count": 30,
       "coverage": 100,
-      "mutation": "G215C",
       "mutationFrom": "G",
       "mutationTo": "C",
       "position": 215,
@@ -355,7 +320,6 @@
     {
       "count": 37,
       "coverage": 98,
-      "mutation": "D377Y",
       "mutationFrom": "D",
       "mutationTo": "Y",
       "position": 377,

--- a/endToEndTests/test/queries/aaMutDistribution_very_low.json
+++ b/endToEndTests/test/queries/aaMutDistribution_very_low.json
@@ -1,21 +1,19 @@
 {
   "testCaseName": "The distribution of Amino Acid Mutations action with minProportion 0.0001",
-  "query": "default.aminoAcidMutations(minProportion:=0.0001, sequenceNames:={E}).orderBy({mutation})",
+  "query": "default.aminoAcidMutations(minProportion:=0.0001, sequenceNames:={E}).orderBy({sequenceName, position, mutationTo})",
   "expectedQueryResult": [
     {
-      "count": 1,
-      "coverage": 99,
-      "mutation": "F20L",
-      "mutationFrom": "F",
-      "mutationTo": "L",
-      "position": 20,
-      "proportion": 0.010101010101010102,
+      "count": 34,
+      "coverage": 98,
+      "mutationFrom": "T",
+      "mutationTo": "I",
+      "position": 9,
+      "proportion": 0.3469387755102041,
       "sequenceName": "E"
     },
     {
       "count": 1,
       "coverage": 99,
-      "mutation": "L18I",
       "mutationFrom": "L",
       "mutationTo": "I",
       "position": 18,
@@ -23,13 +21,12 @@
       "sequenceName": "E"
     },
     {
-      "count": 34,
-      "coverage": 98,
-      "mutation": "T9I",
-      "mutationFrom": "T",
-      "mutationTo": "I",
-      "position": 9,
-      "proportion": 0.3469387755102041,
+      "count": 1,
+      "coverage": 99,
+      "mutationFrom": "F",
+      "mutationTo": "L",
+      "position": 20,
+      "proportion": 0.010101010101010102,
       "sequenceName": "E"
     }
   ]

--- a/endToEndTests/test/queries/insertionsAction.json
+++ b/endToEndTests/test/queries/insertionsAction.json
@@ -1,33 +1,29 @@
 {
   "testCaseName": "The insertions action",
-  "query": "default.insertions().orderBy({insertion})",
+  "query": "default.insertions().orderBy({sequenceName, position, insertedSymbols})",
   "expectedQueryResult": [
     {
       "count": 1,
+      "insertedSymbols": "TAT",
+      "position": 5959,
+      "sequenceName": "main"
+    },
+    {
+      "count": 1,
       "insertedSymbols": "CAGAA",
-      "insertion": "ins_main:22204:CAGAA",
       "position": 22204,
       "sequenceName": "main"
     },
     {
       "count": 1,
       "insertedSymbols": "GCTGGT",
-      "insertion": "ins_main:22339:GCTGGT",
       "position": 22339,
       "sequenceName": "main"
     },
     {
       "count": 17,
       "insertedSymbols": "CCC",
-      "insertion": "ins_main:25701:CCC",
       "position": 25701,
-      "sequenceName": "main"
-    },
-    {
-      "count": 1,
-      "insertedSymbols": "TAT",
-      "insertion": "ins_main:5959:TAT",
-      "position": 5959,
       "sequenceName": "main"
     }
   ]

--- a/endToEndTests/test/queries/insertionsActionAndFilter.json
+++ b/endToEndTests/test/queries/insertionsActionAndFilter.json
@@ -5,7 +5,6 @@
     {
       "count": 1,
       "insertedSymbols": "GCTGGT",
-      "insertion": "ins_main:22339:GCTGGT",
       "position": 22339,
       "sequenceName": "main"
     }

--- a/endToEndTests/test/queries/nOf_2of3_mutations.json
+++ b/endToEndTests/test/queries/nOf_2of3_mutations.json
@@ -5,7 +5,6 @@
     {
       "count": 1,
       "coverage": 1,
-      "mutation": "A1-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 1,
@@ -15,7 +14,6 @@
     {
       "count": 1,
       "coverage": 1,
-      "mutation": "T2-",
       "mutationFrom": "T",
       "mutationTo": "-",
       "position": 2,
@@ -25,7 +23,6 @@
     {
       "count": 53,
       "coverage": 53,
-      "mutation": "C241T",
       "mutationFrom": "C",
       "mutationTo": "T",
       "position": 241,
@@ -35,7 +32,6 @@
     {
       "count": 51,
       "coverage": 51,
-      "mutation": "C3037T",
       "mutationFrom": "C",
       "mutationTo": "T",
       "position": 3037,
@@ -45,7 +41,6 @@
     {
       "count": 52,
       "coverage": 52,
-      "mutation": "C14408T",
       "mutationFrom": "C",
       "mutationTo": "T",
       "position": 14408,
@@ -55,7 +50,6 @@
     {
       "count": 53,
       "coverage": 53,
-      "mutation": "A23403G",
       "mutationFrom": "A",
       "mutationTo": "G",
       "position": 23403,
@@ -65,7 +59,6 @@
     {
       "count": 4,
       "coverage": 4,
-      "mutation": "G29868-",
       "mutationFrom": "G",
       "mutationTo": "-",
       "position": 29868,
@@ -75,7 +68,6 @@
     {
       "count": 4,
       "coverage": 5,
-      "mutation": "A29869-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29869,

--- a/endToEndTests/test/queries/sequenceStartEndMutations.json
+++ b/endToEndTests/test/queries/sequenceStartEndMutations.json
@@ -5,7 +5,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A1-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 1,
@@ -15,7 +14,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "C3037T",
       "mutationFrom": "C",
       "mutationTo": "T",
       "position": 3037,
@@ -25,7 +23,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "C14408T",
       "mutationFrom": "C",
       "mutationTo": "T",
       "position": 14408,
@@ -35,7 +32,6 @@
     {
       "count": 40,
       "coverage": 40,
-      "mutation": "A23403G",
       "mutationFrom": "A",
       "mutationTo": "G",
       "position": 23403,
@@ -45,7 +41,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "C29870-",
       "mutationFrom": "C",
       "mutationTo": "-",
       "position": 29870,
@@ -55,7 +50,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29871-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29871,
@@ -65,7 +59,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29872-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29872,
@@ -75,7 +68,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29873-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29873,
@@ -85,7 +77,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29874-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29874,
@@ -95,7 +86,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29875-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29875,
@@ -105,7 +95,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29876-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29876,
@@ -115,7 +104,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29877-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29877,
@@ -125,7 +113,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29878-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29878,
@@ -135,7 +122,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29879-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29879,
@@ -145,7 +131,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29880-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29880,
@@ -155,7 +140,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29881-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29881,
@@ -165,7 +149,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29882-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29882,
@@ -175,7 +158,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29883-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29883,
@@ -185,7 +167,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29884-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29884,
@@ -195,7 +176,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29885-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29885,
@@ -205,7 +185,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29886-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29886,
@@ -215,7 +194,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29887-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29887,
@@ -225,7 +203,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29888-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29888,
@@ -235,7 +212,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29889-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29889,
@@ -245,7 +221,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29890-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29890,
@@ -255,7 +230,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29891-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29891,
@@ -265,7 +239,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29892-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29892,
@@ -275,7 +248,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29893-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29893,
@@ -285,7 +257,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29894-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29894,
@@ -295,7 +266,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29895-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29895,
@@ -305,7 +275,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29896-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29896,
@@ -315,7 +284,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29897-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29897,
@@ -325,7 +293,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29898-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29898,
@@ -335,7 +302,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29899-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29899,
@@ -345,7 +311,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29900-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29900,
@@ -355,7 +320,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29901-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29901,
@@ -365,7 +329,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29902-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29902,
@@ -375,7 +338,6 @@
     {
       "count": 42,
       "coverage": 42,
-      "mutation": "A29903-",
       "mutationFrom": "A",
       "mutationTo": "-",
       "position": 29903,

--- a/src/silo/query_engine/operators/insertions_node.cpp
+++ b/src/silo/query_engine/operators/insertions_node.cpp
@@ -11,7 +11,6 @@
 
 #include <arrow/acero/exec_plan.h>
 #include <arrow/acero/options.h>
-#include <fmt/format.h>
 #include <spdlog/spdlog.h>
 #include <boost/container_hash/hash.hpp>
 #include <nlohmann/json.hpp>
@@ -100,17 +99,6 @@ arrow::Status addAggregatedInsertionsToInsertionCounts(
       ARROW_RETURN_NOT_OK(output_builder.addValueIfContainedInOutput(
          InsertionsNode<SymbolType>::SEQUENCE_FIELD_NAME,
          [&]() -> OutputValue { return sequence_name; }
-      ));
-      ARROW_RETURN_NOT_OK(output_builder.addValueIfContainedInOutput(
-         InsertionsNode<SymbolType>::INSERTION_FIELD_NAME,
-         [&]() -> OutputValue {
-            return fmt::format(
-               "ins_{}:{}:{}",
-               sequence_name,
-               position_and_insertion.position_idx,
-               position_and_insertion.insertion_value
-            );
-         }
       ));
       ARROW_RETURN_NOT_OK(output_builder.addValueIfContainedInOutput(
          InsertionsNode<SymbolType>::COUNT_FIELD_NAME,

--- a/src/silo/query_engine/operators/insertions_node.h
+++ b/src/silo/query_engine/operators/insertions_node.h
@@ -23,7 +23,6 @@ class InsertionsNode final : public QueryNode {
   public:
    static constexpr std::string_view POSITION_FIELD_NAME = "position";
    static constexpr std::string_view INSERTED_SYMBOLS_FIELD_NAME = "insertedSymbols";
-   static constexpr std::string_view INSERTION_FIELD_NAME = "insertion";
    static constexpr std::string_view SEQUENCE_FIELD_NAME = "sequenceName";
    static constexpr std::string_view COUNT_FIELD_NAME = "count";
 
@@ -45,7 +44,6 @@ class InsertionsNode final : public QueryNode {
       fields.emplace_back(std::string(POSITION_FIELD_NAME), schema::ColumnType::INT32);
       fields.emplace_back(std::string(INSERTED_SYMBOLS_FIELD_NAME), schema::ColumnType::STRING);
       fields.emplace_back(std::string(SEQUENCE_FIELD_NAME), schema::ColumnType::STRING);
-      fields.emplace_back(std::string(INSERTION_FIELD_NAME), schema::ColumnType::STRING);
       fields.emplace_back(std::string(COUNT_FIELD_NAME), schema::ColumnType::INT32);
       return fields;
    }

--- a/src/silo/query_engine/operators/mutations_node.cpp
+++ b/src/silo/query_engine/operators/mutations_node.cpp
@@ -10,7 +10,6 @@
 
 #include <arrow/acero/exec_plan.h>
 #include <arrow/acero/options.h>
-#include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
 #include "evobench/evobench.hpp"
@@ -321,17 +320,6 @@ arrow::Status addMutationsToOutput(
             if (count > threshold_count) {
                const double proportion = static_cast<double>(count) / static_cast<double>(total);
                using OutputValue = std::optional<std::variant<std::string, bool, int32_t, double>>;
-               ARROW_RETURN_NOT_OK(output_builder.addValueIfContainedInOutput(
-                  MutationsNode<SymbolType>::MUTATION_FIELD_NAME,
-                  [&]() -> OutputValue {
-                     return {fmt::format(
-                        "{}{}{}",
-                        SymbolType::symbolToChar(symbol_in_reference_genome),
-                        pos + 1,
-                        SymbolType::symbolToChar(symbol)
-                     )};
-                  }
-               ));
                ARROW_RETURN_NOT_OK(output_builder.addValueIfContainedInOutput(
                   MutationsNode<SymbolType>::MUTATION_FROM_FIELD_NAME,
                   [&]() -> OutputValue {

--- a/src/silo/query_engine/operators/mutations_node.h
+++ b/src/silo/query_engine/operators/mutations_node.h
@@ -21,7 +21,6 @@ namespace silo::query_engine::operators {
 template <typename SymbolType>
 class MutationsNode final : public QueryNode {
   public:
-   constexpr static std::string_view MUTATION_FIELD_NAME = "mutation";
    constexpr static std::string_view MUTATION_FROM_FIELD_NAME = "mutationFrom";
    constexpr static std::string_view MUTATION_TO_FIELD_NAME = "mutationTo";
    constexpr static std::string_view POSITION_FIELD_NAME = "position";
@@ -29,8 +28,7 @@ class MutationsNode final : public QueryNode {
    constexpr static std::string_view PROPORTION_FIELD_NAME = "proportion";
    constexpr static std::string_view COVERAGE_FIELD_NAME = "coverage";
    constexpr static std::string_view COUNT_FIELD_NAME = "count";
-   static constexpr std::array<std::string_view, 8> VALID_FIELDS{
-      MUTATION_FIELD_NAME,
+   static constexpr std::array<std::string_view, 7> VALID_FIELDS{
       MUTATION_FROM_FIELD_NAME,
       MUTATION_TO_FIELD_NAME,
       POSITION_FIELD_NAME,
@@ -62,9 +60,6 @@ class MutationsNode final : public QueryNode {
    [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override {
       using silo::schema::ColumnType;
       std::vector<schema::ColumnIdentifier> output_fields;
-      if (std::ranges::find(fields, MUTATION_FIELD_NAME) != fields.end()) {
-         output_fields.emplace_back(std::string(MUTATION_FIELD_NAME), ColumnType::STRING);
-      }
       if (std::ranges::find(fields, MUTATION_FROM_FIELD_NAME) != fields.end()) {
          output_fields.emplace_back(std::string(MUTATION_FROM_FIELD_NAME), ColumnType::STRING);
       }

--- a/src/silo/query_engine/operators/schema_node.test.cpp
+++ b/src/silo/query_engine/operators/schema_node.test.cpp
@@ -104,8 +104,7 @@ const QueryTestScenario MUTATIONS_SCHEMA_SCENARIO = {
    .name = "MUTATIONS_SCHEMA",
    .query = "default.mutations(minProportion:=0.1).schema()",
    .expected_query_result = nlohmann::json(
-      {{{"fieldName", "mutation"}, {"type", "STRING"}},
-       {{"fieldName", "mutationFrom"}, {"type", "STRING"}},
+      {{{"fieldName", "mutationFrom"}, {"type", "STRING"}},
        {{"fieldName", "mutationTo"}, {"type", "STRING"}},
        {{"fieldName", "sequenceName"}, {"type", "STRING"}},
        {{"fieldName", "position"}, {"type", "INT32"}},
@@ -122,7 +121,6 @@ const QueryTestScenario INSERTIONS_SCHEMA_SCENARIO = {
       {{{"fieldName", "position"}, {"type", "INT32"}},
        {{"fieldName", "insertedSymbols"}, {"type", "STRING"}},
        {{"fieldName", "sequenceName"}, {"type", "STRING"}},
-       {{"fieldName", "insertion"}, {"type", "STRING"}},
        {{"fieldName", "count"}, {"type", "INT32"}}}
    )
 };
@@ -188,8 +186,7 @@ const QueryTestScenario AMINO_ACID_MUTATIONS_SCHEMA_SCENARIO = {
    .name = "AMINO_ACID_MUTATIONS_SCHEMA",
    .query = "default.aminoAcidMutations(minProportion:=0.1).schema()",
    .expected_query_result = nlohmann::json(
-      {{{"fieldName", "mutation"}, {"type", "STRING"}},
-       {{"fieldName", "mutationFrom"}, {"type", "STRING"}},
+      {{{"fieldName", "mutationFrom"}, {"type", "STRING"}},
        {{"fieldName", "mutationTo"}, {"type", "STRING"}},
        {{"fieldName", "sequenceName"}, {"type", "STRING"}},
        {{"fieldName", "position"}, {"type", "INT32"}},
@@ -249,8 +246,7 @@ const QueryTestScenario SCHEMA_AFTER_FILTERED_MUTATIONS_SCENARIO = {
    .name = "SCHEMA_AFTER_FILTERED_MUTATIONS",
    .query = "default.filter(country='CH').mutations(minProportion:=0.1).schema()",
    .expected_query_result = nlohmann::json(
-      {{{"fieldName", "mutation"}, {"type", "STRING"}},
-       {{"fieldName", "mutationFrom"}, {"type", "STRING"}},
+      {{{"fieldName", "mutationFrom"}, {"type", "STRING"}},
        {{"fieldName", "mutationTo"}, {"type", "STRING"}},
        {{"fieldName", "sequenceName"}, {"type", "STRING"}},
        {{"fieldName", "position"}, {"type", "INT32"}},

--- a/src/silo/query_engine/operators/union_all_node.test.cpp
+++ b/src/silo/query_engine/operators/union_all_node.test.cpp
@@ -184,11 +184,11 @@ const QueryTestScenario UNION_ALL_MUTATIONS_ON_UNION_SCENARIO = {
 const QueryTestScenario UNION_ALL_OF_MUTATIONS_SCENARIO = {
    .name = "UNION_ALL_OF_MUTATIONS",
    .query = R"(unionAll(
-      default.filter(country='CH').mutations(minProportion:=0.0, fields:={mutation, proportion}),
-      default.filter(country='DE').mutations(minProportion:=0.0, fields:={mutation, proportion})
-   ).orderBy({asc(mutation)}))",
+      default.filter(country='CH').mutations(minProportion:=0.0, fields:={mutationTo, proportion}),
+      default.filter(country='DE').mutations(minProportion:=0.0, fields:={mutationTo, proportion})
+   ).orderBy({asc(mutationTo)}))",
    .expected_query_result = nlohmann::json(
-      {{{"mutation", "A1T"}, {"proportion", 1.0}}, {{"mutation", "A1T"}, {"proportion", 1.0}}}
+      {{{"mutationTo", "T"}, {"proportion", 1.0}}, {{"mutationTo", "T"}, {"proportion", 1.0}}}
    )
 };
 

--- a/src/silo/query_engine/operators/unresolved_insertions_node.h
+++ b/src/silo/query_engine/operators/unresolved_insertions_node.h
@@ -30,7 +30,6 @@ class UnresolvedInsertionsNode final : public QueryNode {
          {.name = std::string(IN::POSITION_FIELD_NAME), .type = schema::ColumnType::INT32},
          {.name = std::string(IN::INSERTED_SYMBOLS_FIELD_NAME), .type = schema::ColumnType::STRING},
          {.name = std::string(IN::SEQUENCE_FIELD_NAME), .type = schema::ColumnType::STRING},
-         {.name = std::string(IN::INSERTION_FIELD_NAME), .type = schema::ColumnType::STRING},
          {.name = std::string(IN::COUNT_FIELD_NAME), .type = schema::ColumnType::INT32},
       };
    }

--- a/src/silo/query_engine/operators/unresolved_mutations_node.h
+++ b/src/silo/query_engine/operators/unresolved_mutations_node.h
@@ -40,9 +40,6 @@ class UnresolvedMutationsNode final : public QueryNode {
          return include_all || std::ranges::find(fields, name) != fields.end();
       };
       std::vector<schema::ColumnIdentifier> output_fields;
-      if (has(MN::MUTATION_FIELD_NAME)) {
-         output_fields.emplace_back(std::string(MN::MUTATION_FIELD_NAME), ColumnType::STRING);
-      }
       if (has(MN::MUTATION_FROM_FIELD_NAME)) {
          output_fields.emplace_back(std::string(MN::MUTATION_FROM_FIELD_NAME), ColumnType::STRING);
       }

--- a/src/silo/query_engine/optimizer/node_resolution_pass.cpp
+++ b/src/silo/query_engine/optimizer/node_resolution_pass.cpp
@@ -56,7 +56,6 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
    std::vector<std::string_view> fields_to_use;
    if (node.fields.empty()) {
       fields_to_use = {
-         operators::MutationsNode<SymbolType>::MUTATION_FIELD_NAME,
          operators::MutationsNode<SymbolType>::MUTATION_FROM_FIELD_NAME,
          operators::MutationsNode<SymbolType>::MUTATION_TO_FIELD_NAME,
          operators::MutationsNode<SymbolType>::POSITION_FIELD_NAME,
@@ -70,7 +69,7 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
          auto it = std::ranges::find(operators::MutationsNode<SymbolType>::VALID_FIELDS, field_str);
          CHECK_SILO_QUERY(
             it != operators::MutationsNode<SymbolType>::VALID_FIELDS.end(),
-            "The attribute 'fields' contains an invalid field '{}'. Valid fields are mutation, "
+            "The attribute 'fields' contains an invalid field '{}'. Valid fields are "
             "mutationFrom, mutationTo, position, sequenceName, proportion, coverage, count.",
             field_str
          );


### PR DESCRIPTION
resolves #1403

### Summary

Removes the specialized `insertion` field from `insertions` / `aminoAcidInsertions` responses and the `mutation` field from `mutations` / `aminoAcidMutations` responses. These were redundant concatenations (`ins_<seq>:<pos>:<symbols>` and `<from><pos><to>`) that clients can reconstruct from the remaining fields (`sequenceName`, `position`, `insertedSymbols`; `mutationFrom`, `position`, `mutationTo`).

BREAKING CHANGE: Insertions response: removed `insertion` field. Mutations response: removed `mutation` field. The string was constructed from information that is still present in the response.

## PR Checklist

- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
