### PR TITLE
test(performance): split data generation of tests and run with one command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,30 @@ ${SILO_RELEASE_TEST_EXECUTABLE}: build/Release/build.ninja $(shell find src -typ
 ${SILO_RELEASE_APP_TEST_EXECUTABLE}: build/Release/build.ninja $(shell find src app/src -type f)
 	$(CMAKE) --build build/Release --parallel $(CMAKE_BUILD_PARALLEL_LEVEL) --target silo_app_test
 
+GENERATE_TEST_DATA_EXECUTABLE=./build/Release/performance/generate_test_data
+
+${GENERATE_TEST_DATA_EXECUTABLE}: build/Release/build.ninja $(shell find src performance -type f \( -name '*.cpp' -o -name '*.h' \))
+	$(CMAKE) --build build/Release --parallel $(CMAKE_BUILD_PARALLEL_LEVEL) --target generate_test_data
+
+# Generate the datasets consumed by the performance benchmarks and write them to disk under
+# localTestData/performance/ (see the *_NDJSON_PATH constants in performance/sequence_generator.h).
+# Run this once before running any performance benchmark.
+.PHONY: generateTestData
+generateTestData: ${GENERATE_TEST_DATA_EXECUTABLE}
+	${GENERATE_TEST_DATA_EXECUTABLE}
+
+PERFORMANCE_TEST_DATA_SENTINEL=localTestData/performance/.generated
+
+${PERFORMANCE_TEST_DATA_SENTINEL}: ${GENERATE_TEST_DATA_EXECUTABLE}
+	${GENERATE_TEST_DATA_EXECUTABLE}
+	@mkdir -p $(@D)
+	touch $@
+
+.PHONY: benchmarks
+benchmarks: ${PERFORMANCE_TEST_DATA_SENTINEL}
+	$(CMAKE) --build build/Release --parallel $(CMAKE_BUILD_PARALLEL_LEVEL) --target build_benchmarks
+	bash performance/run_benchmarks.sh build/Release/performance
+
 # Only the compiled sources trigger a rebuild; wasm/CMakeLists.txt is already a
 # prerequisite of build/wasm/build.ninja. Non-source assets (wasm/example,
 # wasm/README.md, ...) intentionally do not force a rebuild of the binary.

--- a/performance/CMakeLists.txt
+++ b/performance/CMakeLists.txt
@@ -4,9 +4,22 @@ function(add_benchmark BENCH_NAME)
     target_include_directories(${BENCH_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/performance)
 endfunction(add_benchmark)
 
-add_benchmark(mutation_benchmark)
-add_benchmark(many_string_equals)
-add_benchmark(many_short_read_filters)
-add_benchmark(nof_sequence_filter)
-add_benchmark(sequence_column_insert)
-add_benchmark(co_occurrence_benchmark)
+# Tool that generates all benchmark input data.
+add_benchmark(generate_test_data)
+
+set(BENCHMARK_NAMES
+    mutation_benchmark
+    many_string_equals
+    many_short_read_filters
+    nof_sequence_filter
+    sequence_column_insert
+    co_occurrence_benchmark
+)
+foreach(bench ${BENCHMARK_NAMES})
+    add_benchmark(${bench})
+endforeach()
+
+# Aggregate target that just builds every benchmark. Running them is done by
+# performance/run_benchmarks.sh, invoked from the `benchmarks` Makefile target.
+add_custom_target(build_benchmarks)
+add_dependencies(build_benchmarks ${BENCHMARK_NAMES})

--- a/performance/README.md
+++ b/performance/README.md
@@ -12,3 +12,28 @@ cmake --build build/Release --target performance/mutation_benchmark
 These binaries will provide some text output on the performance and can be profiled independently.
 
 They are not unit tests as they can take more extensive time to execute.
+
+## Test data
+
+The benchmarks no longer generate their input data on every run. Instead, a single tool
+(`generate_test_data`) produces all datasets once and writes them to disk under
+`localTestData/performance/` (gitignored); each benchmark reads its dataset back from there. Generate
+the data once before running any benchmark:
+
+```shell
+make generateTestData
+```
+
+This writes several gigabytes of NDJSON. Re-run it only when the generators in `sequence_generator.h`
+change. If a benchmark is run before the data exists, it fails with a message pointing back to
+`make generateTestData`. The dataset paths are defined as the `*_NDJSON_PATH` constants in
+`sequence_generator.h`.
+
+To build and run every benchmark in one step (generating the data first if needed), use:
+
+```shell
+make benchmarks
+```
+
+This runs `performance/run_benchmarks.sh`, which executes each benchmark in sequence, continues past
+any that fail, and reports which ones exited non-zero.

--- a/performance/co_occurrence_benchmark.cpp
+++ b/performance/co_occurrence_benchmark.cpp
@@ -10,15 +10,14 @@
 #include <array>
 #include <chrono>
 #include <memory>
-#include <random>
 #include <sstream>
 #include <string>
-#include <vector>
 
 #include <arrow/compute/api.h>
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
 
+#include "sequence_generator.h"
 #include "silo/config/database_config.h"
 #include "silo/config/runtime_config.h"
 #include "silo/database.h"
@@ -37,23 +36,10 @@ using silo::query_engine::Planner;
 
 // --- Benchmark parameters ---
 
-constexpr size_t REFERENCE_LENGTH = 100;
-constexpr size_t NUM_SEQUENCES = 2'000'000;
-constexpr double MUTATION_RATE = 0.1;
-// Six 1-based positions to co-group on.
+// Six 1-based positions to co-group on. The dataset shape (reference length, sequence count,
+// mutation rate) lives with the generator in sequence_generator.h.
 constexpr std::array<size_t, 6> POSITIONS{5, 10, 20, 30, 40, 50};
 constexpr int ITERATIONS = 5;
-
-constexpr std::array<char, 4> BASES{'A', 'C', 'G', 'T'};
-
-std::string makeRandomReference(std::mt19937& rng) {
-   std::uniform_int_distribution<size_t> base_dist(0, BASES.size() - 1);
-   std::string reference(REFERENCE_LENGTH, 'A');
-   for (char& base : reference) {
-      base = BASES.at(base_dist(rng));
-   }
-   return reference;
-}
 
 std::shared_ptr<Database> setupDatabase(const std::string& reference) {
    auto database_config = silo::config::DatabaseConfig::getValidatedConfig(R"(
@@ -79,28 +65,7 @@ schema:
       )
    );
 
-   std::mt19937 rng{1234};
-   std::uniform_int_distribution<size_t> base_dist(0, BASES.size() - 1);
-   std::binomial_distribution<size_t> mutation_count(REFERENCE_LENGTH, MUTATION_RATE);
-   std::uniform_int_distribution<size_t> pos_dist(0, REFERENCE_LENGTH - 1);
-
-   std::stringstream ndjson;
-   std::string sequence;
-   sequence.reserve(REFERENCE_LENGTH);
-   for (size_t row = 0; row < NUM_SEQUENCES; ++row) {
-      sequence.assign(reference);
-      const size_t mutations = mutation_count(rng);
-      for (size_t i = 0; i < mutations; ++i) {
-         sequence[pos_dist(rng)] = BASES.at(base_dist(rng));
-      }
-      ndjson << fmt::format(
-                   R"({{"primaryKey":"id_{}","main":{{"sequence":"{}","insertions":[]}}}})",
-                   row,
-                   sequence
-                )
-             << '\n';
-   }
-
+   auto ndjson = openTestDataInput(CO_OCCURRENCE_NDJSON_PATH);
    database->appendData(silo::schema::TableName::getDefault(), ndjson);
    return database;
 }
@@ -146,6 +111,7 @@ size_t planAndExecute(
 }  // namespace
 
 int main() {
+   changeCwdToTestFolder();
    // Register Arrow's compute kernels (e.g. utf8_slice_codeunits, used by the `at` scalar function).
    if (!arrow::compute::Initialize().ok()) {
       SPDLOG_ERROR("Failed to initialize Arrow compute");
@@ -154,15 +120,14 @@ int main() {
 
    const auto query_options = silo::config::RuntimeConfig::withDefaults().query_options;
 
-   std::mt19937 reference_rng{42};
-   const std::string reference = makeRandomReference(reference_rng);
+   const std::string reference = makeCoOccurrenceReference();
 
    SPDLOG_INFO(
       "Co-occurrence query benchmark: {} sequences, reference length {}, mutation rate {}, {} "
       "positions",
-      NUM_SEQUENCES,
-      REFERENCE_LENGTH,
-      MUTATION_RATE,
+      CO_OCCURRENCE_NUM_SEQUENCES,
+      CO_OCCURRENCE_REFERENCE_LENGTH,
+      CO_OCCURRENCE_MUTATION_RATE,
       POSITIONS.size()
    );
 

--- a/performance/generate_test_data.cpp
+++ b/performance/generate_test_data.cpp
@@ -1,0 +1,81 @@
+#include <cstdlib>
+#include <exception>
+#include <fstream>
+#include <string>
+
+#include <fmt/format.h>
+#include <spdlog/spdlog.h>
+
+#include "sequence_generator.h"
+
+// Standalone generator for the datasets consumed by the performance benchmarks. Generating this
+// data (tree-evolution models, millions of rows) is the expensive part of each benchmark, so it is
+// produced once here with fixed parameters, written to disk under localTestData/performance/, and
+// read back by the benchmarks instead of being regenerated on every run. Run with
+// `make generateTestData`.
+
+namespace {
+
+void writeDataset(std::string_view path, const auto& generate) {
+   auto out = openTestDataOutput(path);
+   generate(out);
+   out.flush();
+   if (!out) {
+      throw std::runtime_error(fmt::format("Failed while writing {}", path));
+   }
+   SPDLOG_INFO("Wrote {}", path);
+}
+
+void run() {
+   changeCwdToTestFolder();
+   const std::string reference = readReferenceFromFile();
+   SPDLOG_INFO("Read reference sequence of length {}", reference.size());
+
+   // Short reads: 100k for nof_sequence_filter, 5M shared by many_short_read_filters and the large
+   // nof_sequence_filter case.
+   writeDataset(SHORT_READ_SMALL_NDJSON_PATH, [&](std::ostream& out) {
+      writeShortReadNdjson(out, reference, DEFAULT_FULL_SEQ_COUNT);
+   });
+   writeDataset(SHORT_READ_LARGE_NDJSON_PATH, [&](std::ostream& out) {
+      writeShortReadNdjson(out, reference, DEFAULT_READ_COUNT);
+   });
+
+   // Full-length sequences for nof_sequence_filter.
+   writeDataset(FULL_SEQUENCE_NDJSON_PATH, [&](std::ostream& out) {
+      writeFullSequenceNdjson(out, reference);
+   });
+
+   // Full-length sequences with N runs for sequence_column_insert.
+   writeDataset(SEQUENCE_COLUMN_NDJSON_PATH, [&](std::ostream& out) {
+      writeNRunSequenceNdjson(out, reference);
+   });
+
+   // Synthetic short reads for mutation_benchmark (uses its own repeated ACGT reference).
+   writeDataset(MUTATION_READS_NDJSON_PATH, [](std::ostream& out) {
+      writeMutationBenchmarkNdjson(out);
+   });
+
+   // Accession/country records for many_string_equals.
+   writeDataset(STRING_EQUALS_NDJSON_PATH, [](std::ostream& out) {
+      writeStringEqualsNdjson(out);
+   });
+
+   // Random sequences for co_occurrence_benchmark (uses its own short random reference).
+   const std::string co_occurrence_reference = makeCoOccurrenceReference();
+   writeDataset(CO_OCCURRENCE_NDJSON_PATH, [&](std::ostream& out) {
+      writeCoOccurrenceNdjson(out, co_occurrence_reference);
+   });
+
+   SPDLOG_INFO("All benchmark datasets written.");
+}
+
+}  // namespace
+
+int main() {
+   try {
+      run();
+   } catch (const std::exception& e) {
+      SPDLOG_ERROR(e.what());
+      return EXIT_FAILURE;
+   }
+}

--- a/performance/many_short_read_filters.cpp
+++ b/performance/many_short_read_filters.cpp
@@ -33,11 +33,11 @@ TestDatabaseResult setupTestDatabase() {
    SPDLOG_INFO("Read reference sequence of length {}", reference.size());
    const size_t ref_length = reference.size();
 
-   auto input_buffer = generateShortReadNdjson(reference);
-   SPDLOG_INFO("Generated short read NDJSON data");
+   auto input_file = openTestDataInput(SHORT_READ_LARGE_NDJSON_PATH);
+   SPDLOG_INFO("Reading short read NDJSON data from {}", SHORT_READ_LARGE_NDJSON_PATH);
 
    auto database = initializeDatabaseWithShortReadSchema(reference);
-   database->appendData(silo::schema::TableName::getDefault(), input_buffer);
+   database->appendData(silo::schema::TableName::getDefault(), input_file);
 
    return {database, ref_length};
 }
@@ -64,11 +64,11 @@ class QueryGenerator {
             "default.filter("
             "locationName = 'generated' && "
             "samplingDate.between('2024-01-01'::date, '2024-01-07'::date) && "
-            "(nucleotideEquals(position:={0}, symbol:='A') || "
-            "nucleotideEquals(position:={0}, symbol:='C') || "
-            "nucleotideEquals(position:={0}, symbol:='G') || "
-            "nucleotideEquals(position:={0}, symbol:='T') || "
-            "nucleotideEquals(position:={0}, symbol:='-')) && "
+            "(nucleotideEquals(position:={0}, symbol:='A', sequenceName:='main') || "
+            "nucleotideEquals(position:={0}, symbol:='C', sequenceName:='main') || "
+            "nucleotideEquals(position:={0}, symbol:='G', sequenceName:='main') || "
+            "nucleotideEquals(position:={0}, symbol:='T', sequenceName:='main') || "
+            "nucleotideEquals(position:={0}, symbol:='-', sequenceName:='main')) && "
             "samplingDate.between('2024-01-01'::date, '2024-01-07'::date)"
             ").groupBy({{count:=count()}})",
             position
@@ -80,7 +80,7 @@ class QueryGenerator {
          "default.filter("
          "locationName = 'generated' && "
          "samplingDate.between('2024-01-01'::date, '2024-01-07'::date) && "
-         "nucleotideEquals(position:={}, symbol:='{}') && "
+         "nucleotideEquals(position:={}, symbol:='{}', sequenceName:='main') && "
          "samplingDate.between('2024-01-01'::date, '2024-01-07'::date)"
          ").groupBy({{count:=count()}})",
          position,

--- a/performance/many_string_equals.cpp
+++ b/performance/many_string_equals.cpp
@@ -2,11 +2,13 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <vector>
 
 #include <fmt/format.h>
 
+#include "sequence_generator.h"
 #include "silo/append/database_inserter.h"
 #include "silo/append/ndjson_line_reader.h"
 #include "silo/initialize/initializer.h"
@@ -82,23 +84,9 @@ schema:
    return database;
 }
 
-/// Create a database with `num_records` records, each with a unique accession
-std::shared_ptr<Database> setupTestDatabase(size_t num_records) {
-   std::stringstream input_buffer;
-
-   std::vector<std::string> countries = {"USA", "Germany", "France", "UK", "China", "Japan"};
-
-   for (size_t i = 0; i < num_records; ++i) {
-      std::string accession = fmt::format("ACC{:06}", i);
-      std::string country = countries[i % countries.size()];
-      input_buffer << fmt::format(
-         R"({{"accession":"{}","country":"{}"}}
-)",
-         accession,
-         country
-      );
-   }
-
+/// Create a database from the generated accession/country records on disk
+std::shared_ptr<Database> setupTestDatabase() {
+   auto input_buffer = openTestDataInput(STRING_EQUALS_NDJSON_PATH);
    auto database = initializeDatabase();
    database->appendData(silo::schema::TableName::getDefault(), input_buffer);
 
@@ -214,15 +202,16 @@ BenchmarkResult runBenchmark(
 }  // namespace
 
 int main() {
+   changeCwdToTestFolder();
    SPDLOG_INFO("=== StringInSet vs Many StringEquals Performance Benchmark ===");
    SPDLOG_INFO("");
 
-   constexpr size_t NUM_RECORDS = 100000;
+   constexpr size_t NUM_RECORDS = STRING_EQUALS_RECORD_COUNT;
    constexpr int ITERATIONS = 5;
 
    SPDLOG_INFO("Setting up test database with {} records...", NUM_RECORDS);
    auto start_setup = std::chrono::high_resolution_clock::now();
-   auto database = setupTestDatabase(NUM_RECORDS);
+   auto database = setupTestDatabase();
    auto end_setup = std::chrono::high_resolution_clock::now();
    auto setup_duration =
       std::chrono::duration_cast<std::chrono::milliseconds>(end_setup - start_setup).count();
@@ -293,7 +282,10 @@ int main() {
    SPDLOG_INFO("=== Testing on INDEXED column (country) ===");
    SPDLOG_INFO("");
 
-   std::vector<std::string> all_countries = {"USA", "Germany", "France", "UK", "China", "Japan"};
+   std::vector<std::string> all_countries;
+   for (const auto country : STRING_EQUALS_COUNTRIES) {
+      all_countries.emplace_back(country);
+   }
 
    for (size_t num_values : test_sizes) {
       SPDLOG_INFO("--- Benchmark with {} country values (indexed column) ---", num_values);

--- a/performance/mutation_benchmark.cpp
+++ b/performance/mutation_benchmark.cpp
@@ -1,5 +1,10 @@
+#include <chrono>
+#include <memory>
+#include <sstream>
+#include <string>
 #include <utility>
 
+#include "sequence_generator.h"
 #include "silo/append/database_inserter.h"
 #include "silo/append/ndjson_line_reader.h"
 #include "silo/initialize/initializer.h"
@@ -37,46 +42,10 @@ schema:
    return database;
 }
 
-size_t current_id = 0;
-
-void addThousandShortReads(std::stringstream& buffer, size_t offset) {
-   for (size_t i = 0; i < 1000; ++i) {
-      std::string sequence = "ACGT";
-      buffer << fmt::format(
-         R"({{"key":"{}","main":{{"sequence":"{}","offset":{},"insertions":[]}}}}
-)",
-         current_id++,
-         sequence,
-         offset
-      );
-   }
-}
-
 std::shared_ptr<Database> setupTestDatabase() {
-   const std::string pattern = "ACGT";
-   std::string reference;
-   reference.reserve(4000);
-   for (int i = 0; i < 1000; ++i) {
-      reference += pattern;
-   }
+   const std::string reference = buildMutationBenchmarkReference();
 
-   std::stringstream input_buffer;
-
-   for (size_t i = 0; i < 1000; ++i) {
-      addThousandShortReads(input_buffer, 0);
-   }
-   for (size_t i = 0; i < 1000; ++i) {
-      addThousandShortReads(input_buffer, 4);
-   }
-   for (size_t i = 0; i < 100; ++i) {
-      addThousandShortReads(input_buffer, 99);
-   }
-   for (size_t i = 0; i < 100; ++i) {
-      addThousandShortReads(input_buffer, 100 + i);
-   }
-   for (size_t i = 0; i < 1000; ++i) {
-      addThousandShortReads(input_buffer, 2000);
-   }
+   auto input_buffer = openTestDataInput(MUTATION_READS_NDJSON_PATH);
 
    auto database = initializeDatabaseWithSingleReference(reference);
 
@@ -136,6 +105,7 @@ void executeMutationsAlmostAllQuery(const std::shared_ptr<Database>& database) {
 }  // namespace
 
 int main() {
+   changeCwdToTestFolder();
    SPDLOG_INFO("Starting micro benchmark:");
 
    auto start0 = std::chrono::high_resolution_clock::now();

--- a/performance/nof_sequence_filter.cpp
+++ b/performance/nof_sequence_filter.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <numeric>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <arrow/compute/initialize.h>
@@ -71,7 +72,7 @@ BenchmarkResult runBenchmark(
 // sequence).  This exercises the single-pass NOf optimisation at large scale.
 std::string buildMutationProfileQuery(const std::string& query_sequence, uint32_t distance) {
    return fmt::format(
-      "default.filter(nucleotideMutationProfile(distance:={}, querySequence:='{}'))"
+      "default.filter(nucleotideMutationProfile(distance:={}, sequenceName:='main', querySequence:='{}'))"
       ".groupBy({{count:=count()}})",
       distance,
       query_sequence
@@ -80,21 +81,24 @@ std::string buildMutationProfileQuery(const std::string& query_sequence, uint32_
 
 // ---- Database setup ----
 
-std::shared_ptr<Database> setupShortReadDatabase(const std::string& reference, size_t read_count) {
-   SPDLOG_INFO("Generating {} short reads (length {})...", read_count, DEFAULT_READ_LENGTH);
-   auto ndjson = generateShortReadNdjson(reference, read_count);
+std::shared_ptr<Database> loadShortReadDatabase(
+   const std::string& reference,
+   std::string_view path
+) {
+   SPDLOG_INFO("Loading short reads from {}...", path);
+   auto ndjson = openTestDataInput(path);
    auto database = initializeDatabaseWithShortReadSchema(reference);
    database->appendData(silo::schema::TableName::getDefault(), ndjson);
    SPDLOG_INFO("Short-read database ready.");
    return database;
 }
 
-std::shared_ptr<Database> setupFullSequenceDatabase(
+std::shared_ptr<Database> loadFullSequenceDatabase(
    const std::string& reference,
-   size_t read_count
+   std::string_view path
 ) {
-   SPDLOG_INFO("Generating {} full-length sequences...", read_count);
-   auto ndjson = generateFullSequenceNdjson(reference, read_count);
+   SPDLOG_INFO("Loading full-length sequences from {}...", path);
+   auto ndjson = openTestDataInput(path);
    auto database = initializeDatabaseWithFullSequenceSchema(reference);
    database->appendData(silo::schema::TableName::getDefault(), ndjson);
    SPDLOG_INFO("Full-sequence database ready.");
@@ -151,9 +155,9 @@ void run() {
    );
    SPDLOG_INFO("");
 
-   const auto short_read_db = setupShortReadDatabase(reference, DEFAULT_FULL_SEQ_COUNT);
-   const auto short_read_db_large = setupShortReadDatabase(reference, DEFAULT_READ_COUNT);
-   const auto full_seq_db = setupFullSequenceDatabase(reference, DEFAULT_FULL_SEQ_COUNT);
+   const auto short_read_db = loadShortReadDatabase(reference, SHORT_READ_SMALL_NDJSON_PATH);
+   const auto short_read_db_large = loadShortReadDatabase(reference, SHORT_READ_LARGE_NDJSON_PATH);
+   const auto full_seq_db = loadFullSequenceDatabase(reference, FULL_SEQUENCE_NDJSON_PATH);
 
    // distance=0 tests the "almost nothing matches" extreme (exact profile match).
    // Large distances test the "almost everything matches" extreme.

--- a/performance/run_benchmarks.sh
+++ b/performance/run_benchmarks.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Run every performance benchmark binary in sequence.
+#
+# The run continues past a benchmark that exits non-zero and reports which ones failed at the end.
+# It exits non-zero if any benchmark failed, so CI/automation can detect failures. The benchmarks
+# must already be built and `make generateTestData` must have produced their input data; the
+# `benchmarks` Makefile target takes care of both before invoking this script.
+#
+# Usage: performance/run_benchmarks.sh [BENCHMARK_BINARY_DIR]
+#   BENCHMARK_BINARY_DIR defaults to build/Release/performance.
+set -u
+
+# Run from the repository root so the benchmarks find testBaseData/ and localTestData/ via relative
+# paths regardless of where this script was invoked from.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${script_dir}/.."
+
+bin_dir="${1:-build/Release/performance}"
+
+benchmarks=(
+  mutation_benchmark
+  many_string_equals
+  many_short_read_filters
+  nof_sequence_filter
+  sequence_column_insert
+  co_occurrence_benchmark
+)
+
+failed=()
+for bench in "${benchmarks[@]}"; do
+  echo "=== Running ${bench} ==="
+  if ! "${bin_dir}/${bench}"; then
+    failed+=("${bench}")
+  fi
+done
+
+if [ "${#failed[@]}" -ne 0 ]; then
+  echo "Benchmarks that exited non-zero: ${failed[*]}"
+else
+  echo "All benchmarks completed."
+fi

--- a/performance/sequence_column_insert.cpp
+++ b/performance/sequence_column_insert.cpp
@@ -1,124 +1,48 @@
 #include <chrono>
-#include <random>
+#include <cstdlib>
+#include <exception>
 #include <string>
-#include <vector>
 
 #include <spdlog/spdlog.h>
 
 #include "sequence_generator.h"
-#include "silo/common/nucleotide_symbols.h"
-#include "silo/storage/column/sequence_column.h"
+#include "silo/database.h"
+#include "silo/schema/database_schema.h"
 
-using silo::Nucleotide;
-using silo::storage::column::SequenceColumn;
-using silo::storage::column::SequenceColumnMetadata;
+using silo::Database;
 
 namespace {
-
-constexpr size_t SEQUENCE_COUNT = 100'000;
-
-std::vector<std::string> generateSequences(const std::string& reference) {
-   SequenceTreeGenerator tree_gen(reference, 42, 0.001, 0.1, 12, 3);
-   auto evolved = tree_gen.generateEvolvedSequences();
-   SPDLOG_INFO("generated {} distinct evolved sequences", evolved.size());
-
-   std::mt19937 rng(7);
-   std::uniform_int_distribution<size_t> pick(0, evolved.size() - 1);
-   // realistic-ish N runs at both ends plus a few internal N stretches
-   std::uniform_int_distribution<size_t> head_n(0, 300);
-   std::uniform_int_distribution<size_t> tail_n(0, 300);
-   std::uniform_int_distribution<size_t> internal_runs(0, 5);
-   std::uniform_int_distribution<size_t> run_len(1, 100);
-   std::uniform_int_distribution<size_t> pos_dist(0, reference.size() - 200);
-
-   std::vector<std::string> sequences;
-   sequences.reserve(SEQUENCE_COUNT);
-   for (size_t i = 0; i < SEQUENCE_COUNT; ++i) {
-      std::string sequence = evolved.at(pick(rng));
-      const size_t head = std::min(head_n(rng), sequence.size());
-      const size_t tail = std::min(tail_n(rng), sequence.size());
-      for (size_t j = 0; j < head; ++j) {
-         sequence[j] = 'N';
-      }
-      for (size_t j = 0; j < tail; ++j) {
-         sequence[sequence.size() - 1 - j] = 'N';
-      }
-      const size_t runs = internal_runs(rng);
-      for (size_t r = 0; r < runs; ++r) {
-         const size_t start = pos_dist(rng);
-         const size_t length = run_len(rng);
-         const size_t end = std::min(start + length, sequence.size());
-         for (size_t j = start; j < end; ++j) {
-            sequence[j] = 'N';
-         }
-      }
-      sequences.push_back(std::move(sequence));
-   }
-   return sequences;
-}
 
 double toMs(std::chrono::steady_clock::time_point start, std::chrono::steady_clock::time_point end) {
    return std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() / 1000.0;
 }
 
-}  // namespace
-
-int main() {
+// Ingest full-length sequences with realistic N runs through the regular appendData path (NDJSON ->
+// column-group builder -> sequence column), measuring the end-to-end append time. The dataset is
+// generated once by `make generateTestData` (writeNRunSequenceNdjson).
+void run() {
    changeCwdToTestFolder();
    const std::string reference = readReferenceFromFile();
    SPDLOG_INFO("reference length {}", reference.size());
 
-   const auto sequences = generateSequences(reference);
+   auto database = initializeDatabaseWithFullSequenceSchema(reference);
+   auto input = openTestDataInput(SEQUENCE_COLUMN_NDJSON_PATH);
 
-   std::vector<Nucleotide::Symbol> reference_symbols;
-   for (char character : reference) {
-      reference_symbols.push_back(Nucleotide::charToSymbol(character).value());
+   const auto start = std::chrono::steady_clock::now();
+   database->appendData(silo::schema::TableName::getDefault(), input);
+   const auto end = std::chrono::steady_clock::now();
+
+   SPDLOG_INFO("sequences appended: {}", SEQUENCE_COLUMN_SEQUENCE_COUNT);
+   SPDLOG_INFO("appendData:         {:.1f} ms", toMs(start, end));
+}
+
+}  // namespace
+
+int main() {
+   try {
+      run();
+   } catch (const std::exception& e) {
+      SPDLOG_ERROR(e.what());
+      return EXIT_FAILURE;
    }
-   SequenceColumnMetadata<Nucleotide> metadata{"main", std::move(reference_symbols)};
-   SequenceColumn<Nucleotide> column{&metadata};
-
-   const std::vector<std::string> no_insertions;
-
-   constexpr size_t CHUNK_SIZE = silo::storage::column::COLUMN_CHUNK_SIZE;
-   double builder_ms = 0;
-   double append_ms = 0;
-
-   const auto total_start = std::chrono::steady_clock::now();
-   for (size_t chunk_start = 0; chunk_start < sequences.size(); chunk_start += CHUNK_SIZE) {
-      SequenceColumn<Nucleotide>::Builder builder{&metadata, reference};
-      const size_t chunk_end = std::min(chunk_start + CHUNK_SIZE, sequences.size());
-
-      const auto build_start = std::chrono::steady_clock::now();
-      for (size_t i = chunk_start; i < chunk_end; ++i) {
-         builder.insert(sequences[i], 0, no_insertions);
-      }
-      auto buffer = builder.finalize();
-      const auto build_end = std::chrono::steady_clock::now();
-      builder_ms += toMs(build_start, build_end);
-
-      const auto append_start = std::chrono::steady_clock::now();
-      SILO_ASSERT(column.appendChunk(buffer).has_value());
-      const auto append_end = std::chrono::steady_clock::now();
-      append_ms += toMs(append_start, append_end);
-   }
-
-   const auto finalize_start = std::chrono::steady_clock::now();
-   column.finalize();
-   const auto finalize_end = std::chrono::steady_clock::now();
-   const auto total_end = std::chrono::steady_clock::now();
-
-   size_t adapted_positions = 0;
-   for (size_t i = 0; i < reference.size(); ++i) {
-      if (column.local_reference_sequence_string[i] != reference[i]) {
-         adapted_positions++;
-      }
-   }
-
-   SPDLOG_INFO("adapted positions: {} of {}", adapted_positions, reference.size());
-   SPDLOG_INFO("sequences:        {}", sequences.size());
-   SPDLOG_INFO("builder.insert:   {:.1f} ms", builder_ms);
-   SPDLOG_INFO("column.appendChunk: {:.1f} ms", append_ms);
-   SPDLOG_INFO("column.finalize:  {:.1f} ms", toMs(finalize_start, finalize_end));
-   SPDLOG_INFO("total:            {:.1f} ms", toMs(total_start, total_end));
-   return 0;
 }

--- a/performance/sequence_generator.h
+++ b/performance/sequence_generator.h
@@ -1,12 +1,16 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
+#include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <memory>
+#include <ostream>
 #include <random>
-#include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <fmt/format.h>
@@ -49,6 +53,52 @@ std::string readReferenceFromFile() {
       throw std::runtime_error("No nucleotide sequences found in reference_genomes.json");
    }
    return reference_genomes.raw_nucleotide_sequences.at(0);
+}
+
+// --- Test-data files ---
+//
+// The datasets consumed by the benchmarks are generated once by the `generate_test_data` tool
+// (`make generateTestData`) and written to disk under localTestData/performance/. Each benchmark
+// reads its dataset back instead of regenerating it on every run. All paths are relative to the
+// repository root (see changeCwdToTestFolder) and localTestData/ is gitignored.
+
+constexpr std::string_view SHORT_READ_SMALL_NDJSON_PATH =
+   "localTestData/performance/short_reads_100k.ndjson";
+constexpr std::string_view SHORT_READ_LARGE_NDJSON_PATH =
+   "localTestData/performance/short_reads_5m.ndjson";
+constexpr std::string_view FULL_SEQUENCE_NDJSON_PATH =
+   "localTestData/performance/full_sequences_100k.ndjson";
+constexpr std::string_view MUTATION_READS_NDJSON_PATH =
+   "localTestData/performance/mutation_reads.ndjson";
+constexpr std::string_view STRING_EQUALS_NDJSON_PATH =
+   "localTestData/performance/string_equals_records.ndjson";
+constexpr std::string_view CO_OCCURRENCE_NDJSON_PATH =
+   "localTestData/performance/co_occurrence_sequences.ndjson";
+constexpr std::string_view SEQUENCE_COLUMN_NDJSON_PATH =
+   "localTestData/performance/sequence_column_sequences.ndjson";
+
+// Open a dataset file for writing, creating parent directories as needed.
+std::ofstream openTestDataOutput(std::string_view path) {
+   const std::filesystem::path out_path{path};
+   if (out_path.has_parent_path()) {
+      std::filesystem::create_directories(out_path.parent_path());
+   }
+   std::ofstream out{out_path, std::ios::binary | std::ios::trunc};
+   if (!out) {
+      throw std::runtime_error(fmt::format("Could not open {} for writing", path));
+   }
+   return out;
+}
+
+// Open a dataset file for reading, with a hint to run the generator if it is missing.
+std::ifstream openTestDataInput(std::string_view path) {
+   std::ifstream in{std::string{path}, std::ios::binary};
+   if (!in) {
+      throw std::runtime_error(fmt::format(
+         "Could not open {}. Generate benchmark data first with `make generateTestData`.", path
+      ));
+   }
+   return in;
 }
 
 // --- Sequence evolution model ---
@@ -207,30 +257,32 @@ class ShortReadGenerator {
 };
 
 // --- NDJSON generators ---
+//
+// The generators stream directly to an ostream rather than returning a buffer, so datasets of any
+// size can be written to disk without being held in memory.
 
-std::stringstream generateShortReadNdjson(
+void writeShortReadNdjson(
+   std::ostream& out,
    const std::string& reference,
    size_t count = DEFAULT_READ_COUNT,
    size_t read_length = DEFAULT_READ_LENGTH
 ) {
    ShortReadGenerator generator(reference, count, read_length);
-   std::stringstream buffer;
    for (const auto& read : generator) {
-      buffer
-         << fmt::format(
-               R"({{"readId":"read_{}","samplingDate":"2024-01-01","locationName":"generated","main":{{"insertions":[],"offset":{},"sequence":"{}"}}}})",
-               read.id,
-               read.offset,
-               read.sequence
-            )
-         << "\n";
+      out << fmt::format(
+                R"({{"readId":"read_{}","samplingDate":"2024-01-01","locationName":"generated","main":{{"insertions":[],"offset":{},"sequence":"{}"}}}})",
+                read.id,
+                read.offset,
+                read.sequence
+             )
+          << "\n";
    }
-   return buffer;
 }
 
 constexpr size_t DEFAULT_FULL_SEQ_COUNT = 100'000;
 
-std::stringstream generateFullSequenceNdjson(
+void writeFullSequenceNdjson(
+   std::ostream& out,
    const std::string& reference,
    size_t count = DEFAULT_FULL_SEQ_COUNT
 ) {
@@ -239,13 +291,153 @@ std::stringstream generateFullSequenceNdjson(
    SPDLOG_INFO(
       "Repeating {} evolved sequences to fill {} full-sequence entries", evolved.size(), count
    );
-   std::stringstream buffer;
    for (size_t i = 0; i < count; ++i) {
       const auto& seq = evolved[i % evolved.size()];
-      buffer << fmt::format(R"({{"key":"{}","main":{{"sequence":"{}","insertions":[]}}}})", i, seq)
-             << "\n";
+      out << fmt::format(R"({{"key":"{}","main":{{"sequence":"{}","insertions":[]}}}})", i, seq)
+          << "\n";
    }
-   return buffer;
+}
+
+// --- Sequence-column insert data (full-length sequences with realistic N runs) ---
+
+constexpr size_t SEQUENCE_COLUMN_SEQUENCE_COUNT = 100'000;
+
+// Full-length evolved sequences with realistic-ish N runs at both ends plus a few internal
+// stretches, emitted as full-sequence NDJSON so the benchmark can ingest them through appendData.
+void writeNRunSequenceNdjson(std::ostream& out, const std::string& reference) {
+   SequenceTreeGenerator tree_gen(reference, 42, 0.001, 0.1, 12, 3);
+   auto evolved = tree_gen.generateEvolvedSequences();
+   SPDLOG_INFO("generated {} distinct evolved sequences", evolved.size());
+
+   std::mt19937 rng(7);
+   std::uniform_int_distribution<size_t> pick(0, evolved.size() - 1);
+   // realistic-ish N runs at both ends plus a few internal N stretches
+   std::uniform_int_distribution<size_t> head_n(0, 300);
+   std::uniform_int_distribution<size_t> tail_n(0, 300);
+   std::uniform_int_distribution<size_t> internal_runs(0, 5);
+   std::uniform_int_distribution<size_t> run_len(1, 100);
+   std::uniform_int_distribution<size_t> pos_dist(0, reference.size() - 200);
+
+   for (size_t i = 0; i < SEQUENCE_COLUMN_SEQUENCE_COUNT; ++i) {
+      std::string sequence = evolved.at(pick(rng));
+      const size_t head = std::min(head_n(rng), sequence.size());
+      const size_t tail = std::min(tail_n(rng), sequence.size());
+      for (size_t j = 0; j < head; ++j) {
+         sequence[j] = 'N';
+      }
+      for (size_t j = 0; j < tail; ++j) {
+         sequence[sequence.size() - 1 - j] = 'N';
+      }
+      const size_t runs = internal_runs(rng);
+      for (size_t r = 0; r < runs; ++r) {
+         const size_t start = pos_dist(rng);
+         const size_t length = run_len(rng);
+         const size_t end = std::min(start + length, sequence.size());
+         for (size_t j = start; j < end; ++j) {
+            sequence[j] = 'N';
+         }
+      }
+      out << fmt::format(R"({{"key":"{}","main":{{"sequence":"{}","insertions":[]}}}})", i, sequence)
+          << "\n";
+   }
+}
+
+// --- Mutation benchmark data (synthetic short reads over a repeated ACGT reference) ---
+
+constexpr size_t MUTATION_REFERENCE_REPEATS = 1000;  // "ACGT" repeated -> 4000nt reference
+
+std::string buildMutationBenchmarkReference() {
+   std::string reference;
+   reference.reserve(4 * MUTATION_REFERENCE_REPEATS);
+   for (size_t i = 0; i < MUTATION_REFERENCE_REPEATS; ++i) {
+      reference += "ACGT";
+   }
+   return reference;
+}
+
+// Fixed distribution of 3.2M short (4nt) reads across a handful of offsets, matching the original
+// inline generation (running key, sequence always "ACGT").
+void writeMutationBenchmarkNdjson(std::ostream& out) {
+   size_t current_id = 0;
+   const auto emitBatches = [&](size_t batches, size_t offset) {
+      for (size_t batch = 0; batch < batches; ++batch) {
+         for (size_t i = 0; i < 1000; ++i) {
+            out << fmt::format(
+                      R"({{"key":"{}","main":{{"sequence":"ACGT","offset":{},"insertions":[]}}}})",
+                      current_id++,
+                      offset
+                   )
+                << "\n";
+         }
+      }
+   };
+   emitBatches(1000, 0);
+   emitBatches(1000, 4);
+   emitBatches(100, 99);
+   for (size_t i = 0; i < 100; ++i) {
+      emitBatches(1, 100 + i);
+   }
+   emitBatches(1000, 2000);
+}
+
+// --- String-equals benchmark data ---
+
+constexpr size_t STRING_EQUALS_RECORD_COUNT = 100'000;
+constexpr std::array<std::string_view, 6> STRING_EQUALS_COUNTRIES =
+   {"USA", "Germany", "France", "UK", "China", "Japan"};
+
+void writeStringEqualsNdjson(std::ostream& out) {
+   for (size_t i = 0; i < STRING_EQUALS_RECORD_COUNT; ++i) {
+      out << fmt::format(
+                R"({{"accession":"ACC{:06}","country":"{}"}})",
+                i,
+                STRING_EQUALS_COUNTRIES[i % STRING_EQUALS_COUNTRIES.size()]
+             )
+          << "\n";
+   }
+}
+
+// --- Co-occurrence benchmark data (random sequences over a short random reference) ---
+
+constexpr size_t CO_OCCURRENCE_REFERENCE_LENGTH = 100;
+constexpr size_t CO_OCCURRENCE_NUM_SEQUENCES = 2'000'000;
+constexpr double CO_OCCURRENCE_MUTATION_RATE = 0.1;
+
+std::string makeCoOccurrenceReference() {
+   constexpr std::array<char, 4> bases{'A', 'C', 'G', 'T'};
+   std::mt19937 rng{42};
+   std::uniform_int_distribution<size_t> base_dist(0, bases.size() - 1);
+   std::string reference(CO_OCCURRENCE_REFERENCE_LENGTH, 'A');
+   for (char& base : reference) {
+      base = bases.at(base_dist(rng));
+   }
+   return reference;
+}
+
+void writeCoOccurrenceNdjson(std::ostream& out, const std::string& reference) {
+   constexpr std::array<char, 4> bases{'A', 'C', 'G', 'T'};
+   std::mt19937 rng{1234};
+   std::uniform_int_distribution<size_t> base_dist(0, bases.size() - 1);
+   std::binomial_distribution<size_t> mutation_count(
+      CO_OCCURRENCE_REFERENCE_LENGTH, CO_OCCURRENCE_MUTATION_RATE
+   );
+   std::uniform_int_distribution<size_t> pos_dist(0, CO_OCCURRENCE_REFERENCE_LENGTH - 1);
+
+   std::string sequence;
+   sequence.reserve(CO_OCCURRENCE_REFERENCE_LENGTH);
+   for (size_t row = 0; row < CO_OCCURRENCE_NUM_SEQUENCES; ++row) {
+      sequence.assign(reference);
+      const size_t mutations = mutation_count(rng);
+      for (size_t i = 0; i < mutations; ++i) {
+         sequence[pos_dist(rng)] = bases.at(base_dist(rng));
+      }
+      out << fmt::format(
+                R"({{"primaryKey":"id_{}","main":{{"sequence":"{}","insertions":[]}}}})",
+                row,
+                sequence
+             )
+          << '\n';
+   }
 }
 
 // --- Database initializers ---


### PR DESCRIPTION
This helps the general utilities of the repo, where we can add more features and CI integration to performance tests. 

Importantly this also helps #1151 to provide easier benchmarks, as we want to run the ~same benchmark on sorted and unsorted input