### PR TITLE
fix(silo): allow `limit` on `groupBy`

### DIFF
--- a/src/silo/query_engine/operators/bitmap_aggregation_node.test.cpp
+++ b/src/silo/query_engine/operators/bitmap_aggregation_node.test.cpp
@@ -111,6 +111,19 @@ const QueryTestScenario CO_OCCURRENCE_VIA_MAP_NON_SEQUENCE_NOT_REWRITTEN = {
    ])")
 };
 
+// A limit applied to a generic (unordered) aggregation used to be rejected outright because the
+// group-by output carries no ordering. The FetchNode now marks such a result as implicitly ordered
+// so the limit is honoured, accepting that the retained rows are an arbitrary subset. Grouping on
+// primaryKey.at(1) stays on the generic (non-bitmap) path and the single resulting group keeps the
+// truncated result deterministic.
+const QueryTestScenario LIMIT_ON_UNORDERED_AGGREGATION = {
+   .name = "LIMIT_ON_UNORDERED_AGGREGATION",
+   .query = "default.map({first := primaryKey.at(1)}).groupBy({count:=count()}, {first}).limit(1)",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"first": "i", "count": 4}
+   ])")
+};
+
 // The reference is only 5 symbols long, so position 6 is out of range. The rewritten bitmap
 // aggregation node reports this when it builds the per-symbol bitmaps.
 const QueryTestScenario CO_OCCURRENCE_VIA_MAP_POSITION_OUT_OF_RANGE = {
@@ -276,6 +289,7 @@ QUERY_TEST(
       CO_OCCURRENCE_VIA_MAP_WITH_FILTER,
       CO_OCCURRENCE_VIA_MAP_AMINO_ACID,
       CO_OCCURRENCE_VIA_MAP_NON_SEQUENCE_NOT_REWRITTEN,
+      LIMIT_ON_UNORDERED_AGGREGATION,
       CO_OCCURRENCE_VIA_MAP_POSITION_OUT_OF_RANGE,
       INDEXED_COLUMN_SINGLE,
       MIXED_SEQUENCE_AND_INDEXED_COLUMN

--- a/src/silo/query_engine/operators/fetch_node.cpp
+++ b/src/silo/query_engine/operators/fetch_node.cpp
@@ -8,13 +8,44 @@
 
 #include <arrow/acero/exec_plan.h>
 #include <arrow/acero/options.h>
+#include <arrow/compute/ordering.h>
+#include <arrow/util/async_generator_fwd.h>
 #include <nlohmann/json.hpp>
 
-#include "silo/query_engine/illegal_query_exception.h"
 #include "silo/schema/database_schema.h"
 #include "silo/storage/table.h"
 
 namespace silo::query_engine::operators {
+
+namespace {
+
+// Re-emits the batches of a node through a sink/source pair, with the resulting source declaring
+// the given ordering. Used to attach a fabricated ordering to (and later strip it back off) an
+// otherwise unordered result so that arrow's fetch node accepts it.
+arrow::Result<arrow::acero::ExecNode*> resequenceWithOrdering(
+   arrow::acero::ExecPlan& plan,
+   arrow::acero::ExecNode* child_node,
+   arrow::Ordering ordering,
+   const std::string& label
+) {
+   auto schema = child_node->output_schema();
+   arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> generator;
+   ARROW_ASSIGN_OR_RAISE(
+      auto* sink_node,
+      arrow::acero::MakeExecNode(
+         "sink", &plan, {child_node}, arrow::acero::SinkNodeOptions{&generator}
+      )
+   );
+   sink_node->SetLabel(label);
+   return arrow::acero::MakeExecNode(
+      "source",
+      &plan,
+      {},
+      arrow::acero::SourceNodeOptions{std::move(schema), std::move(generator), std::move(ordering)}
+   );
+}
+
+}  // namespace
 
 FetchNode::FetchNode(
    QueryNodePtr child,
@@ -36,19 +67,38 @@ arrow::Result<arrow::acero::ExecNode*> FetchNode::addToExecPlan(
 ) const {
    ARROW_ASSIGN_OR_RAISE(auto* child_node, child->addToExecPlan(plan, tables, query_options));
 
-   CHECK_SILO_QUERY(
-      !child_node->ordering().is_unordered(),
-      "Offset and limit can only be applied if the output of the operation has some ordering. "
-      "Implicit ordering such as in the case of Details/Fasta is also allowed, Aggregated "
-      "however produces unordered results."
-   );
+   // arrow's fetch node requires an ordered input so that limit/offset is well-defined. If the
+   // child produces an unordered result (e.g. an aggregation/group-by), the user is nonetheless
+   // allowed to request a limit: we mark the result as implicitly ordered, accepting that the
+   // retained rows are an arbitrary subset.
+   const bool child_unordered = child_node->ordering().is_unordered();
+   if (child_unordered) {
+      ARROW_ASSIGN_OR_RAISE(
+         child_node,
+         resequenceWithOrdering(
+            plan, child_node, arrow::Ordering::Implicit(), "resequence for limit/offset"
+         )
+      );
+   }
 
    const arrow::acero::FetchNodeOptions fetch_options(
       offset.value_or(0), count.value_or(std::numeric_limits<int64_t>::max())
    );
-   return arrow::acero::MakeExecNode(
-      std::string{arrow::acero::FetchNodeOptions::kName}, &plan, {child_node}, fetch_options
+   ARROW_ASSIGN_OR_RAISE(
+      auto* fetch_node,
+      arrow::acero::MakeExecNode(
+         std::string{arrow::acero::FetchNodeOptions::kName}, &plan, {child_node}, fetch_options
+      )
    );
+
+   // The implicit ordering above was fabricated purely to satisfy the fetch node; the retained
+   // rows are an arbitrary subset, so restore the unordered contract for downstream nodes.
+   if (child_unordered) {
+      return resequenceWithOrdering(
+         plan, fetch_node, arrow::Ordering::Unordered(), "unordered result of limit/offset"
+      );
+   }
+   return fetch_node;
 }
 
 nlohmann::json FetchNode::toJson() const {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1409

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->


Note that this `marking` does not move/copy the data, it just moves references to batches through auxiliary nodes

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [X] The implemented feature is covered by an appropriate test.
