### PR TITLE
refactor(schema): allow arbitrary strings as table names

### DIFF
--- a/src/silo/schema/database_schema.cpp
+++ b/src/silo/schema/database_schema.cpp
@@ -101,14 +101,8 @@ void TableSchema::load(Archive& archive, const unsigned int /*version*/) {
    }
 }
 
-TableName::TableName(std::string name) {
-   for (const char character : name) {
-      if (character < 'a' || character > 'z') {
-         throw std::runtime_error("Table names may only contain lower-case letters");
-      }
-   }
-   this->name = std::move(name);
-}
+TableName::TableName(std::string name)
+    : name(std::move(name)) {}
 
 namespace {
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1414

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

When the feature of multiple tables was introduced to SILO we were quite restrictive about possible column names. As we do not intend the CLI interface to be the main interacting point of SILO this turns out to be an unnecessary restriction. We should allow arbitrary strings.

This removes the restricted tableName validation.


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
