### PR TITLE
refactor(silo): consistently name the header result-ordering

### DIFF
--- a/documentation/api.md
+++ b/documentation/api.md
@@ -32,7 +32,7 @@ Every response includes:
 | `X-Request-Id` | Echoes the request's `X-Request-Id`, or a generated UUID v4 if none was provided. Useful for correlating logs. |
 | `data-version` | A 10-digit Unix timestamp identifying the database snapshot used to serve the request. Allows clients to detect when the underlying data has changed between requests. |
 
-The `POST /query` endpoint additionally returns an [`ordering`](#response-headers) header describing the sort order of the result rows.
+The `POST /query` endpoint additionally returns an [`result-ordering`](#response-headers) header describing the sort order of the result rows.
 
 ## Endpoints
 
@@ -114,7 +114,7 @@ Queries time out after 120 seconds.
 
 #### Response Headers
 
-In addition to the [common response headers](#common-response-headers), a successful (200) query response carries an `ordering` header describing the order in which the result rows are returned.
+In addition to the [common response headers](#common-response-headers), a successful (200) query response carries an `result-ordering` header describing the order in which the result rows are returned.
 
 | Header | Description |
 |--------|-------------|

--- a/endToEndTests/test/common.js
+++ b/endToEndTests/test/common.js
@@ -19,7 +19,7 @@ export function expectHeaderToHaveDataVersion(response) {
 // Parses the `result-ordering` response header describing the order of the result rows: a JSON array with
 // one `{ field, order, nullPlacement }` object per sort key, or `[]` when there is no explicit
 // ordering.
-export function getOrdering(response) {
+export function getResultOrdering(response) {
   const headers = response.headers;
   expect(headers).to.have.property('result-ordering');
   return JSON.parse(headers['result-ordering']);

--- a/endToEndTests/test/query.test.js
+++ b/endToEndTests/test/query.test.js
@@ -1,4 +1,4 @@
-import { expectHeaderToHaveDataVersion, getOrdering, server } from './common.js';
+import { expectHeaderToHaveDataVersion, getResultOrdering, server } from './common.js';
 import { expect } from 'chai';
 import { describe, it } from 'node:test';
 import fs from 'fs';
@@ -146,13 +146,13 @@ describe('The /query endpoint', () => {
     );
   });
 
-  describe('the ordering response header', () => {
+  describe('the result-ordering response header', () => {
     const postQuery = query => server.post('/query').set('Content-Type', 'text/plain').send(query);
 
     it('serializes the sort key for an explicit ascending order by', async () => {
       const response = await postQuery('default.orderBy({primary_key}).project({primary_key})');
       expect(response.status).to.equal(200);
-      expect(getOrdering(response)).to.deep.equal([
+      expect(getResultOrdering(response)).to.deep.equal([
         { field: 'primary_key', order: 'ascending', nullPlacement: 'atStart' },
       ]);
     });
@@ -160,7 +160,7 @@ describe('The /query endpoint', () => {
     it('reflects the sort direction and null placement for a descending order by', async () => {
       const response = await postQuery('default.orderBy({primary_key.desc()}).project({primary_key})');
       expect(response.status).to.equal(200);
-      expect(getOrdering(response)).to.deep.equal([
+      expect(getResultOrdering(response)).to.deep.equal([
         { field: 'primary_key', order: 'descending', nullPlacement: 'atEnd' },
       ]);
     });
@@ -168,7 +168,7 @@ describe('The /query endpoint', () => {
     it('has no explicit ordering for a query without an order by', async () => {
       const response = await postQuery('default.groupBy({count:=count()})');
       expect(response.status).to.equal(200);
-      expect(getOrdering(response)).to.deep.equal([]);
+      expect(getResultOrdering(response)).to.deep.equal([]);
     });
   });
 


### PR DESCRIPTION
quick followup to #1411 