### PR TITLE
perf(silo): process input sequences word-at-a-time

### DIFF
--- a/src/silo/common/aligned_sequence.cpp
+++ b/src/silo/common/aligned_sequence.cpp
@@ -1,0 +1,155 @@
+#include "silo/common/aligned_sequence.h"
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <expected>
+#include <string>
+#include <string_view>
+
+#include <fmt/format.h>
+
+#include "silo/common/aa_symbols.h"
+#include "silo/common/nucleotide_symbols.h"
+
+namespace silo {
+
+template <typename SymbolType>
+std::expected<CoverageAndMutations<SymbolType>, std::string>
+extractCoverageAndMutationsFromSequence(
+   std::string_view sequence,
+   size_t offset,
+   std::string_view reference,
+   bool reference_is_missing_somewhere
+) {
+   Coverage coverage;
+   Mutations<SymbolType> mutations;
+
+   const char* const sequence_data = sequence.data();
+   const char* const reference_data = reference.data() + offset;
+   const size_t length = sequence.size();
+
+   // lambda to process a single character from the input
+   auto process_one = [&](size_t char_in_sequence) -> std::expected<void, std::string> {
+      const auto position_idx = static_cast<uint32_t>(char_in_sequence + offset);
+      const char character = sequence_data[char_in_sequence];
+      const auto symbol = SymbolType::charToSymbol(character);
+      if (!symbol.has_value()) {
+         return std::unexpected{fmt::format(
+            "illegal character '{}' at position {} in the input sequence", character, position_idx
+         )};
+      }
+      if (symbol == SymbolType::SYMBOL_MISSING) {
+         coverage.missing_positions.push_back(position_idx);
+      } else if (symbol != SymbolType::charToSymbol(reference_data[char_in_sequence])) {
+         // The characters differ but may still encode the same symbol (e.g. lower case
+         // input, or 'U' against a reference 'T'), which is not a mutation.
+         mutations.mutations.emplace_back(position_idx, symbol.value());
+      }
+      return {};
+   };
+
+   size_t char_in_sequence = 0;
+   if (!reference_is_missing_somewhere) {
+      // Sequences deviate from the reference in only a handful of positions, so compare
+      // them a word at a time and only look at the characters that actually differ.
+      static_assert(
+         std::endian::native == std::endian::little,
+         "the lowest set bit of the xor of two words identifies the first differing character "
+         "only on a little endian machine"
+      );
+      constexpr size_t WORD_SIZE = sizeof(uint64_t);
+      for (; char_in_sequence + WORD_SIZE <= length; char_in_sequence += WORD_SIZE) {
+         uint64_t sequence_word;
+         uint64_t reference_word;
+         std::memcpy(&sequence_word, sequence_data + char_in_sequence, WORD_SIZE);
+         std::memcpy(&reference_word, reference_data + char_in_sequence, WORD_SIZE);
+         uint64_t differing_bytes = sequence_word ^ reference_word;
+         while (differing_bytes != 0) {
+            const size_t byte_in_word = static_cast<size_t>(std::countr_zero(differing_bytes)) / 8;
+            auto result = process_one(char_in_sequence + byte_in_word);
+            if (!result.has_value()) {
+               return std::unexpected{result.error()};
+            }
+            differing_bytes &= ~(static_cast<uint64_t>(0xFF) << (byte_in_word * 8));
+         }
+      }
+   }
+   for (; char_in_sequence < length; ++char_in_sequence) {
+      if (reference_is_missing_somewhere ||
+          sequence_data[char_in_sequence] != reference_data[char_in_sequence]) {
+         auto result = process_one(char_in_sequence);
+         if (!result.has_value()) {
+            return std::unexpected{result.error()};
+         }
+      }
+   }
+
+   // The covered region spans from the first to the last non-missing position. Since the
+   // missing positions are collected in ascending order, the ones outside that region are
+   // exactly the leading and trailing ones. They carry no coverage information
+   // (insertCoverage would trim them anyway), so they are dropped to keep the buffered
+   // chunk as small as possible.
+   const auto& missing_positions = coverage.missing_positions;
+   size_t leading_missing = 0;
+   while (leading_missing < missing_positions.size() &&
+          missing_positions[leading_missing] == offset + leading_missing) {
+      ++leading_missing;
+   }
+   size_t trailing_missing = 0;
+   while (trailing_missing < missing_positions.size() - leading_missing &&
+          missing_positions[missing_positions.size() - 1 - trailing_missing] ==
+             offset + length - 1 - trailing_missing) {
+      ++trailing_missing;
+   }
+   if (leading_missing + trailing_missing == length) {
+      // Fully missing sequence: no covered region and nothing to record.
+      coverage.missing_positions.clear();
+   } else {
+      coverage.start = static_cast<uint32_t>(offset + leading_missing);
+      coverage.end = static_cast<uint32_t>(offset + length - trailing_missing);
+      coverage.missing_positions.erase(
+         coverage.missing_positions.end() - static_cast<ptrdiff_t>(trailing_missing),
+         coverage.missing_positions.end()
+      );
+      coverage.missing_positions.erase(
+         coverage.missing_positions.begin(),
+         coverage.missing_positions.begin() + static_cast<ptrdiff_t>(leading_missing)
+      );
+   }
+   return CoverageAndMutations<SymbolType>{coverage, mutations};
+}
+
+template <typename SymbolType>
+std::expected<CoverageAndMutations<SymbolType>, std::string>
+extractCoverageAndMutationsFromSequence(
+   std::string_view sequence,
+   size_t offset,
+   std::string_view reference
+) {
+   return extractCoverageAndMutationsFromSequence<SymbolType>(
+      sequence, offset, reference, referenceContainsMissingSymbol<SymbolType>(reference)
+   );
+}
+
+template std::expected<CoverageAndMutations<Nucleotide>, std::string>
+extractCoverageAndMutationsFromSequence<Nucleotide>(
+   std::string_view,
+   size_t,
+   std::string_view,
+   bool
+);
+template std::expected<CoverageAndMutations<AminoAcid>, std::string>
+extractCoverageAndMutationsFromSequence<AminoAcid>(
+   std::string_view,
+   size_t,
+   std::string_view,
+   bool
+);
+template std::expected<CoverageAndMutations<Nucleotide>, std::string>
+extractCoverageAndMutationsFromSequence<Nucleotide>(std::string_view, size_t, std::string_view);
+template std::expected<CoverageAndMutations<AminoAcid>, std::string>
+extractCoverageAndMutationsFromSequence<AminoAcid>(std::string_view, size_t, std::string_view);
+
+}  // namespace silo

--- a/src/silo/common/aligned_sequence.h
+++ b/src/silo/common/aligned_sequence.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <cstdint>
 #include <expected>
-#include <optional>
+#include <string>
+#include <string_view>
 #include <vector>
-
-#include "silo/append/append_exception.h"
 
 namespace silo {
 
@@ -34,58 +34,34 @@ class CoverageAndMutations {
    Mutations<SymbolType> mutations;
 };
 
+/// A reference that is itself missing at some position makes a character that equals the
+/// reference missing too, which the bulk comparison in extractCoverageAndMutationsFromSequence
+/// must not skip over. This does not hold for the reference genomes we know of, so the check is
+/// hoisted out of the per-sequence path.
+template <typename SymbolType>
+bool referenceContainsMissingSymbol(std::string_view reference) {
+   return reference.find(SymbolType::symbolToChar(SymbolType::SYMBOL_MISSING)) !=
+          std::string_view::npos;
+}
+
+/// Diffs `sequence` (placed at `offset` within the genome) against `reference`, returning the
+/// covered range, the missing (N) positions within it, and the mutations.
+template <typename SymbolType>
+std::expected<CoverageAndMutations<SymbolType>, std::string>
+extractCoverageAndMutationsFromSequence(
+   std::string_view sequence,
+   size_t offset,
+   std::string_view reference,
+   bool reference_is_missing_somewhere
+);
+
+/// Convenience overload - prefer the 4-arg method
 template <typename SymbolType>
 std::expected<CoverageAndMutations<SymbolType>, std::string>
 extractCoverageAndMutationsFromSequence(
    std::string_view sequence,
    size_t offset,
    std::string_view reference
-) {
-   Coverage coverage;
-   Mutations<SymbolType> mutations;
-
-   // Single pass over the sequence computes both the covered range / missing
-   // positions (coverage) and the deviations from the local reference
-   // (mutations), mirroring HorizontalCoverageIndex::insertSequenceCoverage and
-   // the diff loop that used to live in SequenceColumn::appendValue.
-   std::optional<uint32_t> first_non_missing;
-   std::optional<uint32_t> last_non_missing;
-   for (uint32_t char_in_sequence = 0; char_in_sequence < sequence.size(); ++char_in_sequence) {
-      const uint32_t position_idx = char_in_sequence + offset;
-      const char character = sequence[char_in_sequence];
-      const auto symbol = SymbolType::charToSymbol(character);
-      if (!symbol.has_value()) {
-         return std::unexpected{fmt::format(
-            "illegal character '{}' at position {} in the input sequence", character, position_idx
-         )};
-      }
-      if (symbol == SymbolType::SYMBOL_MISSING) {
-         coverage.missing_positions.push_back(position_idx);
-         continue;
-      }
-      if (!first_non_missing.has_value()) {
-         first_non_missing = position_idx;
-      }
-      last_non_missing = position_idx;
-      if (character != reference[position_idx]) {
-         mutations.mutations.emplace_back(position_idx, symbol.value());
-      }
-   }
-
-   if (first_non_missing.has_value()) {
-      coverage.start = first_non_missing.value();
-      coverage.end = last_non_missing.value() + 1;
-      // Missing positions outside the covered region carry no coverage
-      // information (insertCoverage would trim them anyway), so drop them here to
-      // keep the buffered chunk as small as possible.
-      std::erase_if(coverage.missing_positions, [&](uint32_t position_idx) {
-         return position_idx < coverage.start || position_idx >= coverage.end;
-      });
-   } else {
-      // Fully missing sequence: no covered region and nothing to record.
-      coverage.missing_positions.clear();
-   }
-   return CoverageAndMutations<SymbolType>{coverage, mutations};
-}
+);
 
 }  // namespace silo

--- a/src/silo/common/aligned_sequence.test.cpp
+++ b/src/silo/common/aligned_sequence.test.cpp
@@ -144,6 +144,70 @@ TEST(AlignedSequence, leadingGapStartsCoverage) {
    EXPECT_EQ(result.mutations.mutations.at(0).second, Symbol::GAP);
 }
 
+TEST(AlignedSequence, charactersEncodingTheReferenceSymbolAreNoMutation) {
+   // 'a' and 'U' encode the same symbols as the reference 'A' and 'T'
+   const auto result = extractNuc("aCGU", 0, "ACGT");
+
+   EXPECT_EQ(result.coverage.start, 0);
+   EXPECT_EQ(result.coverage.end, 4);
+   EXPECT_TRUE(result.mutations.mutations.empty());
+}
+
+TEST(AlignedSequence, lowerCaseMissingSymbolIsMissing) {
+   const auto result = extractNuc("AnGT", 0, "ACGT");
+
+   EXPECT_EQ(result.coverage.start, 0);
+   EXPECT_EQ(result.coverage.end, 4);
+   EXPECT_EQ(result.coverage.missing_positions, std::vector<uint32_t>{1});
+   EXPECT_TRUE(result.mutations.mutations.empty());
+}
+
+TEST(AlignedSequence, positionsWhereTheReferenceIsMissingAreMissing) {
+   // A reference that is itself missing at a position makes an equal character missing too
+   const auto result = extractNuc("ANGT", 0, "ANGT");
+
+   EXPECT_EQ(result.coverage.start, 0);
+   EXPECT_EQ(result.coverage.end, 4);
+   EXPECT_EQ(result.coverage.missing_positions, std::vector<uint32_t>{1});
+   EXPECT_TRUE(result.mutations.mutations.empty());
+}
+
+TEST(AlignedSequence, mutationAgainstAMissingReferenceSymbolIsRecorded) {
+   const auto result = extractNuc("ACGT", 0, "ANGT");
+
+   EXPECT_EQ(result.coverage.start, 0);
+   EXPECT_EQ(result.coverage.end, 4);
+   EXPECT_TRUE(result.coverage.missing_positions.empty());
+   ASSERT_EQ(result.mutations.mutations.size(), 1);
+   EXPECT_EQ(result.mutations.mutations.at(0).first, 1);
+   EXPECT_EQ(result.mutations.mutations.at(0).second, Symbol::C);
+}
+
+TEST(AlignedSequence, sequencesLongerThanOneWordAreDiffed) {
+   // The comparison against the reference proceeds in 8 byte words, so cover a sequence that
+   // spans several words with deviations in the first, a middle and the last, partial word.
+   const std::string reference(30, 'A');
+   std::string sequence(30, 'A');
+   sequence.at(0) = 'N';
+   sequence.at(3) = 'C';
+   sequence.at(15) = 'G';
+   sequence.at(28) = 'N';
+   sequence.at(29) = 'T';
+
+   const auto result = extractNuc(sequence, 0, reference);
+
+   EXPECT_EQ(result.coverage.start, 1);
+   EXPECT_EQ(result.coverage.end, 30);
+   EXPECT_EQ(result.coverage.missing_positions, std::vector<uint32_t>{28});
+   ASSERT_EQ(result.mutations.mutations.size(), 3);
+   EXPECT_EQ(result.mutations.mutations.at(0).first, 3);
+   EXPECT_EQ(result.mutations.mutations.at(0).second, Symbol::C);
+   EXPECT_EQ(result.mutations.mutations.at(1).first, 15);
+   EXPECT_EQ(result.mutations.mutations.at(1).second, Symbol::G);
+   EXPECT_EQ(result.mutations.mutations.at(2).first, 29);
+   EXPECT_EQ(result.mutations.mutations.at(2).second, Symbol::T);
+}
+
 TEST(AlignedSequence, illegalCharacterHasError) {
    auto result = extractCoverageAndMutationsFromSequence<Nucleotide>("ACXT", 0, "ACGT");
    ASSERT_FALSE(result.has_value());
@@ -228,6 +292,57 @@ TEST(AlignedSequence, largeOffsetShiftsCoverageRange) {
    EXPECT_EQ(result.mutations.mutations.at(0).first, 51);
    EXPECT_EQ(result.mutations.mutations.at(1).first, 52);
    EXPECT_EQ(result.mutations.mutations.at(2).first, 53);
+}
+
+TEST(AlignedSequence, sequencesLongerThanOneWordAreDiffedWithOffset) {
+   // Same as sequencesLongerThanOneWordAreDiffed, but shifted by a non word aligned offset so
+   // that the position arithmetic inside the word wise comparison is exercised as well.
+   const std::string reference(85, 'A');
+   std::string sequence(30, 'A');
+   sequence.at(0) = 'N';
+   sequence.at(3) = 'C';
+   sequence.at(15) = 'G';
+   sequence.at(20) = 'N';
+   sequence.at(29) = 'T';
+
+   const auto result = extractNuc(sequence, 51, reference);
+
+   // the leading N at global position 51 is trimmed, the N at global position 71 is kept
+   EXPECT_EQ(result.coverage.start, 52);
+   EXPECT_EQ(result.coverage.end, 81);
+   EXPECT_EQ(result.coverage.missing_positions, std::vector<uint32_t>{71});
+   ASSERT_EQ(result.mutations.mutations.size(), 3);
+   EXPECT_EQ(result.mutations.mutations.at(0).first, 54);
+   EXPECT_EQ(result.mutations.mutations.at(0).second, Symbol::C);
+   EXPECT_EQ(result.mutations.mutations.at(1).first, 66);
+   EXPECT_EQ(result.mutations.mutations.at(1).second, Symbol::G);
+   EXPECT_EQ(result.mutations.mutations.at(2).first, 80);
+   EXPECT_EQ(result.mutations.mutations.at(2).second, Symbol::T);
+}
+
+TEST(AlignedSequence, aminoAcidSequencesLongerThanOneWordAreDiffed) {
+   // The word wise comparison is symbol type agnostic; verify it for AminoAcid, whose missing
+   // symbol is X, on a sequence spanning several words.
+   const std::string reference(30, 'A');
+   std::string sequence(30, 'A');
+   sequence.at(2) = 'K';
+   sequence.at(11) = 'X';
+   sequence.at(25) = 'W';
+   sequence.at(29) = 'X';
+
+   auto result = extractCoverageAndMutationsFromSequence<AminoAcid>(sequence, 0, reference);
+   ASSERT_TRUE(result.has_value());
+   const auto& value = result.value();
+
+   // the trailing X at position 29 is trimmed, the X at position 11 is kept
+   EXPECT_EQ(value.coverage.start, 0);
+   EXPECT_EQ(value.coverage.end, 29);
+   EXPECT_EQ(value.coverage.missing_positions, std::vector<uint32_t>{11});
+   ASSERT_EQ(value.mutations.mutations.size(), 2);
+   EXPECT_EQ(value.mutations.mutations.at(0).first, 2);
+   EXPECT_EQ(value.mutations.mutations.at(0).second, AminoAcid::Symbol::K);
+   EXPECT_EQ(value.mutations.mutations.at(1).first, 25);
+   EXPECT_EQ(value.mutations.mutations.at(1).second, AminoAcid::Symbol::W);
 }
 
 TEST(AlignedSequence, worksForAminoAcidSymbolType) {

--- a/src/silo/storage/column/sequence_column.cpp
+++ b/src/silo/storage/column/sequence_column.cpp
@@ -314,6 +314,8 @@ SequenceColumnBuilder<SymbolType>::SequenceColumnBuilder(
       )) {
    SILO_ASSERT_GT(metadata->reference_sequence.size(), 0ULL);
    SILO_ASSERT_EQ(this->local_reference.size(), metadata->reference_sequence.size());
+   local_reference_contains_missing_symbol =
+      referenceContainsMissingSymbol<SymbolType>(this->local_reference);
 }
 
 template <typename SymbolType>
@@ -335,7 +337,7 @@ void SequenceColumnBuilder<SymbolType>::insert(
    SILO_ASSERT(sequence.size() + offset < UINT32_MAX);
 
    auto coverage_mutations = extractCoverageAndMutationsFromSequence<SymbolType>(
-      sequence, offset, std::string_view{local_reference}
+      sequence, offset, std::string_view{local_reference}, local_reference_contains_missing_symbol
    );
    if (!coverage_mutations.has_value()) {
       SPDLOG_INFO("{}", coverage_mutations.error());

--- a/src/silo/storage/column/sequence_column.h
+++ b/src/silo/storage/column/sequence_column.h
@@ -182,6 +182,8 @@ class SequenceColumnBuilder {
    // rows share the same reference basis as the already-stored ones.
    std::string local_reference;
 
+   bool local_reference_contains_missing_symbol;
+
   public:
    // Decompresses 'sequenceCompressed' input during phase-1 extraction. Uses the
    // initial (unadapted) reference, which is what inputs are compressed against.


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1363 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This functionally neutral change improves preprocessing times by first comparing the input strings against reference strings on the character level and then only doing the per-base translation logic if the characters mismatch.

Perf improvement:

Before:
```
[info] [reference_genomes.cpp:156] Read reference genomes from file: testBaseData/exampleDataset/reference_genomes.json
[info] [sequence_column_insert.cpp:69] reference length 29903
[info] [sequence_column_insert.cpp:23] generated 185836 distinct evolved sequences
[info] [sequence_column_insert.cpp:117] adapted positions: 40 of 29903
[info] [sequence_column_insert.cpp:118] sequences:        100000
[info] [sequence_column_insert.cpp:119] builder.insert:   3033.8 ms
[info] [sequence_column_insert.cpp:120] column.appendChunk: 719.5 ms
[info] [sequence_column_insert.cpp:121] column.finalize:  833.2 ms
[info] [sequence_column_insert.cpp:122] total:            4605.9 ms
```

After:
```
[info] [reference_genomes.cpp:156] Read reference genomes from file: testBaseData/exampleDataset/reference_genomes.json
[info] [sequence_column_insert.cpp:69] reference length 29903
[info] [sequence_column_insert.cpp:23] generated 185836 distinct evolved sequences
[info] [sequence_column_insert.cpp:117] adapted positions: 40 of 29903
[info] [sequence_column_insert.cpp:118] sequences:        100000
[info] [sequence_column_insert.cpp:119] builder.insert:   704.5 ms
[info] [sequence_column_insert.cpp:120] column.appendChunk: 626.8 ms
[info] [sequence_column_insert.cpp:121] column.finalize:  856.6 ms
[info] [sequence_column_insert.cpp:122] total:            2206.8 ms
```

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [X] The implemented feature is covered by an appropriate test.
