### PR TITLE
refactor(silo): introduce `RoaringContainer` abstraction

### DIFF
--- a/src/silo/query_engine/operators/mutations_node.cpp
+++ b/src/silo/query_engine/operators/mutations_node.cpp
@@ -144,8 +144,9 @@ void countActualMutations(
    EVOBENCH_SCOPE("Mutations", "countActualMutations");
    for (const auto& [sequence_diff_key, sequence_diff] : vertical_bitmaps) {
       count_of_mutations_per_position[sequence_diff_key.symbol][sequence_diff_key.position] +=
-         sequence_diff.cardinality;
-      count_per_local_reference_position[sequence_diff_key.position] -= sequence_diff.cardinality;
+         sequence_diff.getCardinality();
+      count_per_local_reference_position[sequence_diff_key.position] -=
+         sequence_diff.getCardinality();
    }
 }
 
@@ -176,8 +177,8 @@ void countActualFilteredMutations(
          auto contained_count = roaring::internal::container_and_cardinality(
             filter_container,
             filter_container_typecode,
-            sequence_diff.container,
-            sequence_diff.typecode
+            sequence_diff.rawContainer(),
+            sequence_diff.getTypecode()
          );
 
          count_of_mutations_per_position[sequence_diff_key.symbol][sequence_diff_key.position] +=

--- a/src/silo/roaring_util/bitmap_builder.cpp
+++ b/src/silo/roaring_util/bitmap_builder.cpp
@@ -4,7 +4,7 @@ namespace silo::roaring_util {
 
 void BitmapBuilderByContainer::addContainer(
    uint16_t v_index,
-   roaring::internal::container_t* container,
+   const roaring::internal::container_t* container,
    uint8_t typecode
 ) {
    if (current_v_tile_index > v_index) {

--- a/src/silo/roaring_util/bitmap_builder.h
+++ b/src/silo/roaring_util/bitmap_builder.h
@@ -11,7 +11,11 @@ class BitmapBuilderByContainer {
    uint8_t current_typecode = 0;
 
   public:
-   void addContainer(uint16_t v_index, roaring::internal::container_t* container, uint8_t typecode);
+   void addContainer(
+      uint16_t v_index,
+      const roaring::internal::container_t* container,
+      uint8_t typecode
+   );
 
    roaring::Roaring getBitmap() &&;
 };

--- a/src/silo/roaring_util/roaring_container.cpp
+++ b/src/silo/roaring_util/roaring_container.cpp
@@ -1,0 +1,60 @@
+#include "silo/roaring_util/roaring_container.h"
+
+#include "silo/common/panic.h"
+
+namespace silo::roaring_util {
+
+RoaringContainer RoaringContainer::withCapacity(int32_t capacity) {
+   roaring::internal::container_t* container;
+   uint8_t typecode;
+   // roaring::internal::DEFAULT_MAX_SIZE is the maximum size for array containers.
+   if (capacity <= roaring::internal::DEFAULT_MAX_SIZE) {
+      container = roaring::internal::array_container_create_given_capacity(capacity);
+      typecode = ARRAY_CONTAINER_TYPE;
+   } else {
+      container = roaring::internal::bitset_container_create();
+      typecode = BITSET_CONTAINER_TYPE;
+   }
+   SILO_ASSERT(container != nullptr);
+   return RoaringContainer{container, 0, typecode};
+}
+
+RoaringContainer RoaringContainer::clonedFrom(
+   const roaring::internal::container_t* source,
+   uint8_t typecode
+) {
+   auto* clone = roaring::internal::container_clone(source, typecode);
+   SILO_ASSERT(clone != nullptr);
+   const auto cardinality =
+      static_cast<uint32_t>(roaring::internal::container_get_cardinality(clone, typecode));
+   return RoaringContainer{clone, cardinality, typecode};
+}
+
+void RoaringContainer::add(uint16_t value) {
+   uint8_t new_typecode;
+   auto* new_container =
+      roaring::internal::container_add(container, value, typecode, &new_typecode);
+   if (new_container != container) {
+      roaring::internal::container_free(container, typecode);
+      container = new_container;
+      typecode = new_typecode;
+   }
+   cardinality += 1;
+}
+
+size_t RoaringContainer::sizeInBytes() const {
+   return roaring::internal::container_size_in_bytes(container, typecode);
+}
+
+void RoaringContainer::runOptimizeAndShrink() {
+   uint8_t new_typecode;
+   auto* new_container =
+      roaring::internal::convert_run_optimize(container, typecode, &new_typecode);
+   if (new_container != container) {
+      container = new_container;
+      typecode = new_typecode;
+   }
+   roaring::internal::container_shrink_to_fit(container, typecode);
+}
+
+}  // namespace silo::roaring_util

--- a/src/silo/roaring_util/roaring_container.h
+++ b/src/silo/roaring_util/roaring_container.h
@@ -1,0 +1,154 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/string.hpp>
+#include <roaring/roaring.hh>
+
+namespace silo::roaring_util {
+
+/// Owning RAII wrapper around a single roaring bitmap container (the 2^16-valued building block a
+/// `roaring::Roaring` is internally composed of). It bundles the raw `roaring::internal` pointer,
+/// its typecode and its cardinality, and encapsulates the container-level C API -- adding values,
+/// sizing, run-optimizing, cloning and (de)serializing -- so callers do not reach into
+/// `roaring::internal` directly.
+class RoaringContainer {
+   roaring::internal::container_t* container = nullptr;
+   uint32_t cardinality = 0;
+   uint8_t typecode = 0;
+
+  public:
+   /// Constructs an empty container that owns nothing (required for boost deserialization).
+   /// Container will be in invalid state, rawContainer() must be initialized before usage
+   /// Prefer `withCapacity`/`clonedFrom`/the owning constructor otherwise.
+   RoaringContainer() = default;
+
+   /// Takes ownership of an already-allocated container.
+   RoaringContainer(
+      roaring::internal::container_t* container,
+      uint32_t cardinality,
+      uint8_t typecode
+   )
+       : container(container),
+         cardinality(cardinality),
+         typecode(typecode) {}
+
+   /// Creates an empty container sized for `capacity` elements
+   static RoaringContainer withCapacity(int32_t capacity);
+
+   /// Deep-copies an externally owned container and computes its cardinality.
+   static RoaringContainer clonedFrom(
+      const roaring::internal::container_t* source,
+      uint8_t typecode
+   );
+
+   RoaringContainer(RoaringContainer&& other) noexcept
+       : container(other.container),
+         cardinality(other.cardinality),
+         typecode(other.typecode) {
+      other.container = nullptr;
+   }
+   RoaringContainer& operator=(RoaringContainer&& other) noexcept {
+      if (this != &other) {
+         std::swap(container, other.container);
+         std::swap(cardinality, other.cardinality);
+         std::swap(typecode, other.typecode);
+      }
+      return *this;
+   }
+   // Move-only to avoid double freeing of resources
+   RoaringContainer(const RoaringContainer&) = delete;
+   RoaringContainer& operator=(const RoaringContainer&) = delete;
+
+   ~RoaringContainer() {
+      if (container != nullptr) {
+         roaring::internal::container_free(container, typecode);
+      }
+   }
+
+   /// Adds a single 16-bit value, growing/reallocating the underlying container as needed. Like the
+   /// roaring container API this blindly bumps the cardinality, so the caller must only add values
+   /// that are not already present.
+   void add(uint16_t value);
+
+   [[nodiscard]] uint32_t getCardinality() const { return cardinality; }
+
+   [[nodiscard]] bool empty() const { return cardinality == 0; }
+
+   [[nodiscard]] size_t sizeInBytes() const;
+
+   /// Converts the container to a run container if that is more compact, then shrinks it to fit.
+   void runOptimizeAndShrink();
+
+   /// Raw handle for interop with the roaring `internal` API (e.g. BitmapBuilderByContainer,
+   /// roaringSubsetRanks). The container stays owned by this object.
+   [[nodiscard]] const roaring::internal::container_t* rawContainer() const { return container; }
+
+   [[nodiscard]] uint8_t getTypecode() const { return typecode; }
+
+   friend class boost::serialization::access;
+   template <class Archive>
+   void serialize(Archive& archive, [[maybe_unused]] const uint32_t version) {
+      if constexpr (Archive::is_saving::value) {
+         // clang-format off
+         archive & cardinality;
+         archive & typecode;
+         // clang-format on
+         const size_t size_in_bytes =
+            roaring::internal::container_size_in_bytes(container, typecode);
+         std::string buffer(size_in_bytes, '\0');
+         roaring::internal::container_write(container, typecode, buffer.data());
+         archive << buffer;
+      } else {
+         // Free any container this object already owns before overwriting its bookkeeping, so
+         // deserializing into a live container does not leak.
+         if (container != nullptr) {
+            roaring::internal::container_free(container, typecode);
+            container = nullptr;
+         }
+         // clang-format off
+         archive & cardinality;
+         archive & typecode;
+         // clang-format on
+         std::string buffer;
+         archive >> buffer;
+         // The container-level read API takes the cardinality as a signed int32_t.
+         const auto signed_cardinality = static_cast<int32_t>(cardinality);
+         if (typecode == BITSET_CONTAINER_TYPE) {
+            auto* bitset = roaring::internal::bitset_container_create();
+            if (bitset == nullptr) {
+               throw std::runtime_error("failed to allocate bitset container");
+            }
+            bitset_container_read(signed_cardinality, bitset, buffer.data());
+            container = bitset;
+         } else if (typecode == RUN_CONTAINER_TYPE) {
+            auto* run = roaring::internal::run_container_create();
+            if (run == nullptr) {
+               throw std::runtime_error("failed to allocate run container");
+            }
+            run_container_read(signed_cardinality, run, buffer.data());
+            container = run;
+         } else if (typecode == ARRAY_CONTAINER_TYPE) {
+            auto* array =
+               roaring::internal::array_container_create_given_capacity(signed_cardinality);
+            if (array == nullptr) {
+               throw std::runtime_error("failed to allocate array container");
+            }
+            array_container_read(signed_cardinality, array, buffer.data());
+            container = array;
+         } else {
+            throw std::runtime_error("unknown roaring container typecode");
+         }
+      }
+   }
+};
+
+// On 64-bit systems we expect a 16 byte struct, on 32-bit a 12 byte struct
+static_assert(sizeof(RoaringContainer) == (sizeof(void*) == 8 ? 16 : 12));
+
+}  // namespace silo::roaring_util

--- a/src/silo/roaring_util/roaring_container.test.cpp
+++ b/src/silo/roaring_util/roaring_container.test.cpp
@@ -1,0 +1,109 @@
+#include "silo/roaring_util/roaring_container.h"
+
+#include <sstream>
+
+#include <gtest/gtest.h>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <roaring/roaring.hh>
+
+#include "silo/roaring_util/bitmap_builder.h"
+
+using silo::roaring_util::BitmapBuilderByContainer;
+using silo::roaring_util::RoaringContainer;
+
+namespace {
+
+// Reconstructs the set of low-16-bit values held by a container by materializing it into a
+// single-container roaring bitmap.
+roaring::Roaring toRoaring(const RoaringContainer& container) {
+   BitmapBuilderByContainer builder;
+   builder.addContainer(0, container.rawContainer(), container.getTypecode());
+   return std::move(builder).getBitmap();
+}
+
+}  // namespace
+
+TEST(RoaringContainer, addAndCardinality) {
+   auto container = RoaringContainer::withCapacity(4);
+   EXPECT_TRUE(container.empty());
+
+   container.add(3);
+   container.add(7);
+   container.add(9);
+
+   EXPECT_EQ(container.getCardinality(), 3);
+   EXPECT_FALSE(container.empty());
+   EXPECT_EQ(toRoaring(container), (roaring::Roaring{3, 7, 9}));
+}
+
+TEST(RoaringContainer, growsFromArrayToBitset) {
+   // A small capacity starts as an array container and must transparently grow past the array
+   // container limit into a bitset as values are added.
+   auto container = RoaringContainer::withCapacity(1);
+   const uint16_t count = 20000;
+   for (uint16_t value = 0; value < count; ++value) {
+      container.add(value);
+   }
+   EXPECT_EQ(container.getCardinality(), count);
+   roaring::Roaring expected;
+   expected.addRange(0, count);
+   EXPECT_EQ(toRoaring(container), expected);
+}
+
+TEST(RoaringContainer, clonedFromIsIndependent) {
+   auto source = RoaringContainer::withCapacity(4);
+   source.add(1);
+   source.add(2);
+
+   auto clone = RoaringContainer::clonedFrom(source.rawContainer(), source.getTypecode());
+   EXPECT_EQ(clone.getCardinality(), 2);
+
+   // Mutating the clone must not affect the source.
+   clone.add(3);
+   EXPECT_EQ(clone.getCardinality(), 3);
+   EXPECT_EQ(source.getCardinality(), 2);
+}
+
+TEST(RoaringContainer, moveTransfersOwnership) {
+   auto container = RoaringContainer::withCapacity(4);
+   container.add(5);
+
+   auto moved = std::move(container);
+   EXPECT_EQ(moved.getCardinality(), 1);
+   EXPECT_EQ(toRoaring(moved), roaring::Roaring{5});
+}
+
+TEST(RoaringContainer, runOptimizeAndShrinkPreservesContents) {
+   auto container = RoaringContainer::withCapacity(4);
+   for (uint16_t value = 100; value < 200; ++value) {
+      container.add(value);
+   }
+   const auto before = toRoaring(container);
+   container.runOptimizeAndShrink();
+   EXPECT_EQ(container.getCardinality(), 100);
+   EXPECT_EQ(toRoaring(container), before);
+}
+
+TEST(RoaringContainer, serializationRoundTrip) {
+   auto container = RoaringContainer::withCapacity(4);
+   container.add(1);
+   container.add(42);
+   container.add(1000);
+   const auto expected = toRoaring(container);
+
+   std::stringstream stream;
+   {
+      boost::archive::binary_oarchive output_archive(stream);
+      output_archive << container;
+   }
+
+   RoaringContainer restored;
+   {
+      boost::archive::binary_iarchive input_archive(stream);
+      input_archive >> restored;
+   }
+
+   EXPECT_EQ(restored.getCardinality(), 3);
+   EXPECT_EQ(toRoaring(restored), expected);
+}

--- a/src/silo/storage/column/sequence_column.cpp
+++ b/src/silo/storage/column/sequence_column.cpp
@@ -253,15 +253,7 @@ void SequenceColumn<SymbolType>::fillIndexes() {
 template <typename SymbolType>
 void SequenceColumn<SymbolType>::optimizeBitmaps() {
    for (auto& [sequence_diff_key, sequence_diff] : vertical_sequence_index.vertical_bitmaps) {
-      uint8_t new_container_type;
-      auto new_container = roaring::internal::convert_run_optimize(
-         sequence_diff.container, sequence_diff.typecode, &new_container_type
-      );
-      if (new_container != sequence_diff.container) {
-         sequence_diff.container = new_container;
-         sequence_diff.typecode = new_container_type;
-      }
-      roaring::internal::container_shrink_to_fit(sequence_diff.container, sequence_diff.typecode);
+      sequence_diff.runOptimizeAndShrink();
    }
 }
 
@@ -279,9 +271,7 @@ template <typename SymbolType>
 size_t SequenceColumn<SymbolType>::computeVerticalBitmapsSize() const {
    size_t result = 0;
    for (const auto& [_pos, sequence_diff] : vertical_sequence_index.vertical_bitmaps) {
-      result += roaring::internal::container_size_in_bytes(
-         sequence_diff.container, sequence_diff.typecode
-      );
+      result += sequence_diff.sizeInBytes();
    }
    return result;
 }

--- a/src/silo/storage/column/vertical_sequence_index.cpp
+++ b/src/silo/storage/column/vertical_sequence_index.cpp
@@ -31,16 +31,7 @@ void VerticalSequenceIndex<SymbolType>::addSymbolsToPositions(
             getContainerOrCreateWithCapacity(key, lower_bits_vector.size());
 
          for (auto id_lower_bits : lower_bits_vector) {
-            uint8_t new_container_type;
-            auto new_container = roaring::internal::container_add(
-               sequence_diff.container, id_lower_bits, sequence_diff.typecode, &new_container_type
-            );
-            if (new_container != sequence_diff.container) {
-               roaring::internal::container_free(sequence_diff.container, sequence_diff.typecode);
-               sequence_diff.container = new_container;
-               sequence_diff.typecode = new_container_type;
-            }
-            sequence_diff.cardinality += 1;
+            sequence_diff.add(id_lower_bits);
          }
       }
    }
@@ -78,8 +69,8 @@ SymbolMap<SymbolType, uint32_t> VerticalSequenceIndex<SymbolType>::computeSymbol
    for (auto it = start; it != end; ++it) {
       const auto& [sequence_diff_key, sequence_diff] = *it;
       SILO_ASSERT(sequence_diff_key.symbol != current_local_reference_symbol);
-      symbol_counts[sequence_diff_key.symbol] += sequence_diff.cardinality;
-      symbol_counts[current_local_reference_symbol] -= sequence_diff.cardinality;
+      symbol_counts[sequence_diff_key.symbol] += sequence_diff.getCardinality();
+      symbol_counts[current_local_reference_symbol] -= sequence_diff.getCardinality();
    }
    return symbol_counts;
 }
@@ -150,14 +141,12 @@ std::optional<typename SymbolType::Symbol> VerticalSequenceIndex<SymbolType>::ad
    auto num_containers = static_cast<uint16_t>(roaring_array.size);
    for (uint16_t container_idx = 0; container_idx < num_containers; ++container_idx) {
       const uint8_t typecode = roaring_array.typecodes[container_idx];
-      auto* container =
-         roaring::internal::container_clone(roaring_array.containers[container_idx], typecode);
-      const uint32_t cardinality =
-         roaring::internal::container_get_cardinality(container, typecode);
       const uint16_t v_index = roaring_array.keys[container_idx];
 
       auto key = SequenceDiffKey{position_idx, v_index, current_local_reference_symbol};
-      vertical_bitmaps.insert({key, SequenceDiff(container, cardinality, typecode)});
+      vertical_bitmaps.insert(
+         {key, SequenceDiff::clonedFrom(roaring_array.containers[container_idx], typecode)}
+      );
    }
 
    std::vector<uint16_t> v_indices_to_remove;
@@ -181,18 +170,7 @@ VerticalSequenceIndex<SymbolType>::SequenceDiff& VerticalSequenceIndex<
    if (iter != vertical_bitmaps.end()) {
       return iter->second;
    }
-   roaring::internal::container_t* container;
-   uint8_t typecode;
-   // If roaring::internal::DEFAULT_MAX_SIZE specifies the maximum size for array containers
-   if (capacity <= roaring::internal::DEFAULT_MAX_SIZE) {
-      container = roaring::internal::array_container_create_given_capacity(capacity);
-      typecode = ARRAY_CONTAINER_TYPE;
-   } else {
-      container = roaring::internal::bitset_container_create();
-      typecode = BITSET_CONTAINER_TYPE;
-   }
-   SILO_ASSERT(container != nullptr);
-   return vertical_bitmaps.insert({key, SequenceDiff(container, 0, typecode)}).first->second;
+   return vertical_bitmaps.insert({key, SequenceDiff::withCapacity(capacity)}).first->second;
 }
 
 using silo::roaring_util::BitmapBuilderByContainer;
@@ -211,14 +189,14 @@ roaring::Roaring VerticalSequenceIndex<SymbolType>::getMatchingContainersAsBitma
 
    for (auto it = start; it != end; ++it) {
       const auto& [sequence_diff_key, sequence_diff] = *it;
-      SILO_ASSERT(sequence_diff.cardinality > 0);
+      SILO_ASSERT(!sequence_diff.empty());
 
       // Only consider when the symbol is in the requested set
       if (std::find(symbols.begin(), symbols.end(), sequence_diff_key.symbol) == symbols.end()) {
          continue;
       }
       builder.addContainer(
-         sequence_diff_key.v_index, sequence_diff.container, sequence_diff.typecode
+         sequence_diff_key.v_index, sequence_diff.rawContainer(), sequence_diff.getTypecode()
       );
    }
    return std::move(builder).getBitmap();
@@ -270,8 +248,8 @@ void VerticalSequenceIndex<SymbolType>::overwriteSymbolsInSequences(
       auto ranks_in_reconstructed_sequences = roaringSubsetRanks(
          roaring_containers_by_v_index.at(v_index),
          roaring_typecodes_by_v_index.at(v_index),
-         sequence_diff.container,
-         sequence_diff.typecode,
+         sequence_diff.rawContainer(),
+         sequence_diff.getTypecode(),
          /*base=*/0  // Base rank is 0, because we have a slice per container
       );
 

--- a/src/silo/storage/column/vertical_sequence_index.h
+++ b/src/silo/storage/column/vertical_sequence_index.h
@@ -5,9 +5,11 @@
 #include <vector>
 
 #include <boost/serialization/access.hpp>
+#include <boost/serialization/map.hpp>
 #include <roaring/roaring.hh>
 
 #include "silo/common/symbol_map.h"
+#include "silo/roaring_util/roaring_container.h"
 
 namespace silo::storage::column {
 
@@ -35,91 +37,8 @@ class VerticalSequenceIndex {
       }
    };
    static_assert(sizeof(SequenceDiffKey) == 8);
-   struct SequenceDiff {
-      roaring::internal::container_t* container;
-      uint32_t cardinality;
-      uint8_t typecode;
 
-      template <class Archive>
-      void serialize(Archive& archive, [[maybe_unused]] const uint32_t version) {
-         // clang-format off
-         archive & cardinality;
-         archive & typecode;
-         // clang-format on
-         if constexpr (Archive::is_saving::value) {
-            const size_t size_in_bytes =
-               roaring::internal::container_size_in_bytes(container, typecode);
-            std::string buffer(size_in_bytes, '\0');
-            roaring::internal::container_write(container, typecode, buffer.data());
-            archive << buffer;
-         } else {
-            std::string buffer;
-            archive >> buffer;
-            if (typecode == BITSET_CONTAINER_TYPE) {
-               auto* bitset = roaring::internal::bitset_container_create();
-               if (bitset == nullptr) {
-                  throw std::runtime_error("failed to allocate bitset container");
-               }
-               bitset_container_read(cardinality, bitset, buffer.data());
-               container = bitset;
-            } else if (typecode == RUN_CONTAINER_TYPE) {
-               auto* run = roaring::internal::run_container_create();
-               if (run == nullptr) {
-                  throw std::runtime_error("failed to allocate run container");
-               }
-               run_container_read(cardinality, run, buffer.data());
-               container = run;
-            } else {
-               auto* array = roaring::internal::array_container_create_given_capacity(cardinality);
-               if (array == nullptr) {
-                  throw std::runtime_error("failed to allocate array container");
-               }
-               array_container_read(cardinality, array, buffer.data());
-               container = array;
-            }
-         }
-      }
-
-      SequenceDiff()
-          : container(nullptr),
-            cardinality(0),
-            typecode(0) {}
-
-      SequenceDiff(
-         roaring::internal::container_t* container,
-         uint32_t cardinality,
-         uint8_t typecode
-      )
-          : container(container),
-            cardinality(cardinality),
-            typecode(typecode) {}
-
-      SequenceDiff(SequenceDiff&& other) noexcept
-          : container(other.container),
-            cardinality(other.cardinality),
-            typecode(other.typecode) {
-         other.container = nullptr;
-      }
-      SequenceDiff& operator=(SequenceDiff&& other) noexcept {
-         if (this != &other) {
-            std::swap(container, other.container);
-            std::swap(cardinality, other.cardinality);
-            std::swap(typecode, other.typecode);
-         }
-         return *this;
-      }
-
-      SequenceDiff(const SequenceDiff&) = delete;
-      SequenceDiff& operator=(const SequenceDiff&) = delete;
-
-      ~SequenceDiff() {
-         if (container != nullptr) {
-            roaring::internal::container_free(container, typecode);
-         }
-      }
-   };
-   // On 64-bit systems we expect a 16 byte struct, on 32-bit a 12 byte struct
-   static_assert(sizeof(SequenceDiff) == (sizeof(void*) == 8 ? 16 : 12));
+   using SequenceDiff = roaring_util::RoaringContainer;
 
    std::map<SequenceDiffKey, SequenceDiff> vertical_bitmaps;
 


### PR DESCRIPTION
small refactoring that introduces a reusable abstraction for representing a single roaring container (part of a roaring bitmap. can represent `2^16` values)