### PR TITLE
fix(query_engine): do not invalidly reorder filter nodes

### DIFF
--- a/src/silo/query_engine/operators/map_node.test.cpp
+++ b/src/silo/query_engine/operators/map_node.test.cpp
@@ -196,6 +196,23 @@ const QueryTestScenario DECOMPRESS_WITH_USER_MAP_SCENARIO = {
    )
 };
 
+// A nucleotide-symbol filter stacked on top of the implicit decompression MapNode for a
+// sequence column, while ALSO projecting the (decompressed) aligned and unaligned sequences:
+// Filter(nucleotideEquals(segment1)) -> Map(segment1/unaligned_segment1 := zstd_decompress(...)).
+// Projecting the sequences keeps the decompression assignments alive through column narrowing,
+// so the decompression map genuinely materializes them. The assignment is pushdown-transparent,
+// so FilterPushdownPass still pushes the sequence predicate below the map into the scan, where
+// SymbolEquals resolves `segment1` by name to the physical NUCLEOTIDE_SEQUENCE column.
+const QueryTestScenario FILTER_NUCLEOTIDE_EQUALS_OVER_DECOMPRESS_MAP_SCENARIO = {
+   .name = "FILTER_NUCLEOTIDE_EQUALS_OVER_DECOMPRESS_MAP",
+   .query =
+      "default.filter(nucleotideEquals(position := 1, symbol := 'A', sequenceName := 'segment1'))"
+      ".project({primaryKey, segment1, unaligned_segment1})",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"segment1", "ACGT"}, {"unaligned_segment1", "ACGT"}}}
+   )
+};
+
 // Regression guard: selecting the (zstd-compressed) sequence column together with a
 // `limit` must still return the correct, order-stable result.
 const QueryTestScenario DECOMPRESS_SEQUENCE_WITH_LIMIT_SCENARIO = {
@@ -355,6 +372,7 @@ QUERY_TEST(
       MAP_DUPLICATE_OUTPUT_NAME_SCENARIO,
       DECOMPRESS_SEQUENCE_SCENARIO,
       DECOMPRESS_WITH_USER_MAP_SCENARIO,
+      FILTER_NUCLEOTIDE_EQUALS_OVER_DECOMPRESS_MAP_SCENARIO,
       DECOMPRESS_SEQUENCE_WITH_LIMIT_SCENARIO,
       MAP_WITH_LIMIT_TRIGGERS_PULLUP_SCENARIO,
       FILTER_ON_TOP_OF_MAP_SCENARIO,

--- a/src/silo/query_engine/operators/map_node.test.cpp
+++ b/src/silo/query_engine/operators/map_node.test.cpp
@@ -269,12 +269,62 @@ const QueryTestScenario FILTER_MAP_DECOMPRESS_LIMIT_SCENARIO = {
       nlohmann::json({{{"primaryKey", "id_0"}, {"unaligned_segment1", "ACGT"}, {"tag", 7}}})
 };
 
-// A filter that references a column the map produces (`a`) is not yet supported
+// A filter that references a column the map produces (`a`) is not yet executable. The optimizer
+// must NOT push such a filter below the map; instead the FilterNode is left above the
+// map and surfaces the expected runtime error.
 const QueryTestScenario FILTER_ON_MAPPED_COLUMN_SCENARIO = {
    .name = "FILTER_ON_MAPPED_COLUMN",
    .query = "default.map({a := 3}).filter(a = 3).project({primaryKey})",
    .expected_query_result = {},
-   .expected_error_message = "The database does not contain the column 'a'"
+   .expected_error_message =
+      "FilterNode must be eliminated during pushdown before query plan generation"
+};
+
+// #1371 verbatim: filtering on an isoWeek-derived column must not be reordered below the map. The
+// FilterNode stays above the map and the query fails with the expected runtime error rather than
+// producing an invalid plan.
+const QueryTestScenario FILTER_ON_ISO_WEEK_MAPPED_COLUMN_SCENARIO = {
+   .name = "FILTER_ON_ISO_WEEK_MAPPED_COLUMN",
+   .query = "default.map({week := date.isoWeek()}).filter(week = 1).project({primaryKey})",
+   .expected_query_result = {},
+   .expected_error_message =
+      "FilterNode must be eliminated during pushdown before query plan generation"
+};
+
+// A filter on a column the map REPLACES in place with a value-changing expression (`str_value :=
+// str_value.at(1)`) must also stay above the map. Pushing it into the scan would filter on the
+// original, unmodified `str_value` - a silent miscompile - so it must error instead.
+const QueryTestScenario FILTER_ON_REPLACED_MAPPED_COLUMN_SCENARIO = {
+   .name = "FILTER_ON_REPLACED_MAPPED_COLUMN",
+   .query =
+      "default.map({str_value := str_value.at(1)}).filter(str_value = 's').project({primaryKey})",
+   .expected_query_result = {},
+   .expected_error_message =
+      "FilterNode must be eliminated during pushdown before query plan generation"
+};
+
+// A conjunction mixing a pushable sequence predicate (hasMutation) with a non-pushable derived
+// column (`week`). Because the whole filter references `week`, it must stay above the map - and
+// the pushable `segment1` reference must NOT trick column narrowing into pruning the producing
+// map. The query errors rather than producing a wrong answer or crashing.
+const QueryTestScenario FILTER_MIXED_PUSHABLE_AND_DERIVED_SCENARIO = {
+   .name = "FILTER_MIXED_PUSHABLE_AND_DERIVED",
+   .query =
+      "default.map({week := date.isoWeek()})"
+      ".filter(hasMutation(sequenceName := 'segment1', position := 1) && week = 1)"
+      ".project({primaryKey})",
+   .expected_query_result = {},
+   .expected_error_message =
+      "FilterNode must be eliminated during pushdown before query plan generation"
+};
+
+// A filter on a passed-through column (`int_value`) stacked above a map that produces an
+// UNRELATED derived column (`week`). The filter is pushed to the scan and the unused `week` map
+// is pruned by column narrowing; the query succeeds. Guards against over-eager map retention.
+const QueryTestScenario FILTER_PUSHED_PAST_UNRELATED_DERIVED_MAP_SCENARIO = {
+   .name = "FILTER_PUSHED_PAST_UNRELATED_DERIVED_MAP",
+   .query = "default.map({week := date.isoWeek()}).filter(int_value = 1).project({primaryKey})",
+   .expected_query_result = nlohmann::json({{{"primaryKey", "id_0"}}})
 };
 
 // `isoWeek` maps a date column to its ISO 8601 week number as an integer.
@@ -313,6 +363,10 @@ QUERY_TEST(
       FILTER_OVER_DECOMPRESS_MAP_SCENARIO,
       FILTER_MAP_DECOMPRESS_LIMIT_SCENARIO,
       FILTER_ON_MAPPED_COLUMN_SCENARIO,
+      FILTER_ON_ISO_WEEK_MAPPED_COLUMN_SCENARIO,
+      FILTER_ON_REPLACED_MAPPED_COLUMN_SCENARIO,
+      FILTER_MIXED_PUSHABLE_AND_DERIVED_SCENARIO,
+      FILTER_PUSHED_PAST_UNRELATED_DERIVED_MAP_SCENARIO,
       MAP_ISO_WEEK_SCENARIO
    )
 );

--- a/src/silo/query_engine/operators/map_node.test.cpp
+++ b/src/silo/query_engine/operators/map_node.test.cpp
@@ -208,9 +208,9 @@ const QueryTestScenario FILTER_NUCLEOTIDE_EQUALS_OVER_DECOMPRESS_MAP_SCENARIO = 
    .query =
       "default.filter(nucleotideEquals(position := 1, symbol := 'A', sequenceName := 'segment1'))"
       ".project({primaryKey, segment1, unaligned_segment1})",
-   .expected_query_result = nlohmann::json(
-      {{{"primaryKey", "id_0"}, {"segment1", "ACGT"}, {"unaligned_segment1", "ACGT"}}}
-   )
+   .expected_query_result =
+      nlohmann::json({{{"primaryKey", "id_0"}, {"segment1", "ACGT"}, {"unaligned_segment1", "ACGT"}}
+      })
 };
 
 // Regression guard: selecting the (zstd-compressed) sequence column together with a

--- a/src/silo/query_engine/optimizer/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "silo/query_engine/operators/aggregate_node.h"
+#include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/join_node.h"
 #include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/order_by_node.h"
@@ -16,6 +17,21 @@ namespace silo::query_engine::optimizer {
 
 ColumnNarrowingPass ColumnNarrowingPass::makePass(const operators::QueryNodePtr& node) {
    return ColumnNarrowingPass{node->getOutputSchema()};
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::FilterNode& node) {
+   // A filter needs every column its predicate references from its child, in addition to the
+   // columns the parent requires. FilterPushdownPass runs before this pass, so the only
+   // FilterNodes still present are ones that could not be pushed below a producing map (e.g.
+   // filter on an isoWeek/at column).
+   for (const auto& column : node.filter->freeIUs()) {
+      if (std::ranges::find(required, column) == required.end()) {
+         required.push_back(column);
+      }
+   }
+   propagateToNode(node.child);
+   return nullptr;
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static,misc-no-recursion)

--- a/src/silo/query_engine/optimizer/column_narrowing_pass.cpp
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.cpp
@@ -22,9 +22,8 @@ ColumnNarrowingPass ColumnNarrowingPass::makePass(const operators::QueryNodePtr&
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::FilterNode& node) {
    // A filter needs every column its predicate references from its child, in addition to the
-   // columns the parent requires. FilterPushdownPass runs before this pass, so the only
-   // FilterNodes still present are ones that could not be pushed below a producing map (e.g.
-   // filter on an isoWeek/at column).
+   // columns the parent requires. Keeping them required prevents a node below the filter that
+   // produces such a column (e.g. a map) from being pruned away while the filter still needs it.
    for (const auto& column : node.filter->freeIUs()) {
       if (std::ranges::find(required, column) == required.end()) {
          required.push_back(column);

--- a/src/silo/query_engine/optimizer/column_narrowing_pass.h
+++ b/src/silo/query_engine/optimizer/column_narrowing_pass.h
@@ -7,6 +7,7 @@
 #include "silo/schema/database_schema.h"
 
 namespace silo::query_engine::operators {
+class FilterNode;
 class TableScanNode;
 class AggregateNode;
 class ProjectNode;
@@ -37,6 +38,7 @@ class ColumnNarrowingPass : public PipelinePassBase<ColumnNarrowingPass> {
 
    using PipelinePassBase<ColumnNarrowingPass>::operator();
 
+   operators::QueryNodePtr operator()(operators::FilterNode& node);
    operators::QueryNodePtr operator()(operators::TableScanNode& node);
    operators::QueryNodePtr operator()(operators::AggregateNode& node);
    operators::QueryNodePtr operator()(operators::ProjectNode& node);

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
@@ -28,20 +28,12 @@ namespace silo::query_engine::optimizer {
 
 namespace {
 
-/// An assignment `out := expr` is "pushdown-transparent" when a filter that references `out` can
-/// be evaluated by the table scan directly on the physical same-named column. That holds when
-/// `expr` is merely a physical realization (zstd decompression) or identity pass-through of the
-/// same-named column: sequence predicates (e.g. hasMutation) and string filters rewrite and
-/// compile by column NAME against the physical column, so pushing them below such a map is sound.
-///
-/// Genuinely derived expressions (isoWeek, at, ...) are NOT transparent: the produced value does
-/// not exist physically below the map, so a filter referencing it must stay above the map (where
-/// it surfaces the expected runtime error for cases like map().filter(); see #1371). Recognising
-/// transparency structurally means any unknown/new expression kind defaults to non-transparent,
-/// i.e. correct-but-conservative rather than a silent miscompile.
-bool isPushdownTransparent(const operators::MapNode::Assignment& assignment) {
+bool isFieldRef(const operators::MapNode::Assignment& assignment) {
    const scalar_expressions::ScalarExpression* expression = assignment.expression.get();
-   // See through nested physical realizations down to the underlying column reference.
+   // Sequence columns cannot be read into an arrow plan directly: they are stored zstd-compressed
+   // and decompressed on demand, so as a hack we treat a zstd-decompression as an identity here.
+   // A filter referencing such a column is then pushed down and compiles against the physical
+   // (compressed) column by name. This may produce misleading error messages in edge cases.
    while (const auto* decompress =
              scalar_expressions::dynCast<scalar_expressions::ZstdDecompressScalar>(expression)) {
       expression = decompress->input.get();
@@ -63,18 +55,20 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::FilterNode& no
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr FilterPushdownPass::operator()(operators::MapNode& node) {
    // The columns this map produces that a filter may NOT be pushed past, keyed by name. A
-   // produced column blocks pushdown unless its assignment is pushdown-transparent (a physical
-   // realization or identity of the same-named column, which the scan can still evaluate). A
-   // filter referencing a blocking column reads a value that does not exist physically below the
-   // map, so pushing it down would turn a valid plan into an invalid one (see #1371).
+   // produced column blocks pushdown unless its assignment just reproduces the same-named column,
+   // which the scan can still evaluate by name. A filter referencing a blocking
+   // column reads a value that does not exist physically below the map, so pushing it down would
+   // turn a valid plan into an invalid one (see #1371).
    //
    // Matching is by NAME: the produced column and a referencing filter carry identical
    // {name, type} identifiers (e.g. a decompression map's {segment1, STRING} output and a
-   // hasMutation predicate resolved against it), so only the assignment's expression kind can
-   // distinguish a transparent realization from a genuinely derived value.
+   // hasMutation predicate resolved against it), so only the assignment's expression can
+   // distinguish an unchanged column from a genuinely derived value.
+   //
+   // TODO(#1433): instead of blocking, fold the producing map's expression into the filter
    std::unordered_set<std::string> blocking_columns;
    for (const auto& assignment : node.assignments) {
-      if (!isPushdownTransparent(assignment)) {
+      if (!isFieldRef(assignment)) {
          blocking_columns.insert(assignment.output_column.name);
       }
    }

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.cpp
@@ -1,5 +1,8 @@
 #include "silo/query_engine/optimizer/filter_pushdown_pass.h"
 
+#include <algorithm>
+#include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "silo/common/aa_symbols.h"
@@ -8,6 +11,7 @@
 #include "silo/query_engine/operators/filter_node.h"
 #include "silo/query_engine/operators/insertions_node.h"
 #include "silo/query_engine/operators/join_node.h"
+#include "silo/query_engine/operators/map_node.h"
 #include "silo/query_engine/operators/most_recent_common_ancestor_node.h"
 #include "silo/query_engine/operators/mutations_node.h"
 #include "silo/query_engine/operators/phylo_subtree_node.h"
@@ -15,10 +19,38 @@
 #include "silo/query_engine/operators/table_scan_node.h"
 #include "silo/query_engine/operators/union_all_node.h"
 #include "silo/query_engine/scalar_expressions/and.h"
+#include "silo/query_engine/scalar_expressions/field_ref.h"
+#include "silo/query_engine/scalar_expressions/zstd_decompress_scalar.h"
 
 using silo::query_engine::scalar_expressions::And;
 
 namespace silo::query_engine::optimizer {
+
+namespace {
+
+/// An assignment `out := expr` is "pushdown-transparent" when a filter that references `out` can
+/// be evaluated by the table scan directly on the physical same-named column. That holds when
+/// `expr` is merely a physical realization (zstd decompression) or identity pass-through of the
+/// same-named column: sequence predicates (e.g. hasMutation) and string filters rewrite and
+/// compile by column NAME against the physical column, so pushing them below such a map is sound.
+///
+/// Genuinely derived expressions (isoWeek, at, ...) are NOT transparent: the produced value does
+/// not exist physically below the map, so a filter referencing it must stay above the map (where
+/// it surfaces the expected runtime error for cases like map().filter(); see #1371). Recognising
+/// transparency structurally means any unknown/new expression kind defaults to non-transparent,
+/// i.e. correct-but-conservative rather than a silent miscompile.
+bool isPushdownTransparent(const operators::MapNode::Assignment& assignment) {
+   const scalar_expressions::ScalarExpression* expression = assignment.expression.get();
+   // See through nested physical realizations down to the underlying column reference.
+   while (const auto* decompress =
+             scalar_expressions::dynCast<scalar_expressions::ZstdDecompressScalar>(expression)) {
+      expression = decompress->input.get();
+   }
+   const auto* field_ref = scalar_expressions::dynCast<scalar_expressions::FieldRef>(expression);
+   return field_ref != nullptr && field_ref->column.name == assignment.output_column.name;
+}
+
+}  // namespace
 
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr FilterPushdownPass::operator()(operators::FilterNode& node) {
@@ -26,6 +58,59 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::FilterNode& no
    auto child = std::move(node.child);
    propagateToNode(child);
    return child;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr FilterPushdownPass::operator()(operators::MapNode& node) {
+   // The columns this map produces that a filter may NOT be pushed past, keyed by name. A
+   // produced column blocks pushdown unless its assignment is pushdown-transparent (a physical
+   // realization or identity of the same-named column, which the scan can still evaluate). A
+   // filter referencing a blocking column reads a value that does not exist physically below the
+   // map, so pushing it down would turn a valid plan into an invalid one (see #1371).
+   //
+   // Matching is by NAME: the produced column and a referencing filter carry identical
+   // {name, type} identifiers (e.g. a decompression map's {segment1, STRING} output and a
+   // hasMutation predicate resolved against it), so only the assignment's expression kind can
+   // distinguish a transparent realization from a genuinely derived value.
+   std::unordered_set<std::string> blocking_columns;
+   for (const auto& assignment : node.assignments) {
+      if (!isPushdownTransparent(assignment)) {
+         blocking_columns.insert(assignment.output_column.name);
+      }
+   }
+
+   // Partition the accumulated filters: those referencing a blocking column must stay above
+   // this map; the rest can continue to be pushed further down into the child.
+   std::vector<std::unique_ptr<scalar_expressions::ScalarExpression>> filters_staying_above;
+   std::vector<std::unique_ptr<scalar_expressions::ScalarExpression>> filters_to_push_down;
+   for (auto& filter : current_filters) {
+      const auto references_blocking_column =
+         std::ranges::any_of(filter->freeIUs(), [&](const auto& column) {
+            return blocking_columns.contains(column.name);
+         });
+      if (references_blocking_column) {
+         filters_staying_above.push_back(std::move(filter));
+      } else {
+         filters_to_push_down.push_back(std::move(filter));
+      }
+   }
+
+   current_filters = std::move(filters_to_push_down);
+   propagateToNode(node.child);
+
+   if (filters_staying_above.empty()) {
+      // Every filter could be pushed below the map; keep the map in place.
+      return nullptr;
+   }
+
+   // Rebuild the map (its child may have been rewritten by the pushdown above) and place the
+   // remaining filters back on top of it as a single FilterNode. It cannot be pushed further.
+   auto rebuilt_map =
+      std::make_unique<operators::MapNode>(std::move(node.child), std::move(node.assignments));
+   auto remaining_filter = std::make_unique<And>(std::move(filters_staying_above));
+   return std::make_unique<operators::FilterNode>(
+      std::move(rebuilt_map), std::move(remaining_filter)
+   );
 }
 
 operators::QueryNodePtr FilterPushdownPass::operator()(operators::TableScanNode& node) {

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.h
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.h
@@ -6,6 +6,7 @@
 
 namespace silo::query_engine::operators {
 class FilterNode;
+class MapNode;
 class TableScanNode;
 template <typename SymbolType>
 class MutationsNode;
@@ -29,6 +30,7 @@ class FilterPushdownPass : public PipelinePassBase<FilterPushdownPass> {
    using PipelinePassBase<FilterPushdownPass>::operator();
 
    operators::QueryNodePtr operator()(operators::FilterNode& node);
+   operators::QueryNodePtr operator()(operators::MapNode& node);
 
    operators::QueryNodePtr operator()(operators::TableScanNode& node);
    operators::QueryNodePtr operator()(operators::MutationsNode<Nucleotide>& node);

--- a/src/silo/query_engine/optimizer/filter_pushdown_pass.test.cpp
+++ b/src/silo/query_engine/optimizer/filter_pushdown_pass.test.cpp
@@ -156,6 +156,158 @@ TEST(FilterPushdownPass, pushesFilterThroughDecompressMapIntoTableScan) {
    EXPECT_EQ(table_scan->filter->toString(), "And(true & true)");
 }
 
+// --- FilterNode(MapNode(TableScanNode)) referencing a map-produced column ---
+//
+// Regression test for #1371: a filter that references a column produced by the map (here `x`)
+// must NOT be pushed below the map, since `x` does not exist beneath it. The optimizer must not
+// turn this valid plan into an invalid one; the FilterNode is kept above the MapNode instead.
+TEST(FilterPushdownPass, doesNotPushFilterReferencingMapProducedColumnBelowMap) {
+   using silo::schema::ColumnIdentifier;
+   using silo::schema::ColumnType;
+
+   auto table = makeTable();
+   auto scan = std::make_unique<operators::TableScanNode>(
+      table, makeDummyFilter(), std::vector<ColumnIdentifier>{}
+   );
+
+   const ColumnIdentifier produced_column{.name = "x", .type = ColumnType::INT64};
+   std::vector<operators::MapNode::Assignment> assignments;
+   assignments.push_back(
+      {.output_column = produced_column,
+       .expression = std::make_unique<scalar_expressions::Int64Literal>(3)}
+   );
+   auto map_node = std::make_unique<operators::MapNode>(std::move(scan), std::move(assignments));
+
+   // filter references the map-produced column `x`
+   auto filter_node = std::make_unique<operators::FilterNode>(
+      std::move(map_node), std::make_unique<scalar_expressions::FieldRef>(produced_column)
+   );
+
+   auto result = FilterPushdownPass::run(std::move(filter_node));
+
+   // The FilterNode stays on top of the MapNode; nothing was pushed into the TableScan.
+   ASSERT_EQ(result->kind(), operators::NodeKind::FILTER);
+   auto* filter = dynamic_cast<operators::FilterNode*>(result.get());
+   EXPECT_EQ(filter->filter->toString(), "And(x)");
+   ASSERT_EQ(filter->child->kind(), operators::NodeKind::MAP);
+   auto* map = dynamic_cast<operators::MapNode*>(filter->child.get());
+   ASSERT_EQ(map->child->kind(), operators::NodeKind::TABLE_SCAN);
+   auto* table_scan = dynamic_cast<operators::TableScanNode*>(map->child.get());
+   // Only the scan's own filter remains; the outer filter was not pushed in.
+   EXPECT_EQ(table_scan->filter->toString(), "And(true)");
+}
+
+// A filter that references only columns the map passes through (not any map-produced column)
+// is still pushed below the map into the TableScan.
+TEST(FilterPushdownPass, pushesFilterReferencingPassThroughColumnBelowMap) {
+   using silo::schema::ColumnIdentifier;
+   using silo::schema::ColumnType;
+
+   auto table = makeTable();
+   auto scan = std::make_unique<operators::TableScanNode>(
+      table, makeDummyFilter(), std::vector<ColumnIdentifier>{}
+   );
+
+   const ColumnIdentifier produced_column{.name = "x", .type = ColumnType::INT64};
+   std::vector<operators::MapNode::Assignment> assignments;
+   assignments.push_back(
+      {.output_column = produced_column,
+       .expression = std::make_unique<scalar_expressions::Int64Literal>(3)}
+   );
+   auto map_node = std::make_unique<operators::MapNode>(std::move(scan), std::move(assignments));
+
+   // filter references `id`, a pass-through column the map does not produce
+   const ColumnIdentifier pass_through_column{.name = "id", .type = ColumnType::STRING};
+   auto filter_node = std::make_unique<operators::FilterNode>(
+      std::move(map_node), std::make_unique<scalar_expressions::FieldRef>(pass_through_column)
+   );
+
+   auto result = FilterPushdownPass::run(std::move(filter_node));
+
+   // The MapNode is retained; the filter was pushed below it into the TableScan.
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* map = dynamic_cast<operators::MapNode*>(result.get());
+   ASSERT_EQ(map->child->kind(), operators::NodeKind::TABLE_SCAN);
+   auto* table_scan = dynamic_cast<operators::TableScanNode*>(map->child.get());
+   EXPECT_EQ(table_scan->filter->toString(), "And(id & true)");
+}
+
+// A filter referencing a column produced by a pushdown-transparent assignment (a zstd
+// decompression of the same-named column) IS pushed below the map into the TableScan, where the
+// filter compiles against the physical column. This is the shape the compiler inserts for
+// `segment1 := zstd_decompress(segment1)`; the co-occurrence-with-filter query relies on it.
+TEST(FilterPushdownPass, pushesFilterThroughTransparentDecompressMapIntoTableScan) {
+   using silo::schema::ColumnIdentifier;
+   using silo::schema::ColumnType;
+
+   const ColumnIdentifier compressed_column{.name = "seq", .type = ColumnType::NUCLEOTIDE_SEQUENCE};
+   auto scan = std::make_unique<operators::TableScanNode>(
+      makeTable(), makeDummyFilter(), std::vector<ColumnIdentifier>{compressed_column}
+   );
+
+   std::vector<operators::MapNode::Assignment> assignments;
+   assignments.push_back(
+      {.output_column = {.name = "seq", .type = ColumnType::STRING},
+       .expression = std::make_unique<scalar_expressions::ZstdDecompressScalar>(
+          std::make_unique<scalar_expressions::FieldRef>(compressed_column), "A"
+       )}
+   );
+   auto map_node = std::make_unique<operators::MapNode>(std::move(scan), std::move(assignments));
+
+   // filter references the decompressed column `seq` {seq, STRING} - same identifier the map
+   // produces, but the assignment is a transparent realization so the filter can be pushed down.
+   const ColumnIdentifier decompressed_column{.name = "seq", .type = ColumnType::STRING};
+   auto filter_node = std::make_unique<operators::FilterNode>(
+      std::move(map_node), std::make_unique<scalar_expressions::FieldRef>(decompressed_column)
+   );
+
+   auto result = FilterPushdownPass::run(std::move(filter_node));
+
+   ASSERT_EQ(result->kind(), operators::NodeKind::MAP);
+   auto* map = dynamic_cast<operators::MapNode*>(result.get());
+   ASSERT_EQ(map->child->kind(), operators::NodeKind::TABLE_SCAN);
+   auto* table_scan = dynamic_cast<operators::TableScanNode*>(map->child.get());
+   EXPECT_EQ(table_scan->filter->toString(), "And(seq & true)");
+}
+
+// A filter referencing a column that a map REPLACES in place with a value-changing (non
+// transparent) expression must NOT be pushed below the map. Pushing it into the scan would
+// filter on the original physical value instead of the map's computed one - a silent miscompile.
+// This mirrors e.g. `map({primaryKey := primaryKey.at(1)}).filter(primaryKey = 'i')`; here a
+// literal assignment stands in for any non-transparent expression.
+TEST(FilterPushdownPass, doesNotPushFilterThroughValueChangingReplaceInPlaceMap) {
+   using silo::schema::ColumnIdentifier;
+   using silo::schema::ColumnType;
+
+   auto scan = std::make_unique<operators::TableScanNode>(
+      makeTable(), makeDummyFilter(), std::vector<ColumnIdentifier>{}
+   );
+
+   // replace the existing pass-through column `id` with a computed value
+   const ColumnIdentifier replaced_column{.name = "id", .type = ColumnType::INT64};
+   std::vector<operators::MapNode::Assignment> assignments;
+   assignments.push_back(
+      {.output_column = replaced_column,
+       .expression = std::make_unique<scalar_expressions::Int64Literal>(3)}
+   );
+   auto map_node = std::make_unique<operators::MapNode>(std::move(scan), std::move(assignments));
+
+   auto filter_node = std::make_unique<operators::FilterNode>(
+      std::move(map_node), std::make_unique<scalar_expressions::FieldRef>(replaced_column)
+   );
+
+   auto result = FilterPushdownPass::run(std::move(filter_node));
+
+   // The FilterNode is retained above the map; nothing was pushed into the TableScan.
+   ASSERT_EQ(result->kind(), operators::NodeKind::FILTER);
+   auto* filter = dynamic_cast<operators::FilterNode*>(result.get());
+   ASSERT_EQ(filter->child->kind(), operators::NodeKind::MAP);
+   auto* map = dynamic_cast<operators::MapNode*>(filter->child.get());
+   ASSERT_EQ(map->child->kind(), operators::NodeKind::TABLE_SCAN);
+   auto* table_scan = dynamic_cast<operators::TableScanNode*>(map->child.get());
+   EXPECT_EQ(table_scan->filter->toString(), "And(true)");
+}
+
 // --- FilterNode(ProjectNode(MapNode(FilterNode(TableScanNode)))) ---
 TEST(FilterPushdownPass, pushesFilterThroughProjectAndMapIntoTableScan) {
    auto inner_filter = makeFilteredScan(false);

--- a/src/silo/query_engine/planner.cpp
+++ b/src/silo/query_engine/planner.cpp
@@ -51,10 +51,16 @@ QueryPlan Planner::planQuery(
       }
    };
    log_plan("initial");
-   node = ColumnNarrowingPass::run(std::move(node));
-   log_plan("after ColumnNarrowingPass");
+   // FilterPushdownPass must run before ColumnNarrowingPass: it is the single owner of the
+   // filter/map interaction. Running it first means a filter that cannot be pushed below a map
+   // is left as a FilterNode above that map (with the producing assignments intact), while a
+   // pushable filter is moved into the scan. ColumnNarrowingPass then prunes safely: it only
+   // keeps a producing map alive when a non-eliminable FilterNode still references its output,
+   // and still drops maps whose filters were pushed to the scan (preserving #1343).
    node = FilterPushdownPass::run(std::move(node));
    log_plan("after FilterPushdownPass");
+   node = ColumnNarrowingPass::run(std::move(node));
+   log_plan("after ColumnNarrowingPass");
    node = MapPullupPass::run(std::move(node));
    log_plan("after MapPullupPass");
    node = SelectKRewritePass::run(std::move(node));


### PR DESCRIPTION

resolves #1371

### Summary

The optimizer could reorder `map({x := ...}).filter(x = ...)` into an invalid plan that filters on `x` before it exists (runtime error), and for a value-changing replace-in-place map could silently filter on the original column value (wrong result).

- **`FilterPushdownPass` now keeps a filter above a `map`** when it references a column the map produces, unless the assignment is pushdown-transparent (a zstd-decompress / identity of the same-named column, which the scan still evaluates by name). Filters on genuinely derived columns now fail with a clear error instead of miscompiling.
  - It doesn't decompose filters yet: `.map(week = date.isoWeek).filter(hasMutation && week == ...)` is problematic. The mutation filter needs to be pushed down on the table scan to operate on the bitmaps while the isWeek filter must stay above the column producing map.
- **`FilterPushdownPass` runs before `ColumnNarrowingPass`**, so narrowing no longer deletes a producing map that a stuck filter still needs; `ColumnNarrowingPass` marks a surviving filter's referenced columns as required.

Pushing sequence filters (e.g. `hasMutation`) through the implicit decompression map into the scan (#1343) is preserved.

## PR Checklist
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [x] The implemented feature is covered by an appropriate test.
