### PR TITLE
feat(silo): materialize per-lineage relation tables during preprocessing

### DIFF
--- a/documentation/input_format.md
+++ b/documentation/input_format.md
@@ -55,6 +55,12 @@ schema:
 - `type`: One of `string`, `int`, `float`, `date`, `boolean`
 - `generateIndex`: Set to `true` to create a bitmap index for fast equality lookups. This is only valid for `string` columns
 - `generateLineageIndex`: Path to lineage definition file for hierarchical queries. This is only possible if `generateIndex` is also set
+- `lineageIndexType`: How the lineage definition is made available for querying. One of:
+  - `columnMetadata` (default) — the lineage tree is attached to the column itself, which is what the `lineage(...)` filter uses
+  - `table` — preprocessing materializes a separate relation table holding the lineage edges, and the column carries no lineage tree (so `lineage(...)` is *not* available on it)
+  - `both` — both of the above
+
+  Only valid together with `generateLineageIndex`; setting it on a column without a lineage definition is a config error. See [lineage_definitions.md](lineage_definitions.md) for the relation table's schema.
 - `treatUnknownLineagesAsNull`: Treats unknown lineage values as null when adding them to the lineage index
 - `isPhyloTreeField`: Mark this column as a phyloTreeField, which enables the phylogenetic queries. See [phylogenetic_queries.md](phylogenetic_queries.md)
 

--- a/documentation/lineage_definitions.md
+++ b/documentation/lineage_definitions.md
@@ -92,3 +92,47 @@ E:
 - Alias Flexibility: Use aliases to standardize alternative names for lineages.
 - Root Lineages: Specify root lineages with `parents: null`, `parents: []`, or by omitting the key `parents`
 - Minimal assumptions: RhyDB verifies that the lineage labels are unique and the edges contain no cycles. No further assumptions about the lineage system are made
+
+## Lineage Relation Tables
+
+A lineage definition is attached to a metadata column via `generateLineageIndex` in the database
+config. The `lineageIndexType` option of that column controls how it is made available:
+
+- `columnMetadata` (default): the lineage tree lives in the column's metadata and is used by the
+  `lineage(...)` filter, documented in [query_documentation.md](query_documentation.md).
+- `table`: preprocessing materializes the tree as a separate table, and the column carries no
+  lineage tree — `lineage(...)` is not available on it.
+- `both`: both of the above.
+
+For `table` and `both`, the materialized table is named after the column, so a column
+`pango_lineage` yields a table `pango_lineage` that is queried like any other table:
+
+```
+pango_lineage
+  .filter(parent = 'B.1')
+```
+
+### Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | string | Primary key. An opaque row identifier, not a lineage name |
+| `lineage` | string | The canonical lineage name |
+| `parent` | string | One direct parent of `lineage`, or `null` if `lineage` is a root |
+| `is_recombinant_edge` | boolean | `true` if `lineage` has more than one direct parent |
+| `recombinant_clade_ancestor` | string | For a recombinant `lineage`, the most recent common ancestor of its parents. `null` for non-recombinants, and also for a recombinant whose parents share no common ancestor |
+
+### Semantics
+
+- **Direct edges only.** The table holds one row per lineage and each of its immediate parents. The
+  transitive ancestry is walked from these edges at query time rather than being materialized, so
+  the table has no rows for grandparent relationships.
+- **Recombinants yield several rows.** A lineage with *n* parents contributes *n* rows, one per
+  parent, each with `is_recombinant_edge` set to `true` and the same
+  `recombinant_clade_ancestor`.
+- **Roots get a row too.** A root has no parent edge, so it gets a single row with a `null` `parent`
+  instead — this both terminates an upward walk and keeps the root present in the table.
+- **Derived from the definition, not the data.** The rows come from the lineage definition file, so
+  every canonical lineage appears whether or not any sequence carries it.
+- **Aliases are not rows.** An alias resolves to its canonical lineage; only canonical lineage names
+  appear in `lineage` and `parent`.

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -14,7 +14,12 @@ tableName
   .operator2(...)
 ```
 
-The table name is `default` for now.
+The table holding the sequences and their metadata is named `default`.
+
+Additional tables exist if the database config declares columns with `lineageIndexType: table` or
+`both`: each such column gets a companion table named after the column, holding the edges of its
+lineage tree. These are queried like any other table — see
+[lineage_definitions.md](lineage_definitions.md#lineage-relation-tables) for their schema.
 
 ### Tabular data model
 
@@ -544,7 +549,10 @@ primary_key.like('key_[0-9]+')
 
 ### `lineage(column, value [, includeSublineages:=bool] [, recombinantFollowingMode:=string])`
 
-True if the lineage column matches `value`. Column must have `generateLineageIndex: true` in the schema.
+True if the lineage column matches `value`. The column must have `generateLineageIndex` set in the
+schema, with a `lineageIndexType` of `columnMetadata` (the default) or `both` — with
+`lineageIndexType: table` the lineage tree is not attached to the column and this filter is
+unavailable on it.
 
 `includeSublineages` (default `false`) also matches sublineages of `value`. `value` may be `null` to match NULL rows.
 

--- a/src/silo/common/bidirectional_string_map.h
+++ b/src/silo/common/bidirectional_string_map.h
@@ -56,6 +56,8 @@ class BidirectionalStringMap {
 
    [[nodiscard]] std::string_view getValue(Idx idx) const { return id_to_value.at(idx); }
 
+   [[nodiscard]] size_t size() const { return id_to_value.size(); }
+
    [[nodiscard]] std::optional<Idx> getId(std::string_view value) const {
       if (value_to_id.contains(value)) {
          return value_to_id.at(value);

--- a/src/silo/common/lineage_tree.h
+++ b/src/silo/common/lineage_tree.h
@@ -68,8 +68,16 @@ class LineageTree {
    LineageTree& operator=(const LineageTree& other) = default;
    LineageTree& operator=(LineageTree&& other) = default;
 
-   const std::vector<std::vector<Idx>>& getChildToParentRelation() {
+   [[nodiscard]] const std::vector<std::vector<Idx>>& getChildToParentRelation() const {
       return child_to_parent_relation;
+   }
+
+   /// For every recombinant node (a node with more than one parent), the most-recent common
+   /// ancestor of its parents (or `nullopt` when the parents share no common ancestor). Nodes that
+   /// are not recombinant do not appear. Used by the `FOLLOW_IF_FULLY_CONTAINED_IN_CLADE` walk.
+   [[nodiscard]] const std::unordered_map<Idx, std::optional<Idx>>& getRecombinantCladeAncestors(
+   ) const {
+      return recombinant_clade_ancestors;
    }
 
    static std::unordered_map<Idx, std::optional<Idx>> computeRecombinantCladeAncestors(

--- a/src/silo/config/database_config.cpp
+++ b/src/silo/config/database_config.cpp
@@ -34,6 +34,34 @@ ValueType silo::config::toDatabaseValueType(std::string_view type) {
    throw silo::config::ConfigException("Unknown metadata type: " + std::string(type));
 }
 
+silo::config::LineageIndexType silo::config::toLineageIndexType(std::string_view type) {
+   if (type == "columnMetadata") {
+      return LineageIndexType::COLUMN_METADATA;
+   }
+   if (type == "table") {
+      return LineageIndexType::TABLE;
+   }
+   if (type == "both") {
+      return LineageIndexType::BOTH;
+   }
+   throw silo::config::ConfigException(
+      "Unknown lineageIndexType: '" + std::string(type) +
+      "'. Must be one of 'columnMetadata', 'table', 'both'."
+   );
+}
+
+std::string_view silo::config::lineageIndexTypeToString(LineageIndexType type) {
+   switch (type) {
+      case LineageIndexType::COLUMN_METADATA:
+         return "columnMetadata";
+      case LineageIndexType::TABLE:
+         return "table";
+      case LineageIndexType::BOTH:
+         return "both";
+   }
+   SILO_UNREACHABLE();
+}
+
 namespace {
 
 std::string toString(ValueType type) {
@@ -49,7 +77,7 @@ std::string toString(ValueType type) {
       case ValueType::FLOAT:
          return "float";
    }
-   throw std::runtime_error("Non-exhausting switch should be covered by linter");
+   SILO_UNREACHABLE();
 }
 }  // namespace
 
@@ -115,6 +143,12 @@ bool YAML::convert<silo::config::DatabaseMetadata>::decode(
    } else {
       metadata.generate_lineage_index = std::nullopt;
    }
+   if (node["lineageIndexType"].IsDefined()) {
+      metadata.lineage_index_type =
+         silo::config::toLineageIndexType(node["lineageIndexType"].as<std::string>());
+   } else {
+      metadata.lineage_index_type = silo::config::LineageIndexType::COLUMN_METADATA;
+   }
    if (node["isPhyloTreeField"].IsDefined()) {
       metadata.phylo_tree_node_identifier = node["isPhyloTreeField"].as<bool>();
    } else {
@@ -135,7 +169,8 @@ YAML::Node YAML::convert<silo::config::DatabaseMetadata>::encode(
    node["type"] = toString(metadata.type);
    node["generateIndex"] = metadata.generate_index;
    if (metadata.generate_lineage_index) {
-      node["generateLineageIndex"] = true;
+      node["generateLineageIndex"] = metadata.generate_lineage_index.value();
+      node["lineageIndexType"] = std::string{lineageIndexTypeToString(metadata.lineage_index_type)};
    }
    if (metadata.phylo_tree_node_identifier) {
       node["isPhyloTreeField"] = true;
@@ -168,6 +203,15 @@ schema::ColumnType DatabaseMetadata::getColumnType() const {
       return schema::ColumnType::FLOAT;
    }
    throw std::runtime_error("Did not find metadata with name: " + std::string(name));
+}
+
+bool DatabaseMetadata::generatesLineageColumnIndex() const {
+   return generate_lineage_index.has_value() && lineage_index_type != LineageIndexType::TABLE;
+}
+
+bool DatabaseMetadata::generatesLineageTable() const {
+   return generate_lineage_index.has_value() &&
+          lineage_index_type != LineageIndexType::COLUMN_METADATA;
 }
 
 std::optional<DatabaseMetadata> DatabaseConfig::getMetadata(const std::string& name) const {
@@ -255,6 +299,15 @@ std::map<std::string, ValueType> validateMetadataDefinitions(const DatabaseConfi
          throw ConfigException(
             "Metadata '" + metadata.name +
             "' generateLineageIndex is set, generateIndex must also be set."
+         );
+      }
+
+      if (!generate_lineage_indexed_field &&
+          metadata.lineage_index_type != LineageIndexType::COLUMN_METADATA) {
+         throw ConfigException(
+            "Metadata '" + metadata.name + "' lineageIndexType is set to '" +
+            std::string(lineageIndexTypeToString(metadata.lineage_index_type)) +
+            "', but generateLineageIndex is not set."
          );
       }
 

--- a/src/silo/config/database_config.h
+++ b/src/silo/config/database_config.h
@@ -17,16 +17,31 @@ enum class ValueType : uint8_t { STRING, DATE, BOOL, INT, FLOAT };
 
 ValueType toDatabaseValueType(std::string_view type);
 
+enum class LineageIndexType : uint8_t { COLUMN_METADATA, TABLE, BOTH };
+
+LineageIndexType toLineageIndexType(std::string_view type);
+
+std::string_view lineageIndexTypeToString(LineageIndexType type);
+
 class DatabaseMetadata {
   public:
    std::string name;
    ValueType type;
    bool generate_index;
    std::optional<std::string> generate_lineage_index;
+   LineageIndexType lineage_index_type = LineageIndexType::COLUMN_METADATA;
    bool phylo_tree_node_identifier;
    bool treat_unknown_lineages_as_null;
 
    [[nodiscard]] schema::ColumnType getColumnType() const;
+
+   /// Whether the column itself should carry the in-memory lineage index (i.e. the lineage tree is
+   /// attached to the column metadata). True for `COLUMN_METADATA` and `BOTH`.
+   [[nodiscard]] bool generatesLineageColumnIndex() const;
+
+   /// Whether preprocessing should materialize a companion lineage relation table for this column.
+   /// True for `TABLE` and `BOTH`.
+   [[nodiscard]] bool generatesLineageTable() const;
 };
 
 class DatabaseSchema {

--- a/src/silo/config/database_config.test.cpp
+++ b/src/silo/config/database_config.test.cpp
@@ -299,6 +299,120 @@ schema:
    );
 }
 
+TEST(DatabaseConfig, lineageIndexTypeDefaultsToColumnMetadata) {
+   const char* const config_yaml =
+      R"(
+schema:
+  instanceName: "testInstanceName"
+  metadata:
+    - name: "testPrimaryKey"
+      type: "string"
+    - name: "lineage"
+      type: "string"
+      generateIndex: true
+      generateLineageIndex: lineage
+  primaryKey: "testPrimaryKey"
+)";
+
+   const auto config = DatabaseConfig::getValidatedConfig(config_yaml);
+   const auto metadata = config.getMetadata("lineage").value();
+   ASSERT_EQ(metadata.lineage_index_type, silo::config::LineageIndexType::COLUMN_METADATA);
+   ASSERT_TRUE(metadata.generatesLineageColumnIndex());
+   ASSERT_FALSE(metadata.generatesLineageTable());
+}
+
+TEST(DatabaseConfig, lineageIndexTypeTableIsParsedAndTogglesTableOnly) {
+   const char* const config_yaml =
+      R"(
+schema:
+  instanceName: "testInstanceName"
+  metadata:
+    - name: "testPrimaryKey"
+      type: "string"
+    - name: "lineage"
+      type: "string"
+      generateIndex: true
+      generateLineageIndex: lineage
+      lineageIndexType: table
+  primaryKey: "testPrimaryKey"
+)";
+
+   const auto config = DatabaseConfig::getValidatedConfig(config_yaml);
+   const auto metadata = config.getMetadata("lineage").value();
+   ASSERT_EQ(metadata.lineage_index_type, silo::config::LineageIndexType::TABLE);
+   ASSERT_FALSE(metadata.generatesLineageColumnIndex());
+   ASSERT_TRUE(metadata.generatesLineageTable());
+}
+
+TEST(DatabaseConfig, lineageIndexTypeBothTogglesBoth) {
+   const char* const config_yaml =
+      R"(
+schema:
+  instanceName: "testInstanceName"
+  metadata:
+    - name: "testPrimaryKey"
+      type: "string"
+    - name: "lineage"
+      type: "string"
+      generateIndex: true
+      generateLineageIndex: lineage
+      lineageIndexType: both
+  primaryKey: "testPrimaryKey"
+)";
+
+   const auto config = DatabaseConfig::getValidatedConfig(config_yaml);
+   const auto metadata = config.getMetadata("lineage").value();
+   ASSERT_EQ(metadata.lineage_index_type, silo::config::LineageIndexType::BOTH);
+   ASSERT_TRUE(metadata.generatesLineageColumnIndex());
+   ASSERT_TRUE(metadata.generatesLineageTable());
+}
+
+TEST(DatabaseConfig, givenUnknownLineageIndexTypeThenThrows) {
+   const char* const config_yaml =
+      R"(
+schema:
+  instanceName: "testInstanceName"
+  metadata:
+    - name: "testPrimaryKey"
+      type: "string"
+    - name: "lineage"
+      type: "string"
+      generateIndex: true
+      generateLineageIndex: lineage
+      lineageIndexType: nonsense
+  primaryKey: "testPrimaryKey"
+)";
+
+   EXPECT_THAT(
+      [&config_yaml]() { DatabaseConfig::getValidatedConfig(config_yaml); },
+      ThrowsMessage<ConfigException>(::testing::HasSubstr("Unknown lineageIndexType: 'nonsense'"))
+   );
+}
+
+TEST(DatabaseConfig, givenLineageIndexTypeWithoutGenerateLineageIndexThenThrows) {
+   const char* const config_yaml =
+      R"(
+schema:
+  instanceName: "testInstanceName"
+  metadata:
+    - name: "testPrimaryKey"
+      type: "string"
+    - name: "lineage"
+      type: "string"
+      generateIndex: true
+      lineageIndexType: table
+  primaryKey: "testPrimaryKey"
+)";
+
+   EXPECT_THAT(
+      [&config_yaml]() { DatabaseConfig::getValidatedConfig(config_yaml); },
+      ThrowsMessage<ConfigException>(
+         ::testing::HasSubstr("Metadata 'lineage' lineageIndexType is set to 'table', but "
+                              "generateLineageIndex is not set")
+      )
+   );
+}
+
 TEST(DatabaseConfig, givenPhyloTreeIndexAndGenerateThenThrows) {
    const char* const config_yaml =
       R"(

--- a/src/silo/database.cpp
+++ b/src/silo/database.cpp
@@ -1,7 +1,5 @@
 #include "silo/database.h"
 
-#include <array>
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <map>
@@ -38,6 +36,7 @@
 #include "silo/query_engine/scalar_expressions/literal.h"
 #include "silo/schema/database_schema.h"
 #include "silo/storage/column/sequence_column.h"
+#include "silo/storage/column/string_column.h"
 
 namespace {
 template <typename SymbolType>
@@ -336,8 +335,9 @@ DatabaseInfo Database::getDatabaseInfo() const {
       .vertical_bitmaps_size = 0,
       .horizontal_bitmaps_size = 0
    };
-   for (const auto& [_, table] : tables) {
-      addTableStatisticsToDatabaseInfo(database_info, *table);
+   const auto default_table = tables.find(schema::TableName::getDefault());
+   if (default_table != tables.end()) {
+      addTableStatisticsToDatabaseInfo(database_info, *default_table->second);
    }
    return database_info;
 }
@@ -442,6 +442,7 @@ Database Database::loadDatabaseState(const silo::SiloDataSource& silo_data_sourc
    SPDLOG_INFO(
       "Finished loading data_version from {}", (save_directory / DATA_VERSION_FILENAME).string()
    );
+
    SPDLOG_INFO("Database info after loading: {}", database.getDatabaseInfo());
 
    return database;

--- a/src/silo/database.test.cpp
+++ b/src/silo/database.test.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include "config/source/yaml_file.h"
+#include "silo/common/lineage_tree.h"
 #include "silo/common/phylo_tree.h"
 #include "silo/config/preprocessing_config.h"
 #include "silo/database_info.h"

--- a/src/silo/initialize/initializer.cpp
+++ b/src/silo/initialize/initializer.cpp
@@ -1,17 +1,28 @@
 #include "silo/initialize/initializer.h"
 
+#include <ranges>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #include <fmt/ranges.h>
 #include <spdlog/spdlog.h>
-#include <boost/algorithm/string/join.hpp>
+#include <nlohmann/json.hpp>
 
 #include "evobench/evobench.hpp"
+#include "silo/append/ndjson_line_reader.h"
+#include "silo/append/table_inserter.h"
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/common/panic.h"
 #include "silo/common/phylo_tree.h"
 #include "silo/database.h"
 #include "silo/initialize/initialize_exception.h"
+#include "silo/initialize/lineage_relation_table.h"
+#include "silo/storage/column/column_metadata.h"
 #include "silo/storage/column/column_type_visitor.h"
+#include "silo/storage/column/indexed_string_column.h"
+#include "silo/storage/column/string_column.h"
 #include "silo/storage/column/zstd_compressed_string_column.h"
 #include "silo/storage/reference_genomes.h"
 
@@ -35,18 +46,133 @@ void Initializer::createTableInDatabase(
       phylo_tree_file = common::PhyloTree::fromFile(opt_path.value());
    }
 
-   auto validated_config = config::DatabaseConfig::getValidatedConfigFromFile(
-      initialization_files.getDatabaseConfigFilepath()
-   );
-
-   auto table_schema = createSchemaFromConfigFiles(
-      validated_config,
+   createTableInDatabase(
+      std::move(table_name),
+      config::DatabaseConfig::getValidatedConfigFromFile(
+         initialization_files.getDatabaseConfigFilepath()
+      ),
       ReferenceGenomes::readFromFile(initialization_files.getReferenceGenomeFilepath()),
       lineage_trees,
       phylo_tree_file,
-      initialization_files.without_unaligned_sequences
+      initialization_files.without_unaligned_sequences,
+      database
+   );
+}
+
+void Initializer::createTableInDatabase(
+   schema::TableName table_name,
+   const config::DatabaseConfig& database_config,
+   const ReferenceGenomes& reference_genomes,
+   const std::map<std::filesystem::path, common::LineageTreeAndIdMap>& lineage_trees,
+   const common::PhyloTree& phylo_tree,
+   bool without_unaligned_sequences,
+   Database& database
+) {
+   auto table_schema = createSchemaFromConfigFiles(
+      database_config, reference_genomes, lineage_trees, phylo_tree, without_unaligned_sequences
    );
    database.createTable(std::move(table_name), std::move(table_schema));
+
+   // Materialize a companion lineage relation table for every column configured with
+   // `lineageIndexType` 'table' or 'both'. The tree name is resolved against the loaded lineage
+   // definitions the same way the column's in-memory index is.
+   for (const auto& config_metadata : database_config.schema.metadata) {
+      if (!config_metadata.generatesLineageTable()) {
+         continue;
+      }
+      auto lineage_tree =
+         findLineageTreeForName(lineage_trees, config_metadata.generate_lineage_index.value());
+      if (!lineage_tree.has_value()) {
+         auto keys =
+            lineage_trees | std::views::keys |
+            std::views::transform([](const std::filesystem::path& path) { return path.string(); });
+         throw InitializeException(
+            "Column '{}' has lineage tree '{}' configured, but did not find corresponding lineage "
+            "tree in the provided lineageDefinitionFilenames: {}",
+            config_metadata.name,
+            config_metadata.generate_lineage_index.value(),
+            fmt::join(keys, ",")
+         );
+      }
+      createLineageRelationTable(config_metadata.name, lineage_tree.value(), database);
+   }
+}
+
+void Initializer::createLineageRelationTable(
+   std::string_view column_name,
+   const common::LineageTreeAndIdMap& lineage_tree,
+   Database& database
+) {
+   const std::string table_name_string{column_name};
+   const schema::TableName table_name{table_name_string};
+   if (database.tables.contains(table_name)) {
+      throw InitializeException(
+         "Cannot create lineage relation table '{}': a table with that name already exists.",
+         table_name_string
+      );
+   }
+
+   const schema::ColumnIdentifier id_column{.name = "id", .type = schema::ColumnType::STRING};
+   const schema::ColumnIdentifier lineage_column{
+      .name = "lineage", .type = schema::ColumnType::STRING
+   };
+   // The direct parent of `lineage` (null for a root). The transitive ancestry is walked from
+   // these edges at query time rather than materialized.
+   const schema::ColumnIdentifier parent_column{
+      .name = "parent", .type = schema::ColumnType::STRING
+   };
+   // True when `lineage` has more than one direct parent (an edge into a recombinant node).
+   const schema::ColumnIdentifier is_recombinant_edge_column{
+      .name = "is_recombinant_edge", .type = schema::ColumnType::BOOL
+   };
+   // For a recombinant `lineage`, the most-recent common ancestor of its parents; null
+   // otherwise.
+   const schema::ColumnIdentifier recombinant_clade_ancestor_column{
+      .name = "recombinant_clade_ancestor", .type = schema::ColumnType::STRING
+   };
+   auto table_schema = std::make_shared<schema::TableSchema>();
+   table_schema->column_metadata.emplace(
+      id_column, std::make_shared<storage::column::StringColumnMetadata>(id_column.name)
+   );
+   table_schema->column_metadata.emplace(
+      lineage_column, std::make_shared<storage::column::StringColumnMetadata>(lineage_column.name)
+   );
+   table_schema->column_metadata.emplace(
+      parent_column, std::make_shared<storage::column::StringColumnMetadata>(parent_column.name)
+   );
+   table_schema->column_metadata.emplace(
+      is_recombinant_edge_column,
+      std::make_shared<storage::column::ColumnMetadata>(is_recombinant_edge_column.name)
+   );
+   table_schema->column_metadata.emplace(
+      recombinant_clade_ancestor_column,
+      std::make_shared<storage::column::StringColumnMetadata>(recombinant_clade_ancestor_column.name
+      )
+   );
+   table_schema->primary_key = id_column;
+   database.createTable(table_name, std::move(table_schema));
+
+   const auto rows = buildLineageRelationRows(lineage_tree);
+   std::string ndjson;
+   size_t row_id = 0;
+   for (const auto& row : rows) {
+      const nlohmann::json line{
+         {"id", std::to_string(row_id++)},
+         {"lineage", row.lineage},
+         {"parent", row.parent.has_value() ? nlohmann::json(*row.parent) : nlohmann::json(nullptr)},
+         {"is_recombinant_edge", row.is_recombinant_edge},
+         {"recombinant_clade_ancestor",
+          row.recombinant_clade_ancestor.has_value()
+             ? nlohmann::json(*row.recombinant_clade_ancestor)
+             : nlohmann::json(nullptr)}
+      };
+      ndjson += line.dump();
+      ndjson += '\n';
+   }
+   std::stringstream ndjson_stream{ndjson};
+   silo::append::NdjsonLineReader ndjson_reader{ndjson_stream};
+   silo::append::appendDataToTable(database.tables.at(table_name), ndjson_reader);
+   SPDLOG_INFO("Built lineage relation table '{}' with {} rows", table_name_string, rows.size());
 }
 
 struct ColumnMetadataInitializer {
@@ -68,14 +194,14 @@ void ColumnMetadataInitializer::operator()<storage::column::IndexedStringColumn>
    const std::map<std::filesystem::path, common::LineageTreeAndIdMap>& lineage_trees,
    const common::PhyloTree& /*phylo_tree_file*/
 ) {
-   if (config_metadata.generate_lineage_index.has_value()) {
+   if (config_metadata.generatesLineageColumnIndex()) {
       auto lineage_tree_name = config_metadata.generate_lineage_index.value();
       auto lineage_tree = Initializer::findLineageTreeForName(lineage_trees, lineage_tree_name);
       if (not lineage_tree.has_value()) {
          auto keys =
             lineage_trees | std::views::keys |
             std::views::transform([](const std::filesystem::path& path) { return path.string(); });
-         throw silo::initialize::InitializeException(
+         throw InitializeException(
             "Column '{}' has lineage tree '{}' configured, but did not find corresponding lineage "
             "tree in the provided lineageDefinitionFilenames: {}",
             config_metadata.name,
@@ -163,9 +289,7 @@ void assertPrimaryKeyInMetadata(const silo::config::DatabaseConfig& database_con
       }
    );
    if (primary_key_metadata == database_config.schema.metadata.end()) {
-      throw silo::initialize::InitializeException(
-         "The primary key is not contained in the metadata."
-      );
+      throw InitializeException("The primary key is not contained in the metadata.");
    }
 }
 
@@ -178,7 +302,7 @@ void assertPrimaryKeyOfTypeString(const silo::config::DatabaseConfig& database_c
    );
    auto primary_key_type = primary_key_metadata->getColumnType();
    if (primary_key_type != schema::ColumnType::STRING) {
-      throw silo::initialize::InitializeException(
+      throw InitializeException(
          "The primary key must be of type STRING but it is of type {}",
          columnTypeToString(primary_key_type)
       );

--- a/src/silo/initialize/initializer.h
+++ b/src/silo/initialize/initializer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 #include "silo/common/lineage_tree.h"
 #include "silo/common/phylo_tree.h"
 #include "silo/config/database_config.h"
@@ -17,6 +19,16 @@ class Initializer {
       Database& database
    );
 
+   static void createTableInDatabase(
+      schema::TableName table_name,
+      const config::DatabaseConfig& database_config,
+      const ReferenceGenomes& reference_genomes,
+      const std::map<std::filesystem::path, common::LineageTreeAndIdMap>& lineage_trees,
+      const common::PhyloTree& phylo_tree,
+      bool without_unaligned_sequences,
+      Database& database
+   );
+
    static std::shared_ptr<schema::TableSchema> createSchemaFromConfigFiles(
       const config::DatabaseConfig& database_config,
       ReferenceGenomes reference_genomes,
@@ -28,6 +40,13 @@ class Initializer {
    static std::optional<common::LineageTreeAndIdMap> findLineageTreeForName(
       const std::map<std::filesystem::path, common::LineageTreeAndIdMap>& lineage_trees,
       const std::string& lineage_tree_name
+   );
+
+  private:
+   static void createLineageRelationTable(
+      std::string_view column_name,
+      const common::LineageTreeAndIdMap& lineage_tree,
+      Database& database
    );
 };
 }  // namespace silo::initialize

--- a/src/silo/initialize/initializer.test.cpp
+++ b/src/silo/initialize/initializer.test.cpp
@@ -1,7 +1,9 @@
 #include "silo/initialize/initializer.h"
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include "silo/storage/column/indexed_string_column.h"
 #include "silo/storage/column/sequence_column.h"
 #include "silo/storage/column/zstd_compressed_string_column.h"
 
@@ -191,6 +193,65 @@ A.11:
 
    ASSERT_EQ(table_schema->primary_key.name, "primaryKey");
    ASSERT_EQ(table_schema->primary_key.type, ColumnType::STRING);
+}
+
+namespace {
+// Builds a schema from a config whose single lineage column uses the given `lineageIndexType`, and
+// returns whether the resulting column carries the in-memory lineage tree.
+bool lineageColumnHasInMemoryTree(const std::string& lineage_index_type) {
+   const std::string config_yaml = fmt::format(
+      R"(
+schema:
+  instanceName: "test"
+  metadata:
+    - name: "primaryKey"
+      type: "string"
+    - name: "lineage"
+      type: "string"
+      generateIndex: true
+      generateLineageIndex: test_lineage_definition.yaml
+      lineageIndexType: {}
+  primaryKey: "primaryKey"
+)",
+      lineage_index_type
+   );
+   const auto database_config = silo::config::DatabaseConfig::getValidatedConfig(config_yaml);
+   const ReferenceGenomes reference_genomes =
+      ReferenceGenomes::readFromFile("testBaseData/unitTestDummyDataset/reference_genomes.json");
+   const std::map<std::filesystem::path, LineageTreeAndIdMap> lineage_trees{
+      {"test_lineage_definition.yaml",
+       LineageTreeAndIdMap::fromLineageDefinitionFile(
+          silo::preprocessing::LineageDefinitionFile::fromYAMLString(R"(
+A:
+  parents: []
+A.1:
+  parents:
+  - A
+)")
+       )}
+   };
+   auto table_schema = Initializer::createSchemaFromConfigFiles(
+      database_config, reference_genomes, lineage_trees, PhyloTree{}, false
+   );
+   auto* metadata =
+      table_schema->getColumnMetadata<silo::storage::column::IndexedStringColumn>("lineage").value(
+      );
+   return metadata->lineage_tree.has_value();
+}
+}  // namespace
+
+TEST(Initializer, lineageIndexTypeColumnMetadataAttachesInMemoryTree) {
+   EXPECT_TRUE(lineageColumnHasInMemoryTree("columnMetadata"));
+}
+
+TEST(Initializer, lineageIndexTypeBothAttachesInMemoryTree) {
+   EXPECT_TRUE(lineageColumnHasInMemoryTree("both"));
+}
+
+TEST(Initializer, lineageIndexTypeTableDoesNotAttachInMemoryTree) {
+   // 'table' mode materializes only the relation table; the column stays a plain indexed string
+   // column without the in-memory lineage index.
+   EXPECT_FALSE(lineageColumnHasInMemoryTree("table"));
 }
 
 class FindLineageTreeForName : public ::testing::Test {

--- a/src/silo/initialize/lineage_relation_table.cpp
+++ b/src/silo/initialize/lineage_relation_table.cpp
@@ -1,0 +1,60 @@
+#include "silo/initialize/lineage_relation_table.h"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "silo/common/types.h"
+
+namespace silo::initialize {
+
+std::vector<LineageRelationRow> buildLineageRelationRows(
+   const common::LineageTreeAndIdMap& lineage_tree_and_id_map
+) {
+   const auto& tree = lineage_tree_and_id_map.lineage_tree;
+   const auto& names = lineage_tree_and_id_map.lineage_id_lookup_map;
+   const auto& child_to_parent = tree.getChildToParentRelation();
+   const auto& clade_ancestors = tree.getRecombinantCladeAncestors();
+
+   // child_to_parent is indexed by canonical lineage id (aliases are assigned separate ids beyond
+   // this range and are resolved to their canonical lineage rather than emitted as edges).
+   std::vector<LineageRelationRow> rows;
+   for (size_t index = 0; index < child_to_parent.size(); ++index) {
+      const auto child_id = static_cast<Idx>(index);
+      std::string lineage{names.getValue(child_id)};
+      const auto& parents = child_to_parent[index];
+
+      if (parents.empty()) {
+         // A root: no parent edge, but the lineage still needs a row so the walk can terminate and
+         // so a lineage carrying no sequences is still present in the table.
+         rows.push_back(
+            {.lineage = std::move(lineage),
+             .parent = std::nullopt,
+             .is_recombinant_edge = false,
+             .recombinant_clade_ancestor = std::nullopt}
+         );
+         continue;
+      }
+
+      const bool is_recombinant = parents.size() > 1;
+      std::optional<std::string> recombinant_clade_ancestor;
+      if (is_recombinant) {
+         if (const auto iterator = clade_ancestors.find(child_id);
+             iterator != clade_ancestors.end() && iterator->second.has_value()) {
+            recombinant_clade_ancestor = std::string{names.getValue(iterator->second.value())};
+         }
+      }
+      for (const Idx parent_id : parents) {
+         rows.push_back(
+            {.lineage = lineage,
+             .parent = std::string{names.getValue(parent_id)},
+             .is_recombinant_edge = is_recombinant,
+             .recombinant_clade_ancestor = recombinant_clade_ancestor}
+         );
+      }
+   }
+   return rows;
+}
+
+}  // namespace silo::initialize

--- a/src/silo/initialize/lineage_relation_table.h
+++ b/src/silo/initialize/lineage_relation_table.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "silo/common/lineage_tree.h"
+
+namespace silo::initialize {
+
+/// One direct parent->child edge of a lineage tree.
+/// A recombinant node contributes one row per parent
+struct LineageRelationRow {
+   std::string lineage;
+   std::optional<std::string> parent;
+   bool is_recombinant_edge = false;
+   std::optional<std::string> recombinant_clade_ancestor;
+
+   bool operator==(const LineageRelationRow& other) const = default;
+};
+
+/// Builds the **direct** parent->child edges of a lineage tree: one row per canonical lineage and
+/// each of its immediate parents (a recombinant yields several rows), and one root row with an
+/// empty parent for each root. Aliases are not emitted as separate lineages — they resolve to their
+/// canonical lineage. The transitive closure is derived from these edges at query time rather than
+/// materialized here.
+[[nodiscard]] std::vector<LineageRelationRow> buildLineageRelationRows(
+   const common::LineageTreeAndIdMap& lineage_tree_and_id_map
+);
+
+}  // namespace silo::initialize

--- a/src/silo/initialize/lineage_relation_table.test.cpp
+++ b/src/silo/initialize/lineage_relation_table.test.cpp
@@ -1,0 +1,187 @@
+#include "silo/initialize/lineage_relation_table.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include "silo/common/lineage_tree.h"
+#include "silo/preprocessing/lineage_definition_file.h"
+#include "silo/storage/reference_genomes.h"
+#include "silo/test/query_fixture.test.h"
+
+using silo::common::LineageTreeAndIdMap;
+using silo::initialize::buildLineageRelationRows;
+using silo::initialize::LineageRelationRow;
+using silo::preprocessing::LineageDefinitionFile;
+using ::testing::UnorderedElementsAreArray;
+
+namespace {
+LineageRelationRow edge(
+   std::string lineage,
+   std::optional<std::string> parent,
+   bool is_recombinant_edge = false,
+   std::optional<std::string> recombinant_clade_ancestor = std::nullopt
+) {
+   return LineageRelationRow{
+      .lineage = std::move(lineage),
+      .parent = std::move(parent),
+      .is_recombinant_edge = is_recombinant_edge,
+      .recombinant_clade_ancestor = std::move(recombinant_clade_ancestor)
+   };
+}
+}  // namespace
+
+TEST(LineageRelationTable, emitsOnlyDirectEdgesForALinearChain) {
+   auto tree = LineageTreeAndIdMap::fromLineageDefinitionFile(LineageDefinitionFile::fromYAMLString(
+      R"(
+BASE:
+  parents: []
+CHILD:
+  parents:
+    - BASE
+GRANDCHILD:
+  parents:
+    - CHILD
+)"
+   ));
+
+   const auto rows = buildLineageRelationRows(tree);
+
+   // No transitive closure: GRANDCHILD points only at CHILD, not at BASE. The root gets a
+   // parent-less row.
+   EXPECT_THAT(
+      rows,
+      UnorderedElementsAreArray(
+         {edge("BASE", std::nullopt), edge("CHILD", "BASE"), edge("GRANDCHILD", "CHILD")}
+      )
+   );
+}
+
+TEST(LineageRelationTable, recombinantEmitsOneEdgePerParentWithCladeAncestor) {
+   // XBB recombines A.1 and A.2, whose clade ancestor is A.
+   auto tree = LineageTreeAndIdMap::fromLineageDefinitionFile(LineageDefinitionFile::fromYAMLString(
+      R"(
+A:
+  parents: []
+A.1:
+  parents:
+    - A
+A.2:
+  parents:
+    - A
+XBB:
+  parents:
+    - A.1
+    - A.2
+)"
+   ));
+
+   const auto rows = buildLineageRelationRows(tree);
+
+   EXPECT_THAT(
+      rows,
+      UnorderedElementsAreArray(
+         {edge("A", std::nullopt),
+          edge("A.1", "A"),
+          edge("A.2", "A"),
+          edge("XBB", "A.1", /*is_recombinant_edge=*/true, /*recombinant_clade_ancestor=*/"A"),
+          edge("XBB", "A.2", /*is_recombinant_edge=*/true, /*recombinant_clade_ancestor=*/"A")}
+      )
+   );
+}
+
+namespace {
+using silo::ReferenceGenomes;
+using silo::test::QueryTestData;
+using silo::test::QueryTestScenario;
+
+// A column with `lineageIndexType: table` gets a companion relation table named after the column.
+const auto DATABASE_CONFIG =
+   R"(
+schema:
+  instanceName: "dummy name"
+  metadata:
+    - name: "primaryKey"
+      type: "string"
+    - name: "lin"
+      type: "string"
+      generateIndex: true
+      generateLineageIndex: test_lineage_index
+      lineageIndexType: "table"
+  primaryKey: "primaryKey"
+)";
+
+const auto REFERENCE_GENOMES = ReferenceGenomes{
+   {{"segment1", "A"}},
+   {{"gene1", "*"}},
+};
+
+const auto QUERYABLE_LINEAGE_TREE =
+   LineageTreeAndIdMap::fromLineageDefinitionFile(LineageDefinitionFile::fromYAMLString(R"(
+BASE:
+  parents: []
+CHILD:
+  parents:
+    - BASE
+)"));
+
+nlohmann::json createDataWithLineageValue(const std::string& primary_key, std::string value) {
+   return {
+      {"primaryKey", primary_key},
+      {"lin", std::move(value)},
+      {"segment1", nullptr},
+      {"unaligned_segment1", nullptr},
+      {"gene1", nullptr}
+   };
+}
+
+const QueryTestData TEST_DATA{
+   .ndjson_input_data =
+      {createDataWithLineageValue("id_1", "CHILD"), createDataWithLineageValue("id_2", "BASE")},
+   .database_config = DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES,
+   .lineage_trees = {{"test_lineage_index", QUERYABLE_LINEAGE_TREE}}
+};
+
+// Only the direct edges are stored (no transitive closure, no per-mode duplication): the root BASE
+// (parent null) and the edge CHILD->BASE => 2 rows.
+const QueryTestScenario RELATION_TABLE_CONTAINS_ONLY_DIRECT_EDGES = {
+   .name = "RELATION_TABLE_CONTAINS_ONLY_DIRECT_EDGES",
+   .query = "lin.groupBy({count:=count()})",
+   .expected_query_result = nlohmann::json::parse(R"([{"count":2}])")
+};
+
+// The `parent` column is directly queryable: exactly one lineage (CHILD) has BASE as its direct
+// parent.
+const QueryTestScenario RELATION_TABLE_PARENT_IS_QUERYABLE = {
+   .name = "RELATION_TABLE_PARENT_IS_QUERYABLE",
+   .query = "lin.filter(parent = 'BASE').groupBy({count:=count()})",
+   .expected_query_result = nlohmann::json::parse(R"([{"count":1}])")
+};
+
+const QueryTestScenario RELATION_TABLE_ROW_SHAPE = {
+   .name = "RELATION_TABLE_ROW_SHAPE",
+   .query =
+      "lin.filter(lineage = 'CHILD').project({lineage, parent, is_recombinant_edge, "
+      "recombinant_clade_ancestor})",
+   .expected_query_result = nlohmann::json::parse(R"(
+[{"lineage":"CHILD","parent":"BASE","is_recombinant_edge":false,
+"recombinant_clade_ancestor":null}]
+)")
+};
+
+}  // namespace
+
+QUERY_TEST(
+   LineageRelationTableQueryTest,
+   TEST_DATA,
+   ::testing::Values(
+      RELATION_TABLE_CONTAINS_ONLY_DIRECT_EDGES,
+      RELATION_TABLE_PARENT_IS_QUERYABLE,
+      RELATION_TABLE_ROW_SHAPE
+   )
+)

--- a/src/silo/test/query_fixture.test.h
+++ b/src/silo/test/query_fixture.test.h
@@ -53,9 +53,9 @@ namespace silo::test {
 struct QueryTestData {
    const std::vector<nlohmann::json> ndjson_input_data;
    const std::string database_config;
-   const silo::ReferenceGenomes reference_genomes;
-   const std::map<std::filesystem::path, silo::common::LineageTreeAndIdMap> lineage_trees;
-   const silo::common::PhyloTree phylo_tree_file;
+   const ReferenceGenomes reference_genomes;
+   const std::map<std::filesystem::path, common::LineageTreeAndIdMap> lineage_trees;
+   const common::PhyloTree phylo_tree_file;
    const bool without_unaligned_sequences = false;
 };
 
@@ -64,7 +64,7 @@ struct QueryTestScenario {
    std::string query;
    nlohmann::json expected_query_result;
    std::string expected_error_message;
-   std::optional<silo::config::QueryOptions> query_options;
+   std::optional<config::QueryOptions> query_options;
 };
 
 std::string printScenarioName(const ::testing::TestParamInfo<QueryTestScenario>& scenario);
@@ -77,21 +77,22 @@ nlohmann::json executeQueryToJsonArray(
 template <typename DataContainer>
 class QueryTestFixture : public ::testing::TestWithParam<QueryTestScenario> {
   public:
-   static std::shared_ptr<silo::Database> shared_database;
+   static std::shared_ptr<Database> shared_database;
 
    static void SetUpTestSuite() {
       const DataContainer data_container;
       const QueryTestData& test_data = data_container.test_data;
 
       auto database = std::make_shared<Database>();
-      auto table_schema = silo::initialize::Initializer::createSchemaFromConfigFiles(
-         silo::config::DatabaseConfig::getValidatedConfig(test_data.database_config),
+      initialize::Initializer::createTableInDatabase(
+         schema::TableName::getDefault(),
+         config::DatabaseConfig::getValidatedConfig(test_data.database_config),
          test_data.reference_genomes,
          test_data.lineage_trees,
          test_data.phylo_tree_file,
-         test_data.without_unaligned_sequences
+         test_data.without_unaligned_sequences,
+         *database
       );
-      database->createTable(schema::TableName::getDefault(), table_schema);
 
       std::stringstream ndjson_objects;
       for (const auto& object : test_data.ndjson_input_data) {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1368

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This adds the option to create a proper database table from lineage definitions. This allows better scalability and functionality. Real joins can be performed on the 

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
