### PR TITLE
refactor(silo): add a set-algebra api to CopyOnWriteBitmap

### DIFF
--- a/src/silo/database.cpp
+++ b/src/silo/database.cpp
@@ -275,7 +275,7 @@ roaring::Roaring Database::getFilteredBitmap(
    auto rewritten_filter_expression =
       filter_expression->rewrite(*table, ScalarExpression::AmbiguityMode::NONE);
    auto filter_operator = rewritten_filter_expression->compile(*table);
-   roaring::Roaring bitmap = filter_operator->evaluate().getConstReference();
+   roaring::Roaring bitmap = filter_operator->evaluate().toRoaring();
    return bitmap;
 }
 

--- a/src/silo/query_engine/copy_on_write_bitmap.cpp
+++ b/src/silo/query_engine/copy_on_write_bitmap.cpp
@@ -1,6 +1,8 @@
 #include "silo/query_engine/copy_on_write_bitmap.h"
 
+#include <cstdint>
 #include <utility>
+#include <vector>
 
 #include <roaring/roaring.hh>
 
@@ -32,6 +34,62 @@ roaring::Roaring& CopyOnWriteBitmap::getMutable() {
 
 bool CopyOnWriteBitmap::isMutable() const {
    return mutable_bitmap != nullptr;
+}
+
+uint64_t CopyOnWriteBitmap::cardinality() const {
+   return getConstReference().cardinality();
+}
+
+bool CopyOnWriteBitmap::isEmpty() const {
+   return getConstReference().isEmpty();
+}
+
+roaring::Roaring::const_iterator CopyOnWriteBitmap::begin() const {
+   return getConstReference().begin();
+}
+
+roaring::Roaring::const_iterator CopyOnWriteBitmap::end() const {
+   return getConstReference().end();
+}
+
+uint64_t CopyOnWriteBitmap::andCardinality(const CopyOnWriteBitmap& other) const {
+   return getConstReference().and_cardinality(other.getConstReference());
+}
+
+CopyOnWriteBitmap& CopyOnWriteBitmap::operator&=(const CopyOnWriteBitmap& other) {
+   getMutable() &= other.getConstReference();
+   return *this;
+}
+
+CopyOnWriteBitmap& CopyOnWriteBitmap::operator-=(const CopyOnWriteBitmap& other) {
+   getMutable() -= other.getConstReference();
+   return *this;
+}
+
+CopyOnWriteBitmap& CopyOnWriteBitmap::operator|=(const CopyOnWriteBitmap& other) {
+   getMutable() |= other.getConstReference();
+   return *this;
+}
+
+CopyOnWriteBitmap CopyOnWriteBitmap::operator&(const CopyOnWriteBitmap& other) const {
+   return CopyOnWriteBitmap{getConstReference() & other.getConstReference()};
+}
+
+CopyOnWriteBitmap CopyOnWriteBitmap::operator-(const CopyOnWriteBitmap& other) const {
+   return CopyOnWriteBitmap{getConstReference() - other.getConstReference()};
+}
+
+CopyOnWriteBitmap CopyOnWriteBitmap::fastUnion(const std::vector<CopyOnWriteBitmap>& bitmaps) {
+   std::vector<const roaring::Roaring*> inputs;
+   inputs.reserve(bitmaps.size());
+   for (const auto& bitmap : bitmaps) {
+      inputs.push_back(&bitmap.getConstReference());
+   }
+   return CopyOnWriteBitmap{roaring::Roaring::fastunion(inputs.size(), inputs.data())};
+}
+
+roaring::Roaring CopyOnWriteBitmap::toRoaring() const {
+   return getConstReference();
 }
 
 }  // namespace silo::query_engine

--- a/src/silo/query_engine/copy_on_write_bitmap.h
+++ b/src/silo/query_engine/copy_on_write_bitmap.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
+#include <vector>
 
 #include <roaring/roaring.hh>
 
@@ -8,10 +10,21 @@ namespace silo::query_engine {
 
 /// The return value of the Operator::evaluate method.
 /// May return either a mutable or immutable bitmap.
+///
+/// Set-algebra (AND, OR, ANDNOT and the matching cardinalities) is exposed as member operators so
+/// callers never have to reach for the underlying `roaring::Roaring` -- `toRoaring` materializes a
+/// standalone copy only at the very end of a query, where the result leaves the engine. The
+/// operators are currently thin wrappers over `roaring::Roaring`; keeping every caller on this API
+/// lets the internal representation change later without touching call sites.
 class CopyOnWriteBitmap {
-  private:
    std::shared_ptr<roaring::Roaring> mutable_bitmap;
    const roaring::Roaring* immutable_bitmap;
+
+   [[nodiscard]] roaring::Roaring& getMutable();
+
+   [[nodiscard]] const roaring::Roaring& getConstReference() const;
+
+   [[nodiscard]] bool isMutable() const;
 
   public:
    CopyOnWriteBitmap();
@@ -22,11 +35,32 @@ class CopyOnWriteBitmap {
 
    explicit CopyOnWriteBitmap(roaring::Roaring&& bitmap);
 
-   [[nodiscard]] roaring::Roaring& getMutable();
+   [[nodiscard]] uint64_t cardinality() const;
 
-   [[nodiscard]] const roaring::Roaring& getConstReference() const;
+   [[nodiscard]] bool isEmpty() const;
 
-   [[nodiscard]] bool isMutable() const;
+   /// Iterates the contained row ids in ascending order, enabling range-based for over the bitmap.
+   /// The iterators borrow the underlying bitmap, so it must outlive them and must not be mutated
+   /// while an iteration is in progress.
+   [[nodiscard]] roaring::Roaring::const_iterator begin() const;
+   [[nodiscard]] roaring::Roaring::const_iterator end() const;
+
+   /// Cardinality of the intersection with `other`, without materializing it.
+   [[nodiscard]] uint64_t andCardinality(const CopyOnWriteBitmap& other) const;
+
+   CopyOnWriteBitmap& operator&=(const CopyOnWriteBitmap& other);
+   CopyOnWriteBitmap& operator-=(const CopyOnWriteBitmap& other);
+   CopyOnWriteBitmap& operator|=(const CopyOnWriteBitmap& other);
+
+   [[nodiscard]] CopyOnWriteBitmap operator&(const CopyOnWriteBitmap& other) const;
+   [[nodiscard]] CopyOnWriteBitmap operator-(const CopyOnWriteBitmap& other) const;
+
+   /// Union of many bitmaps.
+   [[nodiscard]] static CopyOnWriteBitmap fastUnion(const std::vector<CopyOnWriteBitmap>& bitmaps);
+
+   /// Materializes into a standalone `roaring::Roaring`. Intended for the end of a query only,
+   /// where the result is handed to a consumer -- not for intermediate computation.
+   [[nodiscard]] roaring::Roaring toRoaring() const;
 };
 
 }  // namespace silo::query_engine

--- a/src/silo/query_engine/copy_on_write_bitmap.test.cpp
+++ b/src/silo/query_engine/copy_on_write_bitmap.test.cpp
@@ -1,0 +1,109 @@
+#include "silo/query_engine/copy_on_write_bitmap.h"
+
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <roaring/roaring.hh>
+
+using silo::query_engine::CopyOnWriteBitmap;
+
+namespace {
+
+// Values spanning several 2^16 container blocks, so the operations are exercised across containers
+// present in only one operand and in both.
+roaring::Roaring multiContainer() {
+   roaring::Roaring bitmap{1, 5, 100};
+   bitmap.add((1U << 16) + 3);
+   bitmap.add((3U << 16) + 7);
+   return bitmap;
+}
+
+}  // namespace
+
+TEST(CopyOnWriteBitmap, cardinalityAndEmptiness) {
+   const roaring::Roaring source = multiContainer();
+   const CopyOnWriteBitmap under_test{&source};
+   EXPECT_EQ(under_test.cardinality(), source.cardinality());
+   EXPECT_FALSE(under_test.isEmpty());
+
+   const CopyOnWriteBitmap empty;
+   EXPECT_TRUE(empty.isEmpty());
+   EXPECT_EQ(empty.cardinality(), 0);
+}
+
+TEST(CopyOnWriteBitmap, toRoaringMaterializesEqualCopy) {
+   const roaring::Roaring source = multiContainer();
+   const CopyOnWriteBitmap under_test{&source};
+   EXPECT_EQ(under_test.toRoaring(), source);
+}
+
+TEST(CopyOnWriteBitmap, intersection) {
+   const roaring::Roaring left = multiContainer();
+   const roaring::Roaring right{5, 100, (1U << 16) + 3, 999};
+
+   CopyOnWriteBitmap in_place{&left};
+   in_place &= CopyOnWriteBitmap{&right};
+   EXPECT_EQ(in_place.toRoaring(), left & right);
+
+   const CopyOnWriteBitmap fresh = CopyOnWriteBitmap{&left} & CopyOnWriteBitmap{&right};
+   EXPECT_EQ(fresh.toRoaring(), left & right);
+   EXPECT_EQ(
+      CopyOnWriteBitmap{&left}.andCardinality(CopyOnWriteBitmap{&right}),
+      (left & right).cardinality()
+   );
+}
+
+TEST(CopyOnWriteBitmap, difference) {
+   const roaring::Roaring left = multiContainer();
+   const roaring::Roaring right{5, (1U << 16) + 3};
+
+   CopyOnWriteBitmap in_place{&left};
+   in_place -= CopyOnWriteBitmap{&right};
+   EXPECT_EQ(in_place.toRoaring(), left - right);
+
+   const CopyOnWriteBitmap fresh = CopyOnWriteBitmap{&left} - CopyOnWriteBitmap{&right};
+   EXPECT_EQ(fresh.toRoaring(), left - right);
+}
+
+TEST(CopyOnWriteBitmap, unionInPlaceAndFastUnion) {
+   const roaring::Roaring first{1, 5};
+   const roaring::Roaring second = multiContainer();
+   const roaring::Roaring third{5, (3U << 16) + 7, (4U << 16) + 1};
+
+   CopyOnWriteBitmap in_place{&first};
+   in_place |= CopyOnWriteBitmap{&second};
+   EXPECT_EQ(in_place.toRoaring(), first | second);
+
+   std::vector<CopyOnWriteBitmap> bitmaps;
+   bitmaps.emplace_back(&first);
+   bitmaps.emplace_back(&second);
+   bitmaps.emplace_back(&third);
+   EXPECT_EQ(CopyOnWriteBitmap::fastUnion(bitmaps).toRoaring(), first | second | third);
+}
+
+TEST(CopyOnWriteBitmap, iteratesRowIdsInAscendingOrder) {
+   const roaring::Roaring source = multiContainer();
+   const CopyOnWriteBitmap under_test{&source};
+
+   std::vector<uint32_t> iterated;
+   for (const uint32_t row : under_test) {
+      iterated.push_back(row);
+   }
+   EXPECT_EQ(iterated, (std::vector<uint32_t>{1, 5, 100, (1U << 16) + 3, (3U << 16) + 7}));
+
+   const CopyOnWriteBitmap empty;
+   EXPECT_EQ(empty.begin(), empty.end());
+}
+
+TEST(CopyOnWriteBitmap, mutatingAViewDoesNotDisturbTheSource) {
+   // A bitmap constructed from a pointer is copy-on-write: the first mutation must clone rather
+   // than write through to the borrowed source.
+   const roaring::Roaring source = multiContainer();
+   CopyOnWriteBitmap under_test{&source};
+   const roaring::Roaring other{5};
+   under_test &= CopyOnWriteBitmap{&other};
+
+   EXPECT_EQ(under_test.toRoaring(), roaring::Roaring{5});
+   EXPECT_EQ(source, multiContainer());
+}

--- a/src/silo/query_engine/exec_node/table_scan.h
+++ b/src/silo/query_engine/exec_node/table_scan.h
@@ -58,8 +58,7 @@ class TableScanGenerator {
        : exec_batch_builder(columns),
          bitmap_filter(std::move(bitmap_filter_)),
          table(std::move(table)) {
-      current_bitmap_reader =
-         BatchedBitmapReader{bitmap_filter.getConstReference(), batch_size_cutoff};
+      current_bitmap_reader = BatchedBitmapReader{bitmap_filter.toRoaring(), batch_size_cutoff};
    }
 
    arrow::Future<std::optional<arrow::ExecBatch>> operator()() {

--- a/src/silo/query_engine/filter/operators/bitmap_producer.test.cpp
+++ b/src/silo/query_engine/filter/operators/bitmap_producer.test.cpp
@@ -14,7 +14,7 @@ TEST(OperatorBitmapProducer, evaluateShouldReturnCorrectValues) {
    const auto row_layout = RowLayout::of(5);
 
    const BitmapProducer under_test([&]() { return CopyOnWriteBitmap(&test_bitmap); }, row_layout);
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({1, 2, 3}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({1, 2, 3}));
 }
 
 TEST(OperatorBitmapProducer, evaluateShouldReturnCorrectValuesWhenNegated) {
@@ -26,7 +26,7 @@ TEST(OperatorBitmapProducer, evaluateShouldReturnCorrectValuesWhenNegated) {
    );
    const auto negated = BitmapProducer::negate(std::move(under_test));
 
-   ASSERT_EQ(negated->evaluate().getConstReference(), roaring::Roaring({0, 4}));
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring({0, 4}));
 }
 
 TEST(OperatorBitmapProducer, correctTypeInfo) {

--- a/src/silo/query_engine/filter/operators/complement.cpp
+++ b/src/silo/query_engine/filter/operators/complement.cpp
@@ -50,9 +50,9 @@ Type Complement::type() const {
 
 CopyOnWriteBitmap Complement::evaluate() const {
    EVOBENCH_SCOPE("Complement", "evaluate");
-   auto result = child->evaluate();
-   row_layout.complementInPlace(result.getMutable());
-   return result;
+   roaring::Roaring result = child->evaluate().toRoaring();
+   row_layout.complementInPlace(result);
+   return CopyOnWriteBitmap{std::move(result)};
 }
 
 std::unique_ptr<Operator> Complement::negate(std::unique_ptr<Complement>&& complement) {

--- a/src/silo/query_engine/filter/operators/complement.test.cpp
+++ b/src/silo/query_engine/filter/operators/complement.test.cpp
@@ -17,7 +17,7 @@ TEST(OperatorComplement, evaluateShouldReturnCorrectValues) {
    const Complement under_test(
       std::make_unique<IndexScan>(CopyOnWriteBitmap{&test_bitmap}, row_layout), row_layout
    );
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({0, 4}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({0, 4}));
 }
 
 TEST(OperatorComplement, evaluateShouldReturnCorrectValuesWhenEmptyInput) {
@@ -27,7 +27,7 @@ TEST(OperatorComplement, evaluateShouldReturnCorrectValuesWhenEmptyInput) {
    const Complement under_test(
       std::make_unique<IndexScan>(CopyOnWriteBitmap{&test_bitmap}, row_layout), row_layout
    );
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({0, 1, 2}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({0, 1, 2}));
 }
 
 TEST(OperatorComplement, evaluateShouldReturnCorrectValuesWhenEmptyDatabase) {
@@ -37,7 +37,7 @@ TEST(OperatorComplement, evaluateShouldReturnCorrectValuesWhenEmptyDatabase) {
    const Complement under_test(
       std::make_unique<IndexScan>(CopyOnWriteBitmap{&test_bitmap}, row_layout), row_layout
    );
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({}));
 }
 
 TEST(OperatorComplement, evaluateShouldReturnCorrectValuesWhenFullInput) {
@@ -47,7 +47,7 @@ TEST(OperatorComplement, evaluateShouldReturnCorrectValuesWhenFullInput) {
    const Complement under_test(
       std::make_unique<IndexScan>(CopyOnWriteBitmap{&test_bitmap}, row_layout), row_layout
    );
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({}));
 }
 
 TEST(OperatorComplement, evaluateShouldReturnCorrectValuesWhenSingleInput) {
@@ -57,7 +57,7 @@ TEST(OperatorComplement, evaluateShouldReturnCorrectValuesWhenSingleInput) {
    const Complement under_test(
       std::make_unique<IndexScan>(CopyOnWriteBitmap{&test_bitmap}, row_layout), row_layout
    );
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({0, 2, 3, 4}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({0, 2, 3, 4}));
 }
 
 TEST(OperatorComplement, correctTypeInfo) {

--- a/src/silo/query_engine/filter/operators/empty.test.cpp
+++ b/src/silo/query_engine/filter/operators/empty.test.cpp
@@ -8,7 +8,7 @@ using silo::storage::column::RowLayout;
 
 TEST(OperatorEmpty, evaluateShouldReturnNoValues) {
    const Empty under_test(RowLayout::of(1));
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring());
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring());
 }
 
 TEST(OperatorEmpty, correctTypeInfo) {

--- a/src/silo/query_engine/filter/operators/full.test.cpp
+++ b/src/silo/query_engine/filter/operators/full.test.cpp
@@ -8,12 +8,12 @@ using silo::storage::column::RowLayout;
 
 TEST(OperatorFull, containsCheckShouldReturnCorrectValues) {
    const Full under_test(RowLayout::of(5));
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({0, 1, 2, 3, 4}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({0, 1, 2, 3, 4}));
 }
 
 TEST(OperatorFull, containsCheckShouldReturnCorrectValuesWhenEmptyDatabase) {
    const Full under_test(RowLayout::of());
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring());
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring());
 }
 
 TEST(OperatorFull, correctTypeInfo) {

--- a/src/silo/query_engine/filter/operators/index_scan.cpp
+++ b/src/silo/query_engine/filter/operators/index_scan.cpp
@@ -32,7 +32,7 @@ std::string IndexScan::toString() const {
    return fmt::format(
       "IndexScan(Logical Equivalent: {}, Cardinality: {})",
       logical_equivalent ? logical_equivalent.value()->toString() : "undefined",
-      std::to_string(bitmap.getConstReference().cardinality())
+      std::to_string(bitmap.cardinality())
    );
 }
 

--- a/src/silo/query_engine/filter/operators/index_scan.test.cpp
+++ b/src/silo/query_engine/filter/operators/index_scan.test.cpp
@@ -13,7 +13,7 @@ using silo::storage::column::RowLayout;
 TEST(OperatorIndexScan, evaluateShouldReturnCorrectValues) {
    const roaring::Roaring test_bitmap(roaring::Roaring({1, 3}));
    const IndexScan under_test(CopyOnWriteBitmap{&test_bitmap}, RowLayout::of(5));
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({1, 3}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({1, 3}));
 }
 
 TEST(OperatorIndexScan, correctTypeInfo) {

--- a/src/silo/query_engine/filter/operators/intersection.cpp
+++ b/src/silo/query_engine/filter/operators/intersection.cpp
@@ -56,24 +56,6 @@ Type Intersection::type() const {
    return INTERSECTION;
 }
 
-namespace {
-
-CopyOnWriteBitmap intersectTwo(CopyOnWriteBitmap first, CopyOnWriteBitmap second) {
-   CopyOnWriteBitmap result;
-   if (first.isMutable()) {
-      result = std::move(first);
-      result.getMutable() &= second.getConstReference();
-   } else if (second.isMutable()) {
-      result = std::move(second);
-      result.getMutable() &= first.getConstReference();
-   } else {
-      result = CopyOnWriteBitmap(first.getConstReference() & second.getConstReference());
-   }
-   return result;
-}
-
-}  // namespace
-
 CopyOnWriteBitmap Intersection::evaluate() const {
    EVOBENCH_SCOPE("Intersection", "evaluate");
    std::vector<CopyOnWriteBitmap> children_bm;
@@ -92,34 +74,33 @@ CopyOnWriteBitmap Intersection::evaluate() const {
    std::ranges::sort(
       children_bm,
       [](const CopyOnWriteBitmap& expression1, const CopyOnWriteBitmap& expression2) {
-         return expression1.getConstReference().cardinality() <
-                expression2.getConstReference().cardinality();
+         return expression1.cardinality() < expression2.cardinality();
       }
    );
    // Sort negated children descending by size
    std::ranges::sort(
       negated_children_bm,
       [](const CopyOnWriteBitmap& expression_result1, const CopyOnWriteBitmap& expression_result2) {
-         return expression_result1.getConstReference().cardinality() >
-                expression_result2.getConstReference().cardinality();
+         return expression_result1.cardinality() > expression_result2.cardinality();
       }
    );
 
    // children_bm > 0 as asserted in constructor
    if (children_bm.size() == 1) {
       // negated_children_bm cannot be empty because of size assertion in constructor
-      CopyOnWriteBitmap& result = children_bm[0];
+      CopyOnWriteBitmap result = std::move(children_bm[0]);
       for (auto& neg_bm : negated_children_bm) {
-         result.getMutable() -= neg_bm.getConstReference();
+         result -= neg_bm;
       }
-      return std::move(result);
+      return result;
    }
-   auto result = intersectTwo(std::move(children_bm[0]), std::move(children_bm[1]));
-   for (uint32_t i = 2; i < children.size(); i++) {
-      result.getMutable() &= children_bm[i].getConstReference();
+   CopyOnWriteBitmap result = std::move(children_bm[0]);
+   result &= children_bm[1];
+   for (uint32_t i = 2; i < children_bm.size(); i++) {
+      result &= children_bm[i];
    }
    for (auto& neg_bm : negated_children_bm) {
-      result.getMutable() -= neg_bm.getConstReference();
+      result -= neg_bm;
    }
    return result;
 }

--- a/src/silo/query_engine/filter/operators/intersection.test.cpp
+++ b/src/silo/query_engine/filter/operators/intersection.test.cpp
@@ -73,7 +73,7 @@ TEST(OperatorIntersection, evaluateShouldReturnCorrectValuesNoNegated) {
    OperatorVector non_negated = generateTestInput(test_bitmaps, row_layout);
    OperatorVector negated;
    const Intersection under_test(std::move(non_negated), std::move(negated), row_layout);
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({1, 3}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({1, 3}));
 }
 
 TEST(OperatorIntersection, evaluateShouldReturnCorrectValues) {
@@ -88,7 +88,7 @@ TEST(OperatorIntersection, evaluateShouldReturnCorrectValues) {
    OperatorVector non_negated = generateTestInput(test_bitmaps, row_layout);
    OperatorVector negated = generateTestInput(test_negated_bitmaps, row_layout);
    const Intersection under_test(std::move(non_negated), std::move(negated), row_layout);
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({1}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({1}));
 }
 
 TEST(OperatorIntersection, evaluateShouldReturnCorrectValuesManyNegated) {
@@ -104,7 +104,7 @@ TEST(OperatorIntersection, evaluateShouldReturnCorrectValuesManyNegated) {
    OperatorVector non_negated = generateTestInput(test_bitmaps, row_layout);
    OperatorVector negated = generateTestInput(test_negated_bitmaps, row_layout);
    const Intersection under_test(std::move(non_negated), std::move(negated), row_layout);
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({1}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({1}));
 }
 
 TEST(OperatorIntersection, evaluateShouldReturnCorrectValuesEmptyInput) {
@@ -119,7 +119,7 @@ TEST(OperatorIntersection, evaluateShouldReturnCorrectValuesEmptyInput) {
    OperatorVector non_negated = generateTestInput(test_bitmaps, row_layout);
    OperatorVector negated = generateTestInput(test_negated_bitmaps, row_layout);
    const Intersection under_test(std::move(non_negated), std::move(negated), row_layout);
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring());
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring());
 }
 
 TEST(OperatorIntersection, correctTypeInfo) {

--- a/src/silo/query_engine/filter/operators/is_in_covered_region.test.cpp
+++ b/src/silo/query_engine/filter/operators/is_in_covered_region.test.cpp
@@ -51,9 +51,9 @@ TEST(IsInCoveredRegion, containsCheckShouldReturnCorrectValues) {
       std::make_unique<IsInCoveredRegion>(&coverage_index, 2, Comparator::IS_COVERED),
       RowLayout::of(coverage_index.start_end.at(0).size())
    );
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({1, 3, 4, 5, 6}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({1, 3, 4, 5, 6}));
    auto negated = Selection::negate(std::move(under_test));
-   ASSERT_EQ(negated->evaluate().getConstReference(), roaring::Roaring({0, 2, 7}));
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring({0, 2, 7}));
 }
 
 TEST(IsInCoveredRegion, notContainsCheckShouldReturnCorrectValues) {
@@ -95,7 +95,7 @@ TEST(IsInCoveredRegion, notContainsCheckShouldReturnCorrectValues) {
       std::make_unique<IsInCoveredRegion>(&coverage_index, 2, Comparator::IS_NOT_COVERED),
       RowLayout::of(coverage_index.start_end.at(0).size())
    );
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({0, 2, 7}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({0, 2, 7}));
    auto negated = Selection::negate(std::move(under_test));
-   ASSERT_EQ(negated->evaluate().getConstReference(), roaring::Roaring({1, 3, 4, 5, 6}));
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring({1, 3, 4, 5, 6}));
 }

--- a/src/silo/query_engine/filter/operators/range_selection.test.cpp
+++ b/src/silo/query_engine/filter/operators/range_selection.test.cpp
@@ -16,9 +16,9 @@ TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValues) {
    );
 
    auto under_test = std::make_unique<RangeSelection>(std::move(test_ranges), row_layout);
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({0, 1, 3, 4}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({0, 1, 3, 4}));
    auto negated = RangeSelection::negate(std::move(under_test));
-   ASSERT_EQ(negated->evaluate().getConstReference(), roaring::Roaring({2, 5, 6, 7}));
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring({2, 5, 6, 7}));
 }
 
 TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValuesEmptyDatabase) {
@@ -26,9 +26,9 @@ TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValuesEmptyDatabase) {
    const auto row_layout = RowLayout::of();
 
    auto under_test = std::make_unique<RangeSelection>(std::move(test_ranges), row_layout);
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring());
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring());
    auto negated = RangeSelection::negate(std::move(under_test));
-   ASSERT_EQ(negated->evaluate().getConstReference(), roaring::Roaring());
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring());
 }
 
 TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValuesEmptyRanges) {
@@ -39,11 +39,9 @@ TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValuesEmptyRanges) {
    const auto row_layout = RowLayout::of(9);
 
    auto under_test = std::make_unique<RangeSelection>(std::move(test_ranges), row_layout);
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring());
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring());
    auto negated = RangeSelection::negate(std::move(under_test));
-   ASSERT_EQ(
-      negated->evaluate().getConstReference(), roaring::Roaring({0, 1, 2, 3, 4, 5, 6, 7, 8})
-   );
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring({0, 1, 2, 3, 4, 5, 6, 7, 8}));
 }
 
 TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValuesFullRange) {
@@ -55,11 +53,9 @@ TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValuesFullRange) {
    }}});
 
    auto under_test = std::make_unique<RangeSelection>(std::move(test_ranges), row_layout);
-   ASSERT_EQ(
-      under_test->evaluate().getConstReference(), roaring::Roaring({0, 1, 2, 3, 4, 5, 6, 7})
-   );
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({0, 1, 2, 3, 4, 5, 6, 7}));
    auto negated = RangeSelection::negate(std::move(under_test));
-   ASSERT_EQ(negated->evaluate().getConstReference(), roaring::Roaring());
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring());
 }
 
 TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValuesMeetingRanges) {
@@ -70,9 +66,9 @@ TEST(OperatorRangeSelection, evaluateShouldReturnCorrectValuesMeetingRanges) {
    const auto row_layout = RowLayout::of(9);
 
    auto under_test = std::make_unique<RangeSelection>(std::move(test_ranges), row_layout);
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({0, 1, 2, 3}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({0, 1, 2, 3}));
    auto negated = RangeSelection::negate(std::move(under_test));
-   ASSERT_EQ(negated->evaluate().getConstReference(), roaring::Roaring({4, 5, 6, 7, 8}));
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring({4, 5, 6, 7, 8}));
 }
 
 TEST(OperatorRangeSelection, evaluateExpandsRangeSpanningMultipleChunks) {
@@ -95,7 +91,7 @@ TEST(OperatorRangeSelection, evaluateExpandsRangeSpanningMultipleChunks) {
       RowId{.chunk_id = 2, .row_in_chunk = 0}.toGlobal(),  // partial last chunk
       RowId{.chunk_id = 2, .row_in_chunk = 1}.toGlobal(),
    });
-   ASSERT_EQ(under_test->evaluate().getConstReference(), expected);
+   ASSERT_EQ(under_test->evaluate().toRoaring(), expected);
 
    // The complement covers every other valid row id, including the cross-chunk ranges at the edges.
    auto negated = RangeSelection::negate(std::move(under_test));
@@ -106,7 +102,7 @@ TEST(OperatorRangeSelection, evaluateExpandsRangeSpanningMultipleChunks) {
       RowId{.chunk_id = 2, .row_in_chunk = 3}.toGlobal(),
       RowId{.chunk_id = 2, .row_in_chunk = 4}.toGlobal(),
    });
-   ASSERT_EQ(negated->evaluate().getConstReference(), expected_negated);
+   ASSERT_EQ(negated->evaluate().toRoaring(), expected_negated);
 }
 
 TEST(OperatorRangeSelection, returnsCorrectTypeInfo) {

--- a/src/silo/query_engine/filter/operators/selection.cpp
+++ b/src/silo/query_engine/filter/operators/selection.cpp
@@ -96,24 +96,24 @@ CopyOnWriteBitmap Selection::evaluate() const {
 
    // Build the candidate rows that already satisfy the most selective predicate. Predicates are
    // sorted most-selective-first at construction
-   roaring::Roaring candidates;
+   CopyOnWriteBitmap candidates;
    if (child_operator.has_value()) {
-      CopyOnWriteBitmap child_result = (*child_operator)->evaluate();
+      CopyOnWriteBitmap child_bitmap = (*child_operator)->evaluate();
       // For a small child, matching each of its rows against every predicate is cheaper than
       // materializing the first predicate over the whole partition.
-      if (child_result.getConstReference().cardinality() <= row_layout.numRows() / 10) {
+      if (child_bitmap.cardinality() <= row_layout.numRows() / 10) {
          roaring::Roaring result;
-         for (const uint32_t row : child_result.getConstReference()) {
+         for (const uint32_t row : child_bitmap) {
             if (matchesPredicates(predicates, row)) {
                result.add(row);
             }
          }
          return CopyOnWriteBitmap{std::move(result)};
       }
-      candidates = std::move(child_result.getMutable());
-      candidates &= predicates.front()->makeBitmap(row_layout);
+      candidates = std::move(child_bitmap);
+      candidates &= CopyOnWriteBitmap{predicates.front()->makeBitmap(row_layout)};
    } else {
-      candidates = predicates.front()->makeBitmap(row_layout);
+      candidates = CopyOnWriteBitmap{predicates.front()->makeBitmap(row_layout)};
    }
 
    // `candidates` already satisfies predicates.front(); apply the remaining predicates row by row.

--- a/src/silo/query_engine/filter/operators/selection.test.cpp
+++ b/src/silo/query_engine/filter/operators/selection.test.cpp
@@ -45,9 +45,9 @@ TEST(OperatorSelection, equalsShouldReturnCorrectValues) {
       row_layout
    );
 
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({1, 5, 6, 7, 8, 9}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({1, 5, 6, 7, 8, 9}));
    auto negated = Selection::negate(std::move(under_test));
-   ASSERT_EQ(negated->evaluate().getConstReference(), roaring::Roaring({0, 2, 3, 4}));
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring({0, 2, 3, 4}));
 }
 
 TEST(OperatorSelection, notEqualsShouldReturnCorrectValues) {
@@ -60,9 +60,9 @@ TEST(OperatorSelection, notEqualsShouldReturnCorrectValues) {
       row_layout
    );
 
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({0, 2, 3, 4}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({0, 2, 3, 4}));
    auto negated = Selection::negate(std::move(under_test));
-   ASSERT_EQ(negated->evaluate().getConstReference(), roaring::Roaring({1, 5, 6, 7, 8, 9}));
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring({1, 5, 6, 7, 8, 9}));
 }
 
 TEST(OperatorSelection, lessShouldReturnCorrectValues) {
@@ -75,11 +75,9 @@ TEST(OperatorSelection, lessShouldReturnCorrectValues) {
       row_layout
    );
 
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({0}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({0}));
    auto negated = Selection::negate(std::move(under_test));
-   ASSERT_EQ(
-      negated->evaluate().getConstReference(), roaring::Roaring({1, 2, 3, 4, 5, 6, 7, 8, 9})
-   );
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring({1, 2, 3, 4, 5, 6, 7, 8, 9}));
 }
 
 TEST(OperatorSelection, lessOrEqualsShouldReturnCorrectValues) {
@@ -94,9 +92,9 @@ TEST(OperatorSelection, lessOrEqualsShouldReturnCorrectValues) {
       row_layout
    );
 
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({0, 1, 5, 6, 7, 8, 9}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({0, 1, 5, 6, 7, 8, 9}));
    auto negated = Selection::negate(std::move(under_test));
-   ASSERT_EQ(negated->evaluate().getConstReference(), roaring::Roaring({2, 3, 4}));
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring({2, 3, 4}));
 }
 
 TEST(OperatorSelection, higherOrEqualsShouldReturnCorrectValues) {
@@ -111,11 +109,9 @@ TEST(OperatorSelection, higherOrEqualsShouldReturnCorrectValues) {
       row_layout
    );
 
-   ASSERT_EQ(
-      under_test->evaluate().getConstReference(), roaring::Roaring({1, 2, 3, 4, 5, 6, 7, 8, 9})
-   );
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({1, 2, 3, 4, 5, 6, 7, 8, 9}));
    auto negated = Selection::negate(std::move(under_test));
-   ASSERT_EQ(negated->evaluate().getConstReference(), roaring::Roaring({0}));
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring({0}));
 }
 
 TEST(OperatorSelection, higherShouldReturnCorrectValues) {
@@ -128,9 +124,9 @@ TEST(OperatorSelection, higherShouldReturnCorrectValues) {
       row_layout
    );
 
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({2, 3, 4}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({2, 3, 4}));
    auto negated = Selection::negate(std::move(under_test));
-   ASSERT_EQ(negated->evaluate().getConstReference(), roaring::Roaring({0, 1, 5, 6, 7, 8, 9}));
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring({0, 1, 5, 6, 7, 8, 9}));
 }
 
 TEST(OperatorSelection, correctWithNegativeNumbers) {
@@ -143,7 +139,7 @@ TEST(OperatorSelection, correctWithNegativeNumbers) {
       row_layout
    );
 
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({1, 5, 6, 7, 8, 9}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({1, 5, 6, 7, 8, 9}));
 }
 
 TEST(OperatorSelection, returnsCorrectTypeInfo) {
@@ -197,7 +193,7 @@ TEST(OperatorSelection, multiplePredicatesWithoutChildReturnCorrectValues) {
 
    const Selection under_test(makeRangePredicates(test_column), row_layout);
 
-   ASSERT_EQ(under_test.evaluate().getConstReference(), rangeBitmap(10, 50));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), rangeBitmap(10, 50));
 }
 
 TEST(OperatorSelection, multiplePredicatesWithLargeChildReturnCorrectValues) {
@@ -214,7 +210,7 @@ TEST(OperatorSelection, multiplePredicatesWithLargeChildReturnCorrectValues) {
    const Selection under_test(std::move(child), makeRangePredicates(test_column), row_layout);
 
    // child [5, 80) intersected with [10, 50) == [10, 50).
-   ASSERT_EQ(under_test.evaluate().getConstReference(), rangeBitmap(10, 50));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), rangeBitmap(10, 50));
 }
 
 TEST(OperatorSelection, multiplePredicatesWithSmallChildReturnCorrectValues) {
@@ -230,5 +226,5 @@ TEST(OperatorSelection, multiplePredicatesWithSmallChildReturnCorrectValues) {
 
    const Selection under_test(std::move(child), makeRangePredicates(test_column), row_layout);
 
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({15, 45}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({15, 45}));
 }

--- a/src/silo/query_engine/filter/operators/string_in_set.test.cpp
+++ b/src/silo/query_engine/filter/operators/string_in_set.test.cpp
@@ -62,7 +62,7 @@ TEST(OperatorStringInSet, matchReturnsCorrectValuesForStringColumn) {
       row_layout
    );
 
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({0, 1, 3, 5}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({0, 1, 3, 5}));
 }
 
 TEST(OperatorStringInSet, matchReturnsCorrectValuesForDictionaryEncodedColumn) {
@@ -81,7 +81,7 @@ TEST(OperatorStringInSet, matchReturnsCorrectValuesForDictionaryEncodedColumn) {
       row_layout
    );
 
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({0, 1, 3, 5}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({0, 1, 3, 5}));
 }
 
 TEST(OperatorStringInSet, matchReturnsEmptyForNoMatches) {
@@ -100,7 +100,7 @@ TEST(OperatorStringInSet, matchReturnsEmptyForNoMatches) {
       row_layout
    );
 
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring());
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring());
 }
 
 TEST(OperatorStringInSet, matchReturnsEmptyForEmptySet) {
@@ -117,7 +117,7 @@ TEST(OperatorStringInSet, matchReturnsEmptyForEmptySet) {
       row_layout
    );
 
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring());
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring());
 }
 
 TEST(OperatorStringInSet, negationWorksCorrectly) {
@@ -136,10 +136,10 @@ TEST(OperatorStringInSet, negationWorksCorrectly) {
       row_layout
    );
 
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({0, 1, 3, 5}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({0, 1, 3, 5}));
 
    auto negated = Selection::negate(std::move(under_test));
-   ASSERT_EQ(negated->evaluate().getConstReference(), roaring::Roaring({2, 4}));
+   ASSERT_EQ(negated->evaluate().toRoaring(), roaring::Roaring({2, 4}));
 }
 
 TEST(OperatorStringInSet, notInComparatorWorksCorrectly) {
@@ -158,7 +158,7 @@ TEST(OperatorStringInSet, notInComparatorWorksCorrectly) {
       row_layout
    );
 
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({2, 4}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({2, 4}));
 }
 
 TEST(OperatorStringInSet, toStringReturnsCorrectFormat) {
@@ -213,7 +213,7 @@ TEST(OperatorStringInSet, matchSingleValue) {
       row_layout
    );
 
-   ASSERT_EQ(under_test->evaluate().getConstReference(), roaring::Roaring({0, 3}));
+   ASSERT_EQ(under_test->evaluate().toRoaring(), roaring::Roaring({0, 3}));
 }
 
 TEST(OperatorStringInSet, returnsCorrectTypeInfo) {

--- a/src/silo/query_engine/filter/operators/threshold.cpp
+++ b/src/silo/query_engine/filter/operators/threshold.cpp
@@ -71,11 +71,10 @@ CopyOnWriteBitmap Threshold::evaluate() const {
       dp_table_size = number_of_matchers;
    }
    std::vector<roaring::Roaring> bitmaps(dp_table_size);
-   // Copy bitmap of first child if immutable, otherwise use it directly
    if (non_negated_children.empty()) {
-      bitmaps[0] = negated_children[0]->evaluate().getConstReference();
+      bitmaps[0] = negated_children[0]->evaluate().toRoaring();
    } else {
-      bitmaps[0] = non_negated_children[0]->evaluate().getConstReference();
+      bitmaps[0] = non_negated_children[0]->evaluate().toRoaring();
    }
 
    if (non_negated_children.empty()) {
@@ -92,16 +91,16 @@ CopyOnWriteBitmap Threshold::evaluate() const {
    );  // Number of loop iterations
 
    for (int i = 1; i < non_negated_child_count; ++i) {
-      const auto bitmap = non_negated_children[i]->evaluate();
+      const roaring::Roaring bitmap = non_negated_children[i]->evaluate().toRoaring();
       // positions higher than (i-1) cannot have been reached yet, are therefore all 0s and the
       // conjunction would return 0
       // positions lower than n - k + i - 1 are unable to affect the result, because only (k - i)
       // iterations are left
       for (int j = std::min(max_table_index, i); j > std::max(0, n - k + i - 1); --j) {
-         bitmaps[j] |= bitmaps[j - 1] & bitmap.getConstReference();
+         bitmaps[j] |= bitmaps[j - 1] & bitmap;
       }
       if (k - i > n - 1) {
-         bitmaps[0] |= bitmap.getConstReference();
+         bitmaps[0] |= bitmap;
       }
    }
 
@@ -113,18 +112,18 @@ CopyOnWriteBitmap Threshold::evaluate() const {
    // (Number of children left is less than the distance we need to cross to reach the result)
    const int took_first_offset = non_negated_children.empty() ? 1 : 0;
    for (int local_i = took_first_offset; local_i < negated_child_count; ++local_i) {
-      auto bitmap = negated_children[local_i]->evaluate();
+      roaring::Roaring bitmap = negated_children[local_i]->evaluate().toRoaring();
       const int i = local_i + non_negated_child_count;
       // positions higher than (i-1) cannot have been reached yet, are therefore all 0s and the
       // conjunction would return 0
       // positions lower than (n-1) - (k-i) are unable to affect the result, because only (k-i)
       // iterations are left
       for (int j = std::min(max_table_index, i); j > std::max(0, n - k + i - 1); --j) {
-         bitmaps[j] |= bitmaps[j - 1] - bitmap.getConstReference();
+         bitmaps[j] |= bitmaps[j - 1] - bitmap;
       }
       if (k - i > n - 1) {
-         row_layout.complementInPlace(bitmap.getMutable());
-         bitmaps[0] |= bitmap.getConstReference();
+         row_layout.complementInPlace(bitmap);
+         bitmaps[0] |= bitmap;
       }
    }
    // NOLINTEND(readability-identifier-length)

--- a/src/silo/query_engine/filter/operators/threshold.test.cpp
+++ b/src/silo/query_engine/filter/operators/threshold.test.cpp
@@ -46,12 +46,12 @@ TEST(OperatorThreshold, evaluatesCorrectOnlyNegated) {
    const Threshold under_test_1_exact(
       OperatorVector(), generateTestInput(test_negated_bitmaps, row_layout), 1, true, row_layout
    );
-   ASSERT_EQ(under_test_1_exact.evaluate().getConstReference(), roaring::Roaring({2}));
+   ASSERT_EQ(under_test_1_exact.evaluate().toRoaring(), roaring::Roaring({2}));
 
    const Threshold under_test_1_or_more(
       OperatorVector(), generateTestInput(test_negated_bitmaps, row_layout), 1, false, row_layout
    );
-   ASSERT_EQ(under_test_1_or_more.evaluate().getConstReference(), roaring::Roaring({0, 2}));
+   ASSERT_EQ(under_test_1_or_more.evaluate().toRoaring(), roaring::Roaring({0, 2}));
 }
 
 TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesNoNegated) {
@@ -63,22 +63,22 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesNoNegated) {
    const Threshold under_test_1_exact(
       generateTestInput(test_bitmaps, row_layout), OperatorVector(), 1, true, row_layout
    );
-   ASSERT_EQ(under_test_1_exact.evaluate().getConstReference(), roaring::Roaring({}));
+   ASSERT_EQ(under_test_1_exact.evaluate().toRoaring(), roaring::Roaring({}));
 
    const Threshold under_test_2_exact(
       generateTestInput(test_bitmaps, row_layout), OperatorVector(), 2, true, row_layout
    );
-   ASSERT_EQ(under_test_2_exact.evaluate().getConstReference(), roaring::Roaring({2, 3}));
+   ASSERT_EQ(under_test_2_exact.evaluate().toRoaring(), roaring::Roaring({2, 3}));
 
    const Threshold under_test_1_or_more(
       generateTestInput(test_bitmaps, row_layout), OperatorVector(), 1, false, row_layout
    );
-   ASSERT_EQ(under_test_1_or_more.evaluate().getConstReference(), roaring::Roaring({1, 2, 3}));
+   ASSERT_EQ(under_test_1_or_more.evaluate().toRoaring(), roaring::Roaring({1, 2, 3}));
 
    const Threshold under_test_2_or_more(
       generateTestInput(test_bitmaps, row_layout), OperatorVector(), 2, false, row_layout
    );
-   ASSERT_EQ(under_test_2_or_more.evaluate().getConstReference(), roaring::Roaring({1, 2, 3}));
+   ASSERT_EQ(under_test_2_or_more.evaluate().toRoaring(), roaring::Roaring({1, 2, 3}));
 }
 
 TEST(OperatorThreshold, evaluateShouldReturnCorrectValues) {
@@ -97,7 +97,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValues) {
       true,
       row_layout
    );
-   ASSERT_EQ(under_test_1_exact.evaluate().getConstReference(), roaring::Roaring({}));
+   ASSERT_EQ(under_test_1_exact.evaluate().toRoaring(), roaring::Roaring({}));
 
    const Threshold under_test_2_exact(
       generateTestInput(test_bitmaps, row_layout),
@@ -106,7 +106,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValues) {
       true,
       row_layout
    );
-   ASSERT_EQ(under_test_2_exact.evaluate().getConstReference(), roaring::Roaring({0}));
+   ASSERT_EQ(under_test_2_exact.evaluate().toRoaring(), roaring::Roaring({0}));
 
    const Threshold under_test_3_exact(
       generateTestInput(test_bitmaps, row_layout),
@@ -115,7 +115,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValues) {
       true,
       row_layout
    );
-   ASSERT_EQ(under_test_3_exact.evaluate().getConstReference(), roaring::Roaring({}));
+   ASSERT_EQ(under_test_3_exact.evaluate().toRoaring(), roaring::Roaring({}));
 
    const Threshold under_test_4_exact(
       generateTestInput(test_bitmaps, row_layout),
@@ -124,7 +124,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValues) {
       true,
       row_layout
    );
-   ASSERT_EQ(under_test_4_exact.evaluate().getConstReference(), roaring::Roaring({2, 3}));
+   ASSERT_EQ(under_test_4_exact.evaluate().toRoaring(), roaring::Roaring({2, 3}));
 
    const Threshold under_test_1_or_more(
       generateTestInput(test_bitmaps, row_layout),
@@ -133,7 +133,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValues) {
       false,
       row_layout
    );
-   ASSERT_EQ(under_test_1_or_more.evaluate().getConstReference(), roaring::Roaring({0, 1, 2, 3}));
+   ASSERT_EQ(under_test_1_or_more.evaluate().toRoaring(), roaring::Roaring({0, 1, 2, 3}));
 
    const Threshold under_test_2_or_more(
       generateTestInput(test_bitmaps, row_layout),
@@ -142,7 +142,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValues) {
       false,
       row_layout
    );
-   ASSERT_EQ(under_test_2_or_more.evaluate().getConstReference(), roaring::Roaring({0, 1, 2, 3}));
+   ASSERT_EQ(under_test_2_or_more.evaluate().toRoaring(), roaring::Roaring({0, 1, 2, 3}));
 
    const Threshold under_test_3_or_more(
       generateTestInput(test_bitmaps, row_layout),
@@ -151,7 +151,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValues) {
       false,
       row_layout
    );
-   ASSERT_EQ(under_test_3_or_more.evaluate().getConstReference(), roaring::Roaring({1, 2, 3}));
+   ASSERT_EQ(under_test_3_or_more.evaluate().toRoaring(), roaring::Roaring({1, 2, 3}));
 
    const Threshold under_test_4_or_more(
       generateTestInput(test_bitmaps, row_layout),
@@ -160,7 +160,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValues) {
       false,
       row_layout
    );
-   ASSERT_EQ(under_test_4_or_more.evaluate().getConstReference(), roaring::Roaring({1, 2, 3}));
+   ASSERT_EQ(under_test_4_or_more.evaluate().toRoaring(), roaring::Roaring({1, 2, 3}));
 }
 
 TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesManyNegated) {
@@ -180,7 +180,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesManyNegated) {
       true,
       row_layout
    );
-   ASSERT_EQ(under_test_1_exact.evaluate().getConstReference(), roaring::Roaring({}));
+   ASSERT_EQ(under_test_1_exact.evaluate().toRoaring(), roaring::Roaring({}));
 
    const Threshold under_test_2_exact(
       generateTestInput(test_bitmaps, row_layout),
@@ -189,7 +189,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesManyNegated) {
       true,
       row_layout
    );
-   ASSERT_EQ(under_test_2_exact.evaluate().getConstReference(), roaring::Roaring({4}));
+   ASSERT_EQ(under_test_2_exact.evaluate().toRoaring(), roaring::Roaring({4}));
 
    const Threshold under_test_3_exact(
       generateTestInput(test_bitmaps, row_layout),
@@ -198,7 +198,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesManyNegated) {
       true,
       row_layout
    );
-   ASSERT_EQ(under_test_3_exact.evaluate().getConstReference(), roaring::Roaring({}));
+   ASSERT_EQ(under_test_3_exact.evaluate().toRoaring(), roaring::Roaring({}));
 
    const Threshold under_test_4_exact(
       generateTestInput(test_bitmaps, row_layout),
@@ -207,7 +207,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesManyNegated) {
       true,
       row_layout
    );
-   ASSERT_EQ(under_test_4_exact.evaluate().getConstReference(), roaring::Roaring({0, 2, 3}));
+   ASSERT_EQ(under_test_4_exact.evaluate().toRoaring(), roaring::Roaring({0, 2, 3}));
 
    const Threshold under_test_1_or_more(
       generateTestInput(test_bitmaps, row_layout),
@@ -216,9 +216,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesManyNegated) {
       false,
       row_layout
    );
-   ASSERT_EQ(
-      under_test_1_or_more.evaluate().getConstReference(), roaring::Roaring({0, 1, 2, 3, 4})
-   );
+   ASSERT_EQ(under_test_1_or_more.evaluate().toRoaring(), roaring::Roaring({0, 1, 2, 3, 4}));
 
    const Threshold under_test_2_or_more(
       generateTestInput(test_bitmaps, row_layout),
@@ -227,9 +225,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesManyNegated) {
       false,
       row_layout
    );
-   ASSERT_EQ(
-      under_test_2_or_more.evaluate().getConstReference(), roaring::Roaring({0, 1, 2, 3, 4})
-   );
+   ASSERT_EQ(under_test_2_or_more.evaluate().toRoaring(), roaring::Roaring({0, 1, 2, 3, 4}));
 
    const Threshold under_test_3_or_more(
       generateTestInput(test_bitmaps, row_layout),
@@ -238,7 +234,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesManyNegated) {
       false,
       row_layout
    );
-   ASSERT_EQ(under_test_3_or_more.evaluate().getConstReference(), roaring::Roaring({0, 1, 2, 3}));
+   ASSERT_EQ(under_test_3_or_more.evaluate().toRoaring(), roaring::Roaring({0, 1, 2, 3}));
 
    const Threshold under_test_4_or_more(
       generateTestInput(test_bitmaps, row_layout),
@@ -247,7 +243,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesManyNegated) {
       false,
       row_layout
    );
-   ASSERT_EQ(under_test_4_or_more.evaluate().getConstReference(), roaring::Roaring({0, 1, 2, 3}));
+   ASSERT_EQ(under_test_4_or_more.evaluate().toRoaring(), roaring::Roaring({0, 1, 2, 3}));
 }
 
 TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesEmptyInput) {
@@ -266,7 +262,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesEmptyInput) {
       true,
       row_layout
    );
-   ASSERT_EQ(under_test_1_exact.evaluate().getConstReference(), roaring::Roaring({4}));
+   ASSERT_EQ(under_test_1_exact.evaluate().toRoaring(), roaring::Roaring({4}));
 
    const Threshold under_test_2_exact(
       generateTestInput(test_bitmaps, row_layout),
@@ -275,7 +271,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesEmptyInput) {
       true,
       row_layout
    );
-   ASSERT_EQ(under_test_2_exact.evaluate().getConstReference(), roaring::Roaring({2, 3}));
+   ASSERT_EQ(under_test_2_exact.evaluate().toRoaring(), roaring::Roaring({2, 3}));
 
    const Threshold under_test_3_exact(
       generateTestInput(test_bitmaps, row_layout),
@@ -284,7 +280,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesEmptyInput) {
       true,
       row_layout
    );
-   ASSERT_EQ(under_test_3_exact.evaluate().getConstReference(), roaring::Roaring({0, 1}));
+   ASSERT_EQ(under_test_3_exact.evaluate().toRoaring(), roaring::Roaring({0, 1}));
 
    const Threshold under_test_1_or_more(
       generateTestInput(test_bitmaps, row_layout),
@@ -293,9 +289,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesEmptyInput) {
       false,
       row_layout
    );
-   ASSERT_EQ(
-      under_test_1_or_more.evaluate().getConstReference(), roaring::Roaring({0, 1, 2, 3, 4})
-   );
+   ASSERT_EQ(under_test_1_or_more.evaluate().toRoaring(), roaring::Roaring({0, 1, 2, 3, 4}));
 
    const Threshold under_test_2_or_more(
       generateTestInput(test_bitmaps, row_layout),
@@ -304,7 +298,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesEmptyInput) {
       false,
       row_layout
    );
-   ASSERT_EQ(under_test_2_or_more.evaluate().getConstReference(), roaring::Roaring({0, 1, 2, 3}));
+   ASSERT_EQ(under_test_2_or_more.evaluate().toRoaring(), roaring::Roaring({0, 1, 2, 3}));
 
    const Threshold under_test_3_or_more(
       generateTestInput(test_bitmaps, row_layout),
@@ -313,7 +307,7 @@ TEST(OperatorThreshold, evaluateShouldReturnCorrectValuesEmptyInput) {
       false,
       row_layout
    );
-   ASSERT_EQ(under_test_3_or_more.evaluate().getConstReference(), roaring::Roaring({0, 1}));
+   ASSERT_EQ(under_test_3_or_more.evaluate().toRoaring(), roaring::Roaring({0, 1}));
 }
 
 TEST(OperatorThreshold, correctTypeInfo) {

--- a/src/silo/query_engine/filter/operators/union.cpp
+++ b/src/silo/query_engine/filter/operators/union.cpp
@@ -33,15 +33,12 @@ Type Union::type() const {
 
 CopyOnWriteBitmap Union::evaluate() const {
    EVOBENCH_SCOPE("Union", "evaluate");
-   const uint32_t size_of_children = children.size();
-   std::vector<const roaring::Roaring*> union_tmp(size_of_children);
-   std::vector<CopyOnWriteBitmap> child_res(size_of_children);
-   for (uint32_t i = 0; i < size_of_children; i++) {
-      child_res[i] = children[i]->evaluate();
-      const roaring::Roaring& const_bitmap = child_res[i].getConstReference();
-      union_tmp[i] = &const_bitmap;
+   std::vector<CopyOnWriteBitmap> child_res;
+   child_res.reserve(children.size());
+   for (const auto& child : children) {
+      child_res.push_back(child->evaluate());
    }
-   return CopyOnWriteBitmap(roaring::Roaring::fastunion(union_tmp.size(), union_tmp.data()));
+   return CopyOnWriteBitmap::fastUnion(child_res);
 }
 
 std::unique_ptr<Operator> Union::negate(std::unique_ptr<Union>&& union_operator) {

--- a/src/silo/query_engine/filter/operators/union.test.cpp
+++ b/src/silo/query_engine/filter/operators/union.test.cpp
@@ -29,7 +29,7 @@ TEST(OperatorUnion, evaluatesCorrectOnEmptyInput) {
    const auto row_layout = RowLayout::of(5);
 
    const Union under_test(std::move(input), row_layout);
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring());
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring());
 }
 
 TEST(OperatorUnion, evaluatesCorrectOnOneInput) {
@@ -38,7 +38,7 @@ TEST(OperatorUnion, evaluatesCorrectOnOneInput) {
 
    OperatorVector input = generateTestInput(test_bitmaps, row_layout);
    const Union under_test(std::move(input), row_layout);
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({1, 3, 5}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({1, 3, 5}));
 }
 
 TEST(OperatorUnion, evaluateShouldReturnCorrectValues1) {
@@ -49,7 +49,7 @@ TEST(OperatorUnion, evaluateShouldReturnCorrectValues1) {
 
    OperatorVector input = generateTestInput(test_bitmaps, row_layout);
    const Union under_test(std::move(input), row_layout);
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({1, 2, 3}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({1, 2, 3}));
 }
 
 TEST(OperatorUnion, evaluateShouldReturnCorrectValues2) {
@@ -60,7 +60,7 @@ TEST(OperatorUnion, evaluateShouldReturnCorrectValues2) {
 
    OperatorVector input = generateTestInput(test_bitmaps, row_layout);
    const Union under_test(std::move(input), row_layout);
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({1, 3, 7}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({1, 3, 7}));
 }
 
 TEST(OperatorUnion, evaluateShouldReturnCorrectValuesMany) {
@@ -84,7 +84,7 @@ TEST(OperatorUnion, evaluateShouldReturnCorrectValuesMany) {
 
    OperatorVector input = generateTestInput(test_bitmaps, row_layout);
    const Union under_test(std::move(input), row_layout);
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring({2, 3, 4}));
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring({2, 3, 4}));
 }
 
 TEST(OperatorUnion, evaluateShouldReturnCorrectValuesEmptyInput) {
@@ -93,7 +93,7 @@ TEST(OperatorUnion, evaluateShouldReturnCorrectValuesEmptyInput) {
 
    OperatorVector input = generateTestInput(test_bitmaps, row_layout);
    const Union under_test(std::move(input), row_layout);
-   ASSERT_EQ(under_test.evaluate().getConstReference(), roaring::Roaring());
+   ASSERT_EQ(under_test.evaluate().toRoaring(), roaring::Roaring());
 }
 
 TEST(OperatorUnion, correctTypeInfo) {

--- a/src/silo/query_engine/operators/bitmap_aggregation_node.cpp
+++ b/src/silo/query_engine/operators/bitmap_aggregation_node.cpp
@@ -18,6 +18,7 @@
 
 #include "silo/common/aa_symbols.h"
 #include "silo/common/nucleotide_symbols.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/exec_node/arrow_util.h"
 #include "silo/query_engine/operators/compute_filter.h"
 #include "silo/query_engine/scalar_expressions/symbol_in_set.h"
@@ -53,20 +54,20 @@ GroupBitmaps buildSymbolBitmaps(
    const storage::column::SequenceColumn<SymbolType>& column,
    uint32_t position_idx,
    const storage::column::RowLayout& row_layout,
-   const roaring::Roaring& filter_bitmap
+   const CopyOnWriteBitmap& filter_bitmap
 ) {
    GroupBitmaps result;
    for (const auto symbol : SymbolType::SYMBOLS) {
       auto compiled = scalar_expressions::compileSymbolInSet<SymbolType>(
          column, position_idx, std::vector<typename SymbolType::Symbol>{symbol}, row_layout
       );
-      roaring::Roaring bitmap = compiled->evaluate().getConstReference();
+      CopyOnWriteBitmap bitmap = compiled->evaluate();
       // Restrict each group to the filtered set: the returned bitmaps and every downstream
       // intersection then scale with the filter rather than the whole table, and symbols that no
       // filtered sequence carries drop out (fewer partition branches).
       bitmap &= filter_bitmap;
       if (!bitmap.isEmpty()) {
-         result.emplace_back(std::string(1, SymbolType::symbolToChar(symbol)), std::move(bitmap));
+         result.emplace_back(std::string(1, SymbolType::symbolToChar(symbol)), bitmap.toRoaring());
       }
    }
    // The per-symbol filters exclude sequences that are absent at this position (`SymbolInSet` does
@@ -74,9 +75,10 @@ GroupBitmaps buildSymbolBitmaps(
    // This keeps the groups a partition of the filtered rows and mirrors how the generic
    // `at()`/groupBy path emits a null key for such rows. Appended last so the depth-first output
    // order stays deterministic with the null group after every symbol.
-   roaring::Roaring null_group = column.null_bitmap & filter_bitmap;
-   if (!null_group.isEmpty()) {
-      result.emplace_back(std::nullopt, std::move(null_group));
+
+   CopyOnWriteBitmap intersection = filter_bitmap & CopyOnWriteBitmap{&column.null_bitmap};
+   if (!intersection.isEmpty()) {
+      result.emplace_back(std::nullopt, intersection.toRoaring());
    }
    return result;
 }
@@ -87,7 +89,7 @@ GroupBitmaps buildSymbolBitmaps(
 /// bitmaps and their indices, so it is agnostic to the kind of each dimension.
 // NOLINTNEXTLINE(misc-no-recursion)
 void partition(
-   const roaring::Roaring& current,
+   const CopyOnWriteBitmap& current,
    size_t depth,
    const std::vector<GroupBitmaps>& group_bitmaps_per_dimension,
    std::vector<size_t>& accumulated_indices,
@@ -101,8 +103,7 @@ void partition(
    }
    const auto& dimension = group_bitmaps_per_dimension[depth];
    for (size_t group_index = 0; group_index < dimension.size(); ++group_index) {
-      roaring::Roaring intersection = current;
-      intersection &= dimension[group_index].second;
+      CopyOnWriteBitmap intersection = current & dimension[group_index].second;
       if (intersection.isEmpty()) {
          continue;
       }
@@ -119,7 +120,7 @@ void partition(
 /// non-empty combinations are visited (their number is bounded by the count of matching rows), so
 /// this scales to many dimensions without the exponential blow-up of a full Cartesian product.
 std::vector<GroupCombination> computeCombinations(
-   const roaring::Roaring& filter_bitmap,
+   const CopyOnWriteBitmap& filter_bitmap,
    const std::vector<GroupBitmaps>& group_bitmaps_per_dimension
 ) {
    std::vector<GroupCombination> combinations;
@@ -187,7 +188,7 @@ SequencePositionDimension::SequencePositionDimension(
 
 GroupBitmaps SequencePositionDimension::buildGroups(
    const storage::Table& table,
-   const roaring::Roaring& filter_bitmap
+   const CopyOnWriteBitmap& filter_bitmap
 ) const {
    if (is_nucleotide) {
       const auto& sequence_column = table.columns.getColumns<Nucleotide::Column>().at(column.name);
@@ -224,7 +225,7 @@ IndexedColumnDimension::IndexedColumnDimension(
 
 GroupBitmaps IndexedColumnDimension::buildGroups(
    const storage::Table& table,
-   const roaring::Roaring& filter_bitmap
+   const CopyOnWriteBitmap& filter_bitmap
 ) const {
    const auto& indexed_column =
       table.columns.getColumns<storage::column::DictionaryEncodedColumn>().at(column.name);
@@ -233,7 +234,7 @@ GroupBitmaps IndexedColumnDimension::buildGroups(
    // (its dictionary entry's bitmap does not contain it), so the null group below stays disjoint
    // from the value groups and no row is double-counted.
    for (const auto& [value_id, value_bitmap] : indexed_column.getIndexedValues()) {
-      roaring::Roaring group = value_bitmap & filter_bitmap;
+      CopyOnWriteBitmap group = filter_bitmap & CopyOnWriteBitmap{&value_bitmap};
       if (group.isEmpty()) {
          continue;
       }
@@ -244,7 +245,7 @@ GroupBitmaps IndexedColumnDimension::buildGroups(
    std::ranges::sort(result, [](const auto& lhs, const auto& rhs) {
       return lhs.first < rhs.first;
    });
-   roaring::Roaring null_group = indexed_column.null_bitmap & filter_bitmap;
+   CopyOnWriteBitmap null_group = CopyOnWriteBitmap{&indexed_column.null_bitmap} & filter_bitmap;
    if (!null_group.isEmpty()) {
       result.emplace_back(std::nullopt, std::move(null_group));
    }
@@ -252,7 +253,7 @@ GroupBitmaps IndexedColumnDimension::buildGroups(
 }
 
 schema::ColumnIdentifier IndexedColumnDimension::outputColumn() const {
-   return {output_name, schema::ColumnType::STRING};
+   return {.name = output_name, .type = schema::ColumnType::STRING};
 }
 
 nlohmann::json IndexedColumnDimension::toJson() const {
@@ -306,18 +307,17 @@ arrow::Result<arrow::acero::ExecNode*> BitmapAggregationNode::addToExecPlan(
    const config::QueryOptions& query_options
 ) const {
    auto filter_bitmap = computeFilter(filter, *table);
-   const roaring::Roaring& filter_bitmap_ref = filter_bitmap.getConstReference();
 
    std::vector<GroupBitmaps> group_bitmaps_per_dimension;
    group_bitmaps_per_dimension.reserve(dimensions.size());
    for (const auto& dimension : dimensions) {
       group_bitmaps_per_dimension.push_back(std::visit(
-         [&](const auto& dim) { return dim.buildGroups(*table, filter_bitmap_ref); }, dimension
+         [&](const auto& dim) { return dim.buildGroups(*table, filter_bitmap); }, dimension
       ));
    }
 
    std::vector<GroupCombination> combinations =
-      computeCombinations(filter_bitmap_ref, group_bitmaps_per_dimension);
+      computeCombinations(filter_bitmap, group_bitmaps_per_dimension);
 
    const size_t dimension_count = dimensions.size();
 

--- a/src/silo/query_engine/operators/bitmap_aggregation_node.h
+++ b/src/silo/query_engine/operators/bitmap_aggregation_node.h
@@ -11,9 +11,9 @@
 
 #include <arrow/result.h>
 #include <nlohmann/json_fwd.hpp>
-#include <roaring/roaring.hh>
 
 #include "silo/config/runtime_config.h"
+#include "silo/query_engine/copy_on_write_bitmap.h"
 #include "silo/query_engine/operators/query_node.h"
 #include "silo/query_engine/scalar_expressions/scalar_expression.h"
 #include "silo/schema/database_schema.h"
@@ -29,7 +29,7 @@ namespace silo::query_engine::operators {
 /// work — are bounded by the filtered row set rather than the whole table. Together the groups are
 /// disjoint and cover every filtered row. The value is rendered as a string because the aggregation
 /// node emits every grouping column as STRING (a null group becomes a SQL null).
-using GroupBitmaps = std::vector<std::pair<std::optional<std::string>, roaring::Roaring>>;
+using GroupBitmaps = std::vector<std::pair<std::optional<std::string>, CopyOnWriteBitmap>>;
 
 /// Groups rows by the symbol they carry at a fixed sequence position, e.g. `main.at(123)`.
 struct SequencePositionDimension {
@@ -49,7 +49,7 @@ struct SequencePositionDimension {
    /// `GroupBitmaps`), reading the relevant column from `table`.
    [[nodiscard]] GroupBitmaps buildGroups(
       const storage::Table& table,
-      const roaring::Roaring& filter_bitmap
+      const CopyOnWriteBitmap& filter_bitmap
    ) const;
 
    /// The STRING output column this dimension contributes to the result schema.
@@ -67,7 +67,7 @@ struct IndexedColumnDimension {
 
    [[nodiscard]] GroupBitmaps buildGroups(
       const storage::Table& table,
-      const roaring::Roaring& filter_bitmap
+      const CopyOnWriteBitmap& filter_bitmap
    ) const;
 
    [[nodiscard]] schema::ColumnIdentifier outputColumn() const;

--- a/src/silo/query_engine/operators/count_filter_node.cpp
+++ b/src/silo/query_engine/operators/count_filter_node.cpp
@@ -48,7 +48,7 @@ arrow::Result<arrow::acero::ExecNode*> CountFilterNode::addToExecPlan(
       }
       already_produced = true;
 
-      auto result_count = static_cast<int64_t>(filter_bitmap.getConstReference().cardinality());
+      auto result_count = static_cast<int64_t>(filter_bitmap.cardinality());
 
       arrow::Int64Builder result_builder{};
       ARROW_RETURN_NOT_OK(result_builder.Append(result_count));

--- a/src/silo/query_engine/operators/insertions_node.cpp
+++ b/src/silo/query_engine/operators/insertions_node.cpp
@@ -62,7 +62,8 @@ arrow::Status addAggregatedInsertionsToInsertionCounts(
    const auto& sequence_column =
       table.columns.getColumns<storage::column::SequenceColumn<SymbolType>>().at(sequence_name);
    std::unordered_map<PositionAndInsertionKey, uint32_t> all_insertions;
-   auto bitmap_cardinality = bitmap_filter.getConstReference().cardinality();
+   const roaring::Roaring filter_bitmap = bitmap_filter.toRoaring();
+   auto bitmap_cardinality = filter_bitmap.cardinality();
    if (bitmap_cardinality == 0) {
       return arrow::Status::OK();
    }
@@ -78,8 +79,7 @@ arrow::Status addAggregatedInsertionsToInsertionCounts(
       for (const auto& [position, insertions_at_position] :
            sequence_column.insertion_index.getInsertionPositions()) {
          for (const auto& insertion : insertions_at_position.insertions) {
-            const uint32_t count =
-               insertion.row_ids.and_cardinality(bitmap_filter.getConstReference());
+            const uint32_t count = insertion.row_ids.and_cardinality(filter_bitmap);
             if (count > 0) {
                all_insertions[PositionAndInsertionKey{position, insertion.value}] += count;
             }

--- a/src/silo/query_engine/operators/most_recent_common_ancestor_node.cpp
+++ b/src/silo/query_engine/operators/most_recent_common_ancestor_node.cpp
@@ -36,14 +36,15 @@ NodeValuesResult getNodeValuesFromTable(
    const std::string& column_name,
    silo::query_engine::CopyOnWriteBitmap& bitmap_filter
 ) {
-   const size_t num_rows = bitmap_filter.getConstReference().cardinality();
+   const roaring::Roaring filter_bitmap = bitmap_filter.toRoaring();
+   const size_t num_rows = filter_bitmap.cardinality();
    std::unordered_set<std::string> all_tree_node_ids;
    uint32_t num_empty = 0;
    all_tree_node_ids.reserve(num_rows);
 
    const auto& string_column = table.columns.string_columns.at(column_name);
 
-   for (const uint32_t row_in_table : bitmap_filter.getConstReference()) {
+   for (const uint32_t row_in_table : filter_bitmap) {
       const auto row_id = silo::storage::column::RowId::fromGlobal(row_in_table);
       if (!string_column.isNull(row_id)) {
          auto value = string_column.getValueString(row_id);

--- a/src/silo/query_engine/operators/mutations_node.cpp
+++ b/src/silo/query_engine/operators/mutations_node.cpp
@@ -110,7 +110,7 @@ __attribute__((noinline)) void subtractStartAndEndNCounts(
 
 __attribute__((noinline)) void subtractFilteredNCounts(
    std::vector<uint32_t>& count_per_local_reference_position,
-   const CopyOnWriteBitmap& filter,
+   const roaring::Roaring& filter,
    size_t sequence_length,
    const storage::column::HorizontalCoverageIndex& coverage_index
 ) {
@@ -118,7 +118,7 @@ __attribute__((noinline)) void subtractFilteredNCounts(
    const auto& horizontal_bitmaps = coverage_index.horizontal_bitmaps;
    std::vector<size_t> cumulative_starts(sequence_length + 1);
    std::vector<size_t> cumulative_ends(sequence_length + 1);
-   for (const uint32_t idx : filter.getConstReference()) {
+   for (const uint32_t idx : filter) {
       auto iter = horizontal_bitmaps.find(idx);
       if (iter != horizontal_bitmaps.end()) {
          const roaring::Roaring& n_bitmap = iter->second;
@@ -154,11 +154,11 @@ template <typename SymbolType>
 void countActualFilteredMutations(
    SymbolMap<SymbolType, std::vector<uint32_t>>& count_of_mutations_per_position,
    std::vector<uint32_t>& count_per_local_reference_position,
-   const CopyOnWriteBitmap& filter,
+   const roaring::Roaring& filter,
    const std::map<SequenceDiffKey<SymbolType>, SequenceDiff<SymbolType>>& vertical_bitmaps
 ) {
    EVOBENCH_SCOPE("Mutations", "countActualFilteredMutations");
-   const auto& filter_roaring_array = filter.getConstReference().roaring.high_low_container;
+   const auto& filter_roaring_array = filter.roaring.high_low_container;
    std::map<size_t, roaring::internal::container_t*> filter_containers;
    std::map<size_t, uint8_t> filter_container_typecodes;
    for (int32_t idx = 0; idx < filter_roaring_array.size; ++idx) {
@@ -212,19 +212,23 @@ void addMutationCountsForMixedBitmaps(
    const size_t sequence_length = local_reference.size();
    std::vector<uint32_t> count_per_local_reference_position(sequence_length);
 
+   // Terminal consumer of the filter's bitmap: the counting below reads its containers directly,
+   // so materialize it once here.
+   const roaring::Roaring filter_bitmap = bitmap_filter.toRoaring();
+
    initializeCountsWithSequenceCount(
-      count_per_local_reference_position, bitmap_filter.getConstReference().cardinality()
+      count_per_local_reference_position, filter_bitmap.cardinality()
    );
    subtractFilteredNCounts(
       count_per_local_reference_position,
-      bitmap_filter,
+      filter_bitmap,
       sequence_length,
       sequence_column.horizontal_coverage_index
    );
    countActualFilteredMutations(
       count_of_mutations_per_position,
       count_per_local_reference_position,
-      bitmap_filter,
+      filter_bitmap,
       sequence_column.vertical_sequence_index.vertical_bitmaps
    );
    accumulateFinalCounts(
@@ -272,9 +276,10 @@ SymbolMap<SymbolType, std::vector<uint32_t>> calculateMutationsPerPosition(
    for (const auto symbol : SymbolType::SYMBOLS) {
       count_of_mutations_per_position[symbol] = std::vector<uint32_t>(sequence_length, 0);
    }
-   if (bitmap_filter.getConstReference().cardinality() == sequence_count_in_column) {
+   const uint64_t filter_cardinality = bitmap_filter.cardinality();
+   if (filter_cardinality == sequence_count_in_column) {
       addMutationCountsForFullBitmaps<SymbolType>(sequence_column, count_of_mutations_per_position);
-   } else if (bitmap_filter.getConstReference().cardinality() > 0) {
+   } else if (filter_cardinality > 0) {
       addMutationCountsForMixedBitmaps<SymbolType>(
          sequence_column, bitmap_filter, count_of_mutations_per_position
       );

--- a/src/silo/query_engine/operators/phylo_subtree_node.cpp
+++ b/src/silo/query_engine/operators/phylo_subtree_node.cpp
@@ -36,14 +36,15 @@ NodeValuesResult getNodeValuesFromTable(
    const std::string& column_name,
    silo::query_engine::CopyOnWriteBitmap& bitmap_filter
 ) {
-   const size_t num_rows = bitmap_filter.getConstReference().cardinality();
+   const roaring::Roaring filter_bitmap = bitmap_filter.toRoaring();
+   const size_t num_rows = filter_bitmap.cardinality();
    std::unordered_set<std::string> all_tree_node_ids;
    uint32_t num_empty = 0;
    all_tree_node_ids.reserve(num_rows);
 
    const auto& string_column = table.columns.string_columns.at(column_name);
 
-   for (const uint32_t row_in_table : bitmap_filter.getConstReference()) {
+   for (const uint32_t row_in_table : filter_bitmap) {
       const auto row_id = silo::storage::column::RowId::fromGlobal(row_in_table);
       if (!string_column.isNull(row_id)) {
          auto value = string_column.getValueString(row_id);


### PR DESCRIPTION
Another minor refactor following #1441.

Now we will be able to consolidate and resolve #1191.


This adds set-operation directly to `CopyOnWriteBitmap`. The accessors to the underlying bitmap are now changed to private methods. All callers now directly formulate their computations on our abstraction -> next we can change the internal behavior without touching all call sites!