### PR TITLE
refactor(silo): move the primary key uniqueness change to `preprocessing`

### DIFF
--- a/documentation/incremental_preprocessing.md
+++ b/documentation/incremental_preprocessing.md
@@ -52,9 +52,7 @@ When `rhydb append` is invoked, the following steps are performed:
 
 5. Each subsequent line is parsed and its values are inserted into the database. Progress is logged every 10,000 records.
 
-6. After all records have been inserted, the database is finalized and validated. This includes checking for duplicate primary keys across both old and new data.
-
-7. A new data version is assigned, and the updated database state is saved as a new timestamped subdirectory within the silo-directory.
+6. A new data version is assigned, and the updated database state is saved as a new timestamped subdirectory within the silo-directory.
 
 ## Examples
 

--- a/src/silo/append/table_inserter.cpp
+++ b/src/silo/append/table_inserter.cpp
@@ -11,7 +11,6 @@
 #include "silo/common/error.h"
 #include "silo/common/nucleotide_symbols.h"
 #include "silo/common/panic.h"
-#include "silo/schema/duplicate_primary_key_exception.h"
 #include "silo/storage/column/sequence_column.h"
 
 namespace silo::append {
@@ -351,13 +350,9 @@ TableInserter::Commit TableInserter::commit() {
    for (auto& buffer : output_buffers) {
       flush_buffer(buffer);
    }
-   try {
-      table->finalize();
-      table->validate();
-      return Commit{};
-   } catch (const schema::DuplicatePrimaryKeyException& exception) {
-      throw AppendException(exception.what());
-   }
+   table->finalize();
+   table->validate();
+   return Commit{};
 }
 
 TableInserter::Commit appendDataToTable(

--- a/src/silo/preprocessing/preprocessing.cpp
+++ b/src/silo/preprocessing/preprocessing.cpp
@@ -6,6 +6,7 @@
 #include "silo/initialize/initialize_exception.h"
 #include "silo/initialize/initializer.h"
 #include "silo/preprocessing/preprocessing_exception.h"
+#include "silo/schema/duplicate_primary_key_exception.h"
 
 namespace silo::preprocessing {
 
@@ -23,15 +24,22 @@ Database preprocessing(const config::PreprocessingConfig& preprocessing_config) 
       SPDLOG_INFO("preprocessing - appending data to Database");
       database.appendData(schema::TableName::getDefault(), input.getInputStream());
 
+      SPDLOG_INFO("preprocessing - validating primary key uniqueness");
+      database.tables.at(schema::TableName::getDefault())->validatePrimaryKeyUnique();
+
       SPDLOG_INFO("preprocessing - finished preprocessing");
       return database;
    } catch (const initialize::InitializeException& exception) {
-      throw preprocessing::PreprocessingException(
+      throw PreprocessingException(
          "preprocessing - exception when initializing database: {}", exception.what()
       );
    } catch (const append::AppendException& exception) {
-      throw preprocessing::PreprocessingException(
+      throw PreprocessingException(
          "preprocessing - exception when appending data: {}", exception.what()
+      );
+   } catch (const schema::DuplicatePrimaryKeyException& exception) {
+      throw PreprocessingException(
+         "preprocessing - primary key uniqueness validation failed: {}", exception.what()
       );
    }
 }

--- a/src/silo/storage/table.cpp
+++ b/src/silo/storage/table.cpp
@@ -64,7 +64,6 @@ nlohmann::json Table::logTable() const {
 }
 
 void Table::validate() const {
-   validatePrimaryKeyUnique();
    validateNucleotideSequences();
    validateAminoAcidSequences();
    validateMetadataColumns();


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1465

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

Currently, table.h owns about the primary key uniqueness check. This should be moved to preprocessing. Some consumers of SILO (e.g. through python bindings) might decide that they do not want this behavior.

This allows are more succinct `createTable` api for the python bindings, where the primary key will not necessarily be specified