### PR TITLE
ci: allow `rhydb` as scope instead of `silo`

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -37,7 +37,7 @@ const Configuration = {
     "scope-enum": [
       RuleConfigSeverity.Error,
       "always",
-      [...trackedRootDirectories, ...siloSubdirectories, "silo", "main", "deps", "deps-dev"],
+      [...trackedRootDirectories, ...siloSubdirectories, "rhydb", "main", "deps", "deps-dev"],
     ],
   },
 };


### PR DESCRIPTION
minor ci  change