### PR TITLE
feat(rhydb): return ISO week date string from isoWeek()

### DIFF
--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -489,9 +489,7 @@ default.map({second_char := primary_key.at(2)})
 
 ### `isoWeek(column)`
 
-Maps a date `column` to its ISO 8601 week number (1–53) as an integer.
-`column` must be a date column. A `null` date yields `null`.
-Use it inside [`map()`](#mapexpressions).
+Maps a date `column` to its ISO 8601 week date, formatted as `<ISO-year>-W<ISO-week>` (e.g. `2026-W12`), as a string. The ISO week-numbering year is used, so it can differ from the calendar year around January (e.g. `2021-01-01` is `2020-W53`); the zero-padded week keeps the value chronologically sortable within a year. `column` must be a date column. A `null` date yields `null`. Use it inside [`map()`](#mapexpressions).
 
 ```
 default.map({week := date.isoWeek()})

--- a/src/silo/query_engine/operators/map_node.cpp
+++ b/src/silo/query_engine/operators/map_node.cpp
@@ -11,6 +11,7 @@
 #include <arrow/acero/options.h>
 #include <arrow/compute/api.h>
 #include <arrow/datum.h>
+#include <arrow/type.h>
 #include <nlohmann/json_fwd.hpp>
 
 #include "silo/common/size_constants.h"
@@ -73,7 +74,24 @@ arrow::Result<arrow::compute::Expression> scalarToArrowExpression(const ScalarEx
    }
    if (const auto* iso_week = dynCast<IsoWeek>(&expression)) {
       ARROW_ASSIGN_OR_RAISE(auto input, scalarToArrowExpression(*iso_week->input));
-      return arrow::compute::call("iso_week", {input});
+      // Render the ISO 8601 week date `<ISO-year>-W<ISO-week>`, e.g. `2026-W12`
+      const auto year_string = arrow::compute::call(
+         "cast",
+         {arrow::compute::call("iso_year", {input})},
+         arrow::compute::CastOptions::Safe(arrow::utf8())
+      );
+      const auto week_string = arrow::compute::call(
+         "cast",
+         {arrow::compute::call("iso_week", {input})},
+         arrow::compute::CastOptions::Safe(arrow::utf8())
+      );
+      // Zero-pad the week to two digits so `2021-W02` sorts before `2021-W10`.
+      const auto week_padded =
+         arrow::compute::call("utf8_lpad", {week_string}, arrow::compute::PadOptions(2, "0"));
+      // Join `<year> + "-W" + <week>` -- third argument is separator
+      return arrow::compute::call(
+         "binary_join_element_wise", {year_string, week_padded, arrow::compute::literal("-W")}
+      );
    }
    return arrow::Status::NotImplemented(
       "the scalar expression ", expression.toString(), " is not supported in map() assignments"

--- a/src/silo/query_engine/operators/map_node.test.cpp
+++ b/src/silo/query_engine/operators/map_node.test.cpp
@@ -302,7 +302,7 @@ const QueryTestScenario FILTER_ON_MAPPED_COLUMN_SCENARIO = {
 // producing an invalid plan.
 const QueryTestScenario FILTER_ON_ISO_WEEK_MAPPED_COLUMN_SCENARIO = {
    .name = "FILTER_ON_ISO_WEEK_MAPPED_COLUMN",
-   .query = "default.map({week := date.isoWeek()}).filter(week = 1).project({primaryKey})",
+   .query = "default.map({week := date.isoWeek()}).filter(week = '2023-W01').project({primaryKey})",
    .expected_query_result = {},
    .expected_error_message =
       "FilterNode must be eliminated during pushdown before query plan generation"
@@ -328,7 +328,7 @@ const QueryTestScenario FILTER_MIXED_PUSHABLE_AND_DERIVED_SCENARIO = {
    .name = "FILTER_MIXED_PUSHABLE_AND_DERIVED",
    .query =
       "default.map({week := date.isoWeek()})"
-      ".filter(hasMutation(sequenceName := 'segment1', position := 1) && week = 1)"
+      ".filter(hasMutation(sequenceName := 'segment1', position := 1) && week = '2023-W01')"
       ".project({primaryKey})",
    .expected_query_result = {},
    .expected_error_message =
@@ -344,13 +344,14 @@ const QueryTestScenario FILTER_PUSHED_PAST_UNRELATED_DERIVED_MAP_SCENARIO = {
    .expected_query_result = nlohmann::json({{{"primaryKey", "id_0"}}})
 };
 
-// `isoWeek` maps a date column to its ISO 8601 week number as an integer.
+// `isoWeek` maps a date column to its ISO 8601 week date, `<ISO-year>-W<ISO-week>`, as a string.
 const QueryTestScenario MAP_ISO_WEEK_SCENARIO = {
    .name = "MAP_ISO_WEEK",
    .query = "default.map({week := date.isoWeek()}).project({primaryKey, week})",
-   .expected_query_result =
-      nlohmann::json({{{"primaryKey", "id_0"}, {"week", 1}}, {{"primaryKey", "id_1"}, {"week", 52}}}
-      )
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"week", "2023-W01"}},
+       {{"primaryKey", "id_1"}, {"week", "2023-W52"}}}
+   )
 };
 
 }  // namespace
@@ -406,7 +407,7 @@ const QueryTestScenario MAP_ISO_WEEK_NULL_SCENARIO = {
    .name = "MAP_ISO_WEEK_NULL",
    .query = "default.map({week := date.isoWeek()}).project({primaryKey, week})",
    .expected_query_result = nlohmann::json(
-      {{{"primaryKey", "id_0"}, {"week", nullptr}}, {{"primaryKey", "id_1"}, {"week", 53}}}
+      {{{"primaryKey", "id_0"}, {"week", nullptr}}, {{"primaryKey", "id_1"}, {"week", "2020-W53"}}}
    )
 };
 

--- a/src/silo/query_engine/saneql/ast_to_query.test.cpp
+++ b/src/silo/query_engine/saneql/ast_to_query.test.cpp
@@ -496,7 +496,7 @@ TEST(AstToQueryMap, isoWeekResolvesToWeekOfDateColumn) {
    const auto found =
       std::ranges::find_if(output_schema, [](const auto& col) { return col.name == "w"; });
    ASSERT_NE(found, output_schema.end());
-   EXPECT_EQ(found->type, silo::schema::ColumnType::INT64);
+   EXPECT_EQ(found->type, silo::schema::ColumnType::STRING);
 }
 
 TEST(AstToQueryMap, isoWeekOnUnknownColumnThrows) {

--- a/src/silo/query_engine/scalar_expressions/iso_week.cpp
+++ b/src/silo/query_engine/scalar_expressions/iso_week.cpp
@@ -32,7 +32,6 @@ std::unique_ptr<ScalarExpression> IsoWeek::rewrite(const storage::Table& table, 
 
 std::unique_ptr<filter::operators::Operator> IsoWeek::compile(const storage::Table& /*table*/)
    const {
-   // `isoWeek` yields an int scalar value, not a filter predicate.
    SILO_UNIMPLEMENTED();
 }
 

--- a/src/silo/query_engine/scalar_expressions/iso_week.h
+++ b/src/silo/query_engine/scalar_expressions/iso_week.h
@@ -10,17 +10,15 @@
 
 namespace silo::query_engine::scalar_expressions {
 
-/// A scalar expression that evaluates to the ISO week number (int) of the date its child expression
-/// evaluates to, e.g. `myDate.isoWeek()`. The child is usually a `FieldRef` to a date column. Its
-/// value is an int, so it is not a filter predicate; compile() is unimplemented and it is only
-/// meaningful as a scalar expression (e.g. in a map() assignment).
+/// A scalar expression that evaluates to the ISO 8601 week date of the date its child expression
+/// evaluates to, formatted as `<ISO-year>-W<ISO-week>`, e.g. `2026-W12`
 class IsoWeek : public ScalarExpression {
   public:
    std::unique_ptr<ScalarExpression> input;
 
    explicit IsoWeek(std::unique_ptr<ScalarExpression> input);
 
-   [[nodiscard]] schema::ColumnType type() const override { return schema::ColumnType::INT64; }
+   [[nodiscard]] schema::ColumnType type() const override { return schema::ColumnType::STRING; }
 
    static constexpr Kind KIND = Kind::ISO_WEEK;
    [[nodiscard]] Kind kind() const override { return KIND; }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1471 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This changes the scalar function `isoWeek` to e.g. return `"2026-W07"`, `"2026-W12"` instead of `7`,`12`. This function is not exposed through LAPIS yet, so has no external dependents

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
