### PR TITLE
refactor(rhydb): rename `Silo`-prefixed classes to `RhyDB` prefix

### DIFF
--- a/app/src/api.cpp
+++ b/app/src/api.cpp
@@ -53,10 +53,10 @@ int Api::runApi(const rhydb::config::RuntimeConfig& runtime_config) {
    auto database = std::make_shared<ActiveDatabase>();
 
    auto silo_request_handler_factory =
-      std::make_unique<silo_app::SiloRequestHandlerFactory>(runtime_config, database);
+      std::make_unique<silo_app::RhyDBRequestHandlerFactory>(runtime_config, database);
 
-   const silo_app::SiloDirectoryWatcher directory_watcher(
-      rhydb::SiloDirectory{runtime_config.data_directory}, database
+   const silo_app::RhyDBDirectoryWatcher directory_watcher(
+      rhydb::RhyDBDirectory{runtime_config.data_directory}, database
    );
 
    const silo_app::MemoryMonitor memory_monitor{runtime_config.api_options.soft_memory_limit};

--- a/app/src/request_handler_factory.cpp
+++ b/app/src/request_handler_factory.cpp
@@ -18,14 +18,14 @@
 
 namespace silo_app {
 
-SiloRequestHandlerFactory::SiloRequestHandlerFactory(
+RhyDBRequestHandlerFactory::RhyDBRequestHandlerFactory(
    rhydb::config::RuntimeConfig runtime_config,
    std::shared_ptr<ActiveDatabase> database_handle
 )
     : runtime_config(std::move(runtime_config)),
       database_handle(std::move(database_handle)) {}
 
-Poco::Net::HTTPRequestHandler* SiloRequestHandlerFactory::createRequestHandler(
+Poco::Net::HTTPRequestHandler* RhyDBRequestHandlerFactory::createRequestHandler(
    const Poco::Net::HTTPServerRequest& request
 ) {
    return new RequestIdHandler(
@@ -35,7 +35,7 @@ Poco::Net::HTTPRequestHandler* SiloRequestHandlerFactory::createRequestHandler(
    );
 }
 
-std::unique_ptr<Poco::Net::HTTPRequestHandler> SiloRequestHandlerFactory::routeRequest(
+std::unique_ptr<Poco::Net::HTTPRequestHandler> RhyDBRequestHandlerFactory::routeRequest(
    const Poco::URI& uri
 ) {
    const std::string_view path = uri.getPath();

--- a/app/src/request_handler_factory.h
+++ b/app/src/request_handler_factory.h
@@ -12,13 +12,13 @@
 
 namespace silo_app {
 
-class SiloRequestHandlerFactory : public Poco::Net::HTTPRequestHandlerFactory {
+class RhyDBRequestHandlerFactory : public Poco::Net::HTTPRequestHandlerFactory {
   private:
    const rhydb::config::RuntimeConfig runtime_config;
    std::shared_ptr<ActiveDatabase> database_handle;
 
   public:
-   SiloRequestHandlerFactory(
+   RhyDBRequestHandlerFactory(
       rhydb::config::RuntimeConfig runtime_config,
       std::shared_ptr<ActiveDatabase> database_handle
    );

--- a/app/src/request_handler_factory.test.cpp
+++ b/app/src/request_handler_factory.test.cpp
@@ -10,11 +10,11 @@
 #include "query_handler.h"
 #include "request_handler_factory.h"
 
-using silo_app::SiloRequestHandlerFactory;
+using silo_app::RhyDBRequestHandlerFactory;
 
 namespace {
 
-std::unique_ptr<SiloRequestHandlerFactory> createRequestHandlerWithInitializedDatabase() {
+std::unique_ptr<RhyDBRequestHandlerFactory> createRequestHandlerWithInitializedDatabase() {
    auto handle = std::make_shared<silo_app::ActiveDatabase>();
    auto table_schema = std::make_shared<rhydb::schema::TableSchema>();
    table_schema->primary_key = {.name = "primary_key", .type = rhydb::schema::ColumnType::STRING};
@@ -27,7 +27,7 @@ std::unique_ptr<SiloRequestHandlerFactory> createRequestHandlerWithInitializedDa
    rhydb::schema::DatabaseSchema schema;
    schema.tables.emplace(rhydb::schema::TableName::getDefault(), table_schema);
    handle->setActiveDatabase(rhydb::Database(schema));
-   auto request_handler = std::make_unique<SiloRequestHandlerFactory>(
+   auto request_handler = std::make_unique<RhyDBRequestHandlerFactory>(
       rhydb::config::RuntimeConfig::withDefaults(), handle
    );
    return request_handler;
@@ -40,13 +40,13 @@ void assertHoldsHandlerType(std::unique_ptr<Poco::Net::HTTPRequestHandler>& hand
 }
 }  // namespace
 
-TEST(SiloRequestHandlerFactory, returns503ResponseWhenDatabaseIsNotInitializedOnInfoEndpoint) {
+TEST(RhyDBRequestHandlerFactory, returns503ResponseWhenDatabaseIsNotInitializedOnInfoEndpoint) {
    silo_app::test::MockResponse response;
    silo_app::test::MockRequest request(response);
    request.setURI("/info");
 
    auto handle = std::make_shared<silo_app::ActiveDatabase>();
-   SiloRequestHandlerFactory under_test{rhydb::config::RuntimeConfig::withDefaults(), handle};
+   RhyDBRequestHandlerFactory under_test{rhydb::config::RuntimeConfig::withDefaults(), handle};
 
    std::unique_ptr<Poco::Net::HTTPRequestHandler> handler{under_test.createRequestHandler(request)};
 
@@ -56,14 +56,14 @@ TEST(SiloRequestHandlerFactory, returns503ResponseWhenDatabaseIsNotInitializedOn
    EXPECT_THAT(response.out_stream.str(), testing::HasSubstr("Database not initialized yet"));
 }
 
-TEST(SiloRequestHandlerFactory, returns503ResponseWhenDatabaseIsNotInitializedOnQueryEndpoint) {
+TEST(RhyDBRequestHandlerFactory, returns503ResponseWhenDatabaseIsNotInitializedOnQueryEndpoint) {
    silo_app::test::MockResponse response;
    silo_app::test::MockRequest request(response);
    request.setMethod("POST");
    request.setURI("/query");
 
    auto handle = std::make_shared<silo_app::ActiveDatabase>();
-   SiloRequestHandlerFactory under_test{rhydb::config::RuntimeConfig::withDefaults(), handle};
+   RhyDBRequestHandlerFactory under_test{rhydb::config::RuntimeConfig::withDefaults(), handle};
 
    std::unique_ptr<Poco::Net::HTTPRequestHandler> handler{under_test.createRequestHandler(request)};
 
@@ -74,7 +74,7 @@ TEST(SiloRequestHandlerFactory, returns503ResponseWhenDatabaseIsNotInitializedOn
 }
 
 TEST(
-   SiloRequestHandlerFactory,
+   RhyDBRequestHandlerFactory,
    returns503ResponseWhenDatabaseIsNotInitializedOnLineageDefinitionEndpoint
 ) {
    silo_app::test::MockResponse response;
@@ -82,7 +82,7 @@ TEST(
    request.setURI("/lineageDefinition/someColumn");
 
    auto handle = std::make_shared<silo_app::ActiveDatabase>();
-   SiloRequestHandlerFactory under_test{rhydb::config::RuntimeConfig::withDefaults(), handle};
+   RhyDBRequestHandlerFactory under_test{rhydb::config::RuntimeConfig::withDefaults(), handle};
 
    std::unique_ptr<Poco::Net::HTTPRequestHandler> handler{under_test.createRequestHandler(request)};
 
@@ -92,7 +92,7 @@ TEST(
    EXPECT_THAT(response.out_stream.str(), testing::HasSubstr("Database not initialized yet"));
 }
 
-TEST(SiloRequestHandlerFactory, routesGetInfoRequest) {
+TEST(RhyDBRequestHandlerFactory, routesGetInfoRequest) {
    const Poco::URI uri("/info");
 
    auto under_test = createRequestHandlerWithInitializedDatabase();
@@ -102,7 +102,7 @@ TEST(SiloRequestHandlerFactory, routesGetInfoRequest) {
    assertHoldsHandlerType<silo_app::InfoHandler>(handler);
 }
 
-TEST(SiloRequestHandlerFactory, routesLineageDefinitionRequest) {
+TEST(RhyDBRequestHandlerFactory, routesLineageDefinitionRequest) {
    const Poco::URI uri("/lineageDefinition/someId");
 
    auto under_test = createRequestHandlerWithInitializedDatabase();
@@ -112,7 +112,7 @@ TEST(SiloRequestHandlerFactory, routesLineageDefinitionRequest) {
    assertHoldsHandlerType<silo_app::LineageDefinitionHandler>(handler);
 }
 
-TEST(SiloRequestHandlerFactory, routesPostQueryRequest) {
+TEST(RhyDBRequestHandlerFactory, routesPostQueryRequest) {
    const Poco::URI uri("/query");
 
    auto under_test = createRequestHandlerWithInitializedDatabase();
@@ -122,7 +122,7 @@ TEST(SiloRequestHandlerFactory, routesPostQueryRequest) {
    assertHoldsHandlerType<silo_app::QueryHandler>(handler);
 }
 
-TEST(SiloRequestHandlerFactory, routesUnknownUrlToNotFoundHandler) {
+TEST(RhyDBRequestHandlerFactory, routesUnknownUrlToNotFoundHandler) {
    const Poco::URI uri("/unknown");
 
    auto under_test = createRequestHandlerWithInitializedDatabase();
@@ -132,7 +132,7 @@ TEST(SiloRequestHandlerFactory, routesUnknownUrlToNotFoundHandler) {
    assertHoldsHandlerType<silo_app::NotFoundHandler>(handler);
 }
 
-TEST(SiloRequestHandlerFactory, routesToHealth) {
+TEST(RhyDBRequestHandlerFactory, routesToHealth) {
    const Poco::URI uri("/health");
 
    auto under_test = createRequestHandlerWithInitializedDatabase();

--- a/app/src/silo_directory_watcher.cpp
+++ b/app/src/silo_directory_watcher.cpp
@@ -12,19 +12,19 @@
 
 #include "active_database.h"
 
-silo_app::SiloDirectoryWatcher::SiloDirectoryWatcher(
-   rhydb::SiloDirectory silo_directory,
+silo_app::RhyDBDirectoryWatcher::RhyDBDirectoryWatcher(
+   rhydb::RhyDBDirectory silo_directory,
    std::shared_ptr<ActiveDatabase> database_handle
 )
     : silo_directory(std::move(silo_directory)),
       database_handle(std::move(database_handle)),
       timer(0, 2000) {
-   timer.start(
-      Poco::TimerCallback<SiloDirectoryWatcher>(*this, &SiloDirectoryWatcher::checkDirectoryForData)
-   );
+   timer.start(Poco::TimerCallback<RhyDBDirectoryWatcher>(
+      *this, &RhyDBDirectoryWatcher::checkDirectoryForData
+   ));
 }
 
-void silo_app::SiloDirectoryWatcher::checkDirectoryForData(Poco::Timer& /*timer*/) {
+void silo_app::RhyDBDirectoryWatcher::checkDirectoryForData(Poco::Timer& /*timer*/) {
    auto maybe_most_recent_database_state = silo_directory.getMostRecentDataDirectory();
 
    if (maybe_most_recent_database_state == std::nullopt) {

--- a/app/src/silo_directory_watcher.h
+++ b/app/src/silo_directory_watcher.h
@@ -8,14 +8,14 @@
 
 namespace silo_app {
 
-class SiloDirectoryWatcher {
-   rhydb::SiloDirectory silo_directory;
+class RhyDBDirectoryWatcher {
+   rhydb::RhyDBDirectory silo_directory;
    std::shared_ptr<ActiveDatabase> database_handle;
    Poco::Timer timer;
 
   public:
-   SiloDirectoryWatcher(
-      rhydb::SiloDirectory silo_directory,
+   RhyDBDirectoryWatcher(
+      rhydb::RhyDBDirectory silo_directory,
       std::shared_ptr<ActiveDatabase> database_handle
    );
 

--- a/src/rhydb/append/append.cpp
+++ b/src/rhydb/append/append.cpp
@@ -16,12 +16,12 @@ class AppendError : public std::runtime_error {
 
 namespace {
 
-rhydb::SiloDataSource getMostRecentOrSpecifiedDatabaseState(
-   const rhydb::SiloDirectory& silo_directory,
+rhydb::RhyDBDataSource getMostRecentOrSpecifiedDatabaseState(
+   const rhydb::RhyDBDirectory& silo_directory,
    const std::optional<std::filesystem::path>& specified_directory
 ) {
    if (specified_directory.has_value()) {
-      return rhydb::SiloDataSource::checkValidDataSource(specified_directory.value());
+      return rhydb::RhyDBDataSource::checkValidDataSource(specified_directory.value());
    }
    SPDLOG_INFO(
       "No data directory specified, automatically using the most recent one in the silo-directory "
@@ -43,7 +43,7 @@ rhydb::SiloDataSource getMostRecentOrSpecifiedDatabaseState(
 namespace rhydb::append {
 
 int runAppend(const rhydb::config::AppendConfig& append_config) {
-   const rhydb::SiloDirectory silo_directory{append_config.silo_directory};
+   const rhydb::RhyDBDirectory silo_directory{append_config.silo_directory};
 
    const auto database_state_directory =
       getMostRecentOrSpecifiedDatabaseState(silo_directory, append_config.silo_data_source);

--- a/src/rhydb/common/german_string.h
+++ b/src/rhydb/common/german_string.h
@@ -109,6 +109,6 @@ class GermanString {
    }
 };
 
-using SiloString = GermanString<12, storage::vector::VariableDataRegistry::Identifier>;
+using RhyDBString = GermanString<12, storage::vector::VariableDataRegistry::Identifier>;
 
 }  // namespace rhydb

--- a/src/rhydb/common/german_string.test.cpp
+++ b/src/rhydb/common/german_string.test.cpp
@@ -3,17 +3,17 @@
 #include <gtest/gtest.h>
 
 using rhydb::GermanString;
-using rhydb::SiloString;
+using rhydb::RhyDBString;
 
 TEST(String, correctToString) {
-   const SiloString under_test("value 1");
+   const RhyDBString under_test("value 1");
 
    EXPECT_TRUE(under_test.isInPlace());
    EXPECT_EQ(under_test.getShortString(), "value 1");
 }
 
 TEST(String, correctWithEmptyString) {
-   const SiloString under_test("");
+   const RhyDBString under_test("");
 
    EXPECT_TRUE(under_test.isInPlace());
    EXPECT_EQ(under_test.getShortString(), "");
@@ -21,7 +21,7 @@ TEST(String, correctWithEmptyString) {
 
 using rhydb::storage::vector::VariableDataRegistry;
 TEST(String, correctlyReturnsSuffixId) {
-   const SiloString under_test(
+   const RhyDBString under_test(
       100, "prfx", VariableDataRegistry::Identifier{.page_id = 0, .offset = 3}
    );
 
@@ -30,7 +30,7 @@ TEST(String, correctlyReturnsSuffixId) {
 }
 
 TEST(String, correctlyReturnsLengthLong) {
-   const SiloString under_test(
+   const RhyDBString under_test(
       100, "prfx", VariableDataRegistry::Identifier{.page_id = 0, .offset = 3}
    );
 
@@ -38,7 +38,7 @@ TEST(String, correctlyReturnsLengthLong) {
 }
 
 TEST(String, correctlyReturnsLengthInPlace) {
-   const SiloString under_test("in_place");
+   const RhyDBString under_test("in_place");
 
    EXPECT_EQ(under_test.length(), 8);
 }

--- a/src/rhydb/common/silo_directory.cpp
+++ b/src/rhydb/common/silo_directory.cpp
@@ -4,7 +4,7 @@
 
 namespace rhydb {
 
-SiloDataSource SiloDataSource::checkValidDataSource(
+RhyDBDataSource RhyDBDataSource::checkValidDataSource(
    const std::filesystem::path& candidate_data_source_path
 ) {
    if (!std::filesystem::is_directory(candidate_data_source_path)) {
@@ -43,17 +43,17 @@ SiloDataSource SiloDataSource::checkValidDataSource(
          candidate_data_source_path.string()
       );
    }
-   SiloDataSource data_source{candidate_data_source_path, data_version_in_file};
+   RhyDBDataSource data_source{candidate_data_source_path, data_version_in_file};
    return data_source;
 }
 
-std::optional<SiloDataSource> SiloDirectory::getMostRecentDataDirectory() const {
+std::optional<RhyDBDataSource> RhyDBDirectory::getMostRecentDataDirectory() const {
    SPDLOG_TRACE("Scanning path {} for valid data", directory.string());
-   std::vector<SiloDataSource> all_found_data;
+   std::vector<RhyDBDataSource> all_found_data;
    for (const auto& directory_entry : std::filesystem::directory_iterator{directory}) {
       SPDLOG_TRACE("Checking directory entry {}", directory_entry.path().string());
       try {
-         auto silo_data_source = SiloDataSource::checkValidDataSource(directory_entry.path());
+         auto silo_data_source = RhyDBDataSource::checkValidDataSource(directory_entry.path());
          SPDLOG_TRACE(
             "Found candidate data source {} with data version {}",
             directory_entry.path().string(),
@@ -89,7 +89,7 @@ std::optional<SiloDataSource> SiloDirectory::getMostRecentDataDirectory() const 
    return std::nullopt;
 }
 
-std::string SiloDataSource::toDebugString() const {
+std::string RhyDBDataSource::toDebugString() const {
    return fmt::format(
       "{{path: '{}', data_version: {}}}", path.string(), this->data_version.toString()
    );

--- a/src/rhydb/common/silo_directory.h
+++ b/src/rhydb/common/silo_directory.h
@@ -21,41 +21,41 @@ class InvalidSiloDataSourceException : public std::runtime_error {
        : std::runtime_error(fmt::format(fmt_str, std::forward<Args>(args)...)) {}
 };
 
-class SiloDataSource {
-   SiloDataSource(std::filesystem::path path, rhydb::DataVersion data_version)
+class RhyDBDataSource {
+   RhyDBDataSource(std::filesystem::path path, rhydb::DataVersion data_version)
        : path(std::move(path)),
          data_version(std::move(data_version)) {}
 
   public:
-   SiloDataSource() = delete;
+   RhyDBDataSource() = delete;
 
    std::filesystem::path path;
    rhydb::DataVersion data_version;
 
-   static SiloDataSource checkValidDataSource(
+   static RhyDBDataSource checkValidDataSource(
       const std::filesystem::path& candidate_data_source_path
    );
 
    [[nodiscard]] std::string toDebugString() const;
 };
 
-class SiloDirectory {
+class RhyDBDirectory {
    std::filesystem::path directory;
 
   public:
-   explicit SiloDirectory(std::filesystem::path directory)
+   explicit RhyDBDirectory(std::filesystem::path directory)
        : directory(std::move(directory)) {}
 
-   [[nodiscard]] std::optional<SiloDataSource> getMostRecentDataDirectory() const;
+   [[nodiscard]] std::optional<RhyDBDataSource> getMostRecentDataDirectory() const;
 
-   NLOHMANN_DEFINE_TYPE_INTRUSIVE(SiloDirectory, directory);
+   NLOHMANN_DEFINE_TYPE_INTRUSIVE(RhyDBDirectory, directory);
 };
 
 }  // namespace rhydb
 
 template <>
-struct [[maybe_unused]] fmt::formatter<rhydb::SiloDirectory> : fmt::formatter<std::string> {
-   [[maybe_unused]] static auto format(const rhydb::SiloDirectory& val, format_context& ctx)
+struct [[maybe_unused]] fmt::formatter<rhydb::RhyDBDirectory> : fmt::formatter<std::string> {
+   [[maybe_unused]] static auto format(const rhydb::RhyDBDirectory& val, format_context& ctx)
       -> decltype(ctx.out()) {
       auto out = ctx.out();
       const nlohmann::json json = val;

--- a/src/rhydb/common/silo_directory.test.cpp
+++ b/src/rhydb/common/silo_directory.test.cpp
@@ -2,11 +2,11 @@
 
 #include <gtest/gtest.h>
 
-using rhydb::SiloDirectory;
+using rhydb::RhyDBDirectory;
 
 TEST(DatabaseDirectoryWatcher, validBackwardsCompatible) {
    auto under_test =
-      rhydb::SiloDataSource::checkValidDataSource("testBaseData/dataDirectories/1234");
+      rhydb::RhyDBDataSource::checkValidDataSource("testBaseData/dataDirectories/1234");
    ASSERT_FALSE(under_test.data_version.isCompatibleVersion());
    ASSERT_EQ(
       under_test.data_version.getTimestamp(), rhydb::DataVersion::Timestamp::fromString("1234")
@@ -15,7 +15,7 @@ TEST(DatabaseDirectoryWatcher, validBackwardsCompatible) {
 
 TEST(DatabaseDirectoryWatcher, validNewFormatOldVersion) {
    auto under_test =
-      rhydb::SiloDataSource::checkValidDataSource("testBaseData/dataDirectories/1235");
+      rhydb::RhyDBDataSource::checkValidDataSource("testBaseData/dataDirectories/1235");
    ASSERT_FALSE(under_test.data_version.isCompatibleVersion());
    ASSERT_EQ(
       under_test.data_version.getTimestamp(), rhydb::DataVersion::Timestamp::fromString("1235")
@@ -25,13 +25,13 @@ TEST(DatabaseDirectoryWatcher, validNewFormatOldVersion) {
 TEST(DatabaseDirectoryWatcher, validNewFormatCurrentVersion) {
    auto most_recent = rhydb::DataVersion::mineDataVersion();
 
-   std::filesystem::path test_data_directories_dir{"testBaseData/dataDirectories"};
+   const std::filesystem::path test_data_directories_dir{"testBaseData/dataDirectories"};
    auto most_recent_save_dir = test_data_directories_dir / most_recent.getTimestamp().value;
    std::filesystem::create_directory(most_recent_save_dir);
 
    most_recent.saveToFile(most_recent_save_dir / "data_version.silo");
 
-   auto under_test = rhydb::SiloDataSource::checkValidDataSource(most_recent_save_dir);
+   auto under_test = rhydb::RhyDBDataSource::checkValidDataSource(most_recent_save_dir);
    ASSERT_TRUE(under_test.data_version.isCompatibleVersion());
    ASSERT_EQ(under_test.data_version.getTimestamp(), most_recent.getTimestamp());
 
@@ -40,7 +40,7 @@ TEST(DatabaseDirectoryWatcher, validNewFormatCurrentVersion) {
 
 TEST(DatabaseDirectoryWatcher, validNewFormatIncompatible) {
    auto under_test =
-      rhydb::SiloDataSource::checkValidDataSource("testBaseData/dataDirectories/9999999999991234");
+      rhydb::RhyDBDataSource::checkValidDataSource("testBaseData/dataDirectories/9999999999991234");
    ASSERT_FALSE(under_test.data_version.isCompatibleVersion());
    ASSERT_EQ(
       under_test.data_version.getTimestamp(),
@@ -49,30 +49,30 @@ TEST(DatabaseDirectoryWatcher, validNewFormatIncompatible) {
 }
 
 TEST(DatabaseDirectoryWatcher, invalidFormat) {
-   ASSERT_ANY_THROW(rhydb::SiloDataSource::checkValidDataSource("testBaseData/dataDirectories/3123")
-   );
+   ASSERT_ANY_THROW(rhydb::RhyDBDataSource::checkValidDataSource("testBaseData/dataDirectories/3123"
+   ));
 }
 
 TEST(DatabaseDirectoryWatcher, invalidUInt32) {
-   ASSERT_ANY_THROW(rhydb::SiloDataSource::checkValidDataSource("testBaseData/dataDirectories/3124")
-   );
+   ASSERT_ANY_THROW(rhydb::RhyDBDataSource::checkValidDataSource("testBaseData/dataDirectories/3124"
+   ));
 }
 
 TEST(DatabaseDirectoryWatcher, invalidYAML) {
-   ASSERT_ANY_THROW(rhydb::SiloDataSource::checkValidDataSource("testBaseData/dataDirectories/3125")
-   );
+   ASSERT_ANY_THROW(rhydb::RhyDBDataSource::checkValidDataSource("testBaseData/dataDirectories/3125"
+   ));
 }
 
 TEST(DatabaseDirectoryWatcher, getsMostRecentCompatible) {
    auto most_recent = rhydb::DataVersion::mineDataVersion();
 
-   std::filesystem::path test_data_directories_dir{"testBaseData/dataDirectories"};
+   const std::filesystem::path test_data_directories_dir{"testBaseData/dataDirectories"};
    auto most_recent_save_dir = test_data_directories_dir / most_recent.getTimestamp().value;
    std::filesystem::create_directory(most_recent_save_dir);
 
    most_recent.saveToFile(most_recent_save_dir / "data_version.silo");
 
-   auto under_test = SiloDirectory{"testBaseData/dataDirectories"};
+   auto under_test = RhyDBDirectory{"testBaseData/dataDirectories"};
    auto under_test_most_recent = under_test.getMostRecentDataDirectory();
    ASSERT_TRUE(under_test_most_recent.has_value());
    ASSERT_EQ(under_test_most_recent.value().path, most_recent_save_dir);

--- a/src/rhydb/database.cpp
+++ b/src/rhydb/database.cpp
@@ -415,7 +415,7 @@ DataVersion loadDataVersion(const std::filesystem::path& file_path) {
 std::optional<Database> Database::loadDatabaseStateFromPath(
    const std::filesystem::path& save_directory
 ) {
-   const SiloDirectory silo_directory{save_directory};
+   const RhyDBDirectory silo_directory{save_directory};
    auto silo_data_source = silo_directory.getMostRecentDataDirectory();
    if (silo_data_source.has_value()) {
       return loadDatabaseState(silo_data_source.value());
@@ -423,7 +423,7 @@ std::optional<Database> Database::loadDatabaseStateFromPath(
    return std::nullopt;
 }
 
-Database Database::loadDatabaseState(const rhydb::SiloDataSource& silo_data_source) {
+Database Database::loadDatabaseState(const rhydb::RhyDBDataSource& silo_data_source) {
    SPDLOG_INFO("Loading database from data source: {}", silo_data_source.toDebugString());
    const auto save_directory = silo_data_source.path;
 

--- a/src/rhydb/database.h
+++ b/src/rhydb/database.h
@@ -92,7 +92,7 @@ class Database {
       const std::filesystem::path& save_directory
    );
 
-   static Database loadDatabaseState(const SiloDataSource& silo_data_source);
+   static Database loadDatabaseState(const RhyDBDataSource& silo_data_source);
 
    [[nodiscard]] virtual DatabaseInfo getDatabaseInfo() const;
 

--- a/src/rhydb/database.test.cpp
+++ b/src/rhydb/database.test.cpp
@@ -78,8 +78,8 @@ TEST(DatabaseTest, shouldSaveAndReloadDatabaseWithoutErrors) {
 
    first_database->saveDatabaseState(directory);
 
-   const rhydb::SiloDataSource data_source =
-      rhydb::SiloDataSource::checkValidDataSource(directory / data_version_timestamp.value);
+   const rhydb::RhyDBDataSource data_source =
+      rhydb::RhyDBDataSource::checkValidDataSource(directory / data_version_timestamp.value);
 
    auto database = rhydb::Database::loadDatabaseState(data_source);
 
@@ -101,7 +101,7 @@ TEST(DatabaseTest, shouldReturnCorrectDatabaseInfoAfterAppendingNewSequences) {
    // If this load fails, the serialization version likely needs to be increased
    // Run `make bump-serialization-version`
    auto database = rhydb::Database::loadDatabaseState(
-      rhydb::SiloDirectory{"testBaseData/siloSerializedState"}.getMostRecentDataDirectory().value()
+      rhydb::RhyDBDirectory{"testBaseData/siloSerializedState"}.getMostRecentDataDirectory().value()
    );
 
    const auto database_info = database.getDatabaseInfo();

--- a/src/rhydb/query_engine/filter/operators/selection.cpp
+++ b/src/rhydb/query_engine/filter/operators/selection.cpp
@@ -168,7 +168,7 @@ bool CompareToValueSelection<StringColumn>::match(uint32_t global_row_id) const 
       return with_nulls;
    }
 
-   const SiloString row_value = column.getValue(row_id);
+   const RhyDBString row_value = column.getValue(row_id);
 
    auto fast_compare = row_value.fastCompare(value);
    if (fast_compare.has_value()) {

--- a/src/rhydb/storage/column/string_column.cpp
+++ b/src/rhydb/storage/column/string_column.cpp
@@ -16,29 +16,29 @@ using rhydb::common::TreeNodeId;
 namespace rhydb::storage::column {
 
 size_t StringColumnChunk::insert(std::string_view value) {
-   if (value.size() <= SiloString::SHORT_STRING_SIZE) {
-      return fixed_string_data.insert(SiloString{value});
+   if (value.size() <= RhyDBString::SHORT_STRING_SIZE) {
+      return fixed_string_data.insert(RhyDBString{value});
    }
    SILO_ASSERT(value.length() < UINT32_MAX);
-   auto suffix_id = variable_string_data.insert(value.substr(SiloString::PREFIX_LENGTH));
-   return fixed_string_data.insert(SiloString{
-      static_cast<uint32_t>(value.length()), value.substr(0, SiloString::PREFIX_LENGTH), suffix_id
+   auto suffix_id = variable_string_data.insert(value.substr(RhyDBString::PREFIX_LENGTH));
+   return fixed_string_data.insert(RhyDBString{
+      static_cast<uint32_t>(value.length()), value.substr(0, RhyDBString::PREFIX_LENGTH), suffix_id
    });
 }
 
 size_t StringColumnChunk::insertNull() {
-   return fixed_string_data.insert(SiloString(""));
+   return fixed_string_data.insert(RhyDBString(""));
 }
 
 size_t StringColumnChunk::numValues() const {
    return fixed_string_data.numValues();
 }
 
-SiloString StringColumnChunk::getValue(size_t row_in_chunk) const {
+RhyDBString StringColumnChunk::getValue(size_t row_in_chunk) const {
    return fixed_string_data.get(row_in_chunk);
 }
 
-std::string StringColumnChunk::lookupValue(SiloString string) const {
+std::string StringColumnChunk::lookupValue(RhyDBString string) const {
    if (string.isInPlace()) {
       auto string_view = string.getShortString();
       return std::string{string_view};
@@ -60,7 +60,7 @@ std::string StringColumnChunk::lookupValue(SiloString string) const {
 StringColumn::StringColumn(StringColumnMetadata* metadata)
     : metadata(metadata) {}
 
-SiloString StringColumn::getValue(RowId row_id) const {
+RhyDBString StringColumn::getValue(RowId row_id) const {
    return chunks[row_id.chunk_id].getValue(row_id.row_in_chunk);
 }
 

--- a/src/rhydb/storage/column/string_column.h
+++ b/src/rhydb/storage/column/string_column.h
@@ -83,11 +83,11 @@ class StringColumnChunk {
 
    [[nodiscard]] size_t numValues() const;
 
-   [[nodiscard]] SiloString getValue(size_t row_in_chunk) const;
+   [[nodiscard]] RhyDBString getValue(size_t row_in_chunk) const;
 
    /// This includes an (re)allocation of the resulting string, one should generally
-   /// work with the SiloString and @getValue instead
-   [[nodiscard]] std::string lookupValue(SiloString string) const;
+   /// work with the RhyDBString and @getValue instead
+   [[nodiscard]] std::string lookupValue(RhyDBString string) const;
 
    template <class Archive>
    [[maybe_unused]] void serialize(Archive& archive, const uint32_t /* version */) {
@@ -128,7 +128,7 @@ class StringColumn {
 
    [[nodiscard]] bool isNull(RowId row_id) const;
 
-   [[nodiscard]] SiloString getValue(RowId row_id) const;
+   [[nodiscard]] RhyDBString getValue(RowId row_id) const;
 
    [[nodiscard]] std::string getValueString(RowId row_id) const;
 

--- a/src/rhydb/storage/vector/german_string_registry.cpp
+++ b/src/rhydb/storage/vector/german_string_registry.cpp
@@ -2,7 +2,7 @@
 
 namespace rhydb::storage::vector {
 
-Idx GermanStringRegistry::insert(const rhydb::SiloString& silo_string) {
+Idx GermanStringRegistry::insert(const rhydb::RhyDBString& silo_string) {
    const bool need_new_page = german_string_pages.empty() || german_string_pages.back().full();
    if (need_new_page) {
       german_string_pages.emplace_back();
@@ -12,7 +12,7 @@ Idx GermanStringRegistry::insert(const rhydb::SiloString& silo_string) {
    return (page_id * GermanStringPage::MAX_STRINGS_PER_PAGE) + row_in_page;
 }
 
-SiloString GermanStringRegistry::get(Idx row_id) const {
+RhyDBString GermanStringRegistry::get(Idx row_id) const {
    const Idx page_id = row_id / GermanStringPage::MAX_STRINGS_PER_PAGE;
    const Idx row_in_page = row_id - (page_id * GermanStringPage::MAX_STRINGS_PER_PAGE);
    return german_string_pages.at(page_id).get(row_in_page);

--- a/src/rhydb/storage/vector/german_string_registry.h
+++ b/src/rhydb/storage/vector/german_string_registry.h
@@ -14,9 +14,9 @@ class GermanStringPage {
    //
    //     2B     14B          16B
    //    |---|----------|--------------|--------------|--------------|
-   //    | n | reserved |  SiloString  |  SiloString  |  SiloString  |
+   //    | n | reserved |  RhyDBString |  RhyDBString |  RhyDBString |
    //    |---|----------|--------------|--------------|--------------|
-   //    |  SiloString  |  SiloString  |  SiloString  |              |
+   //    |  RhyDBString |  RhyDBString |  RhyDBString |              |
    //    |--------------|--------------|--------------|              |
    //    |                                                           |
    //    |                                                           |
@@ -24,8 +24,8 @@ class GermanStringPage {
    //    |-----------------------------------------------------------|
    //                                                                `16384
    //
-   // A total of 16384/16 - 1= 1023 SiloStrings would fit on the page
-   static_assert(sizeof(SiloString) == 16);
+   // A total of 16384/16 - 1= 1023 RhyDBStrings would fit on the page
+   static_assert(sizeof(RhyDBString) == 16);
    static constexpr size_t MAX_STRINGS_PER_PAGE = 1023;
    struct Header {
       std::array<uint8_t, 16> bytes;
@@ -41,22 +41,22 @@ class GermanStringPage {
 
    [[nodiscard]] bool full() const { return n() == MAX_STRINGS_PER_PAGE; }
 
-   [[nodiscard]] size_t insert(const SiloString& silo_string) const {
+   [[nodiscard]] size_t insert(const RhyDBString& silo_string) const {
       SILO_ASSERT(full() == false);
       // We need to silence a false-positive warning, where the linter does not realise that
       // the placement-new in the next expression needs a writeable pointer
       // NOLINTNEXTLINE(misc-const-correctness)
       uint8_t* const start_of_next_string_struct =
-         page.buffer + sizeof(Header) + (n() * sizeof(SiloString));
-      new (start_of_next_string_struct) SiloString(silo_string);
+         page.buffer + sizeof(Header) + (n() * sizeof(RhyDBString));
+      new (start_of_next_string_struct) RhyDBString(silo_string);
       return n()++;
    }
 
-   [[nodiscard]] const SiloString& get(const Idx& row_id) const {
+   [[nodiscard]] const RhyDBString& get(const Idx& row_id) const {
       SILO_ASSERT(row_id < n());
       uint8_t* start_of_string_struct =
-         page.buffer + sizeof(Header) + (row_id * sizeof(SiloString));
-      return *reinterpret_cast<SiloString*>(start_of_string_struct);
+         page.buffer + sizeof(Header) + (row_id * sizeof(RhyDBString));
+      return *reinterpret_cast<RhyDBString*>(start_of_string_struct);
    }
 
   private:
@@ -74,9 +74,9 @@ class GermanStringRegistry {
    std::deque<GermanStringPage> german_string_pages;
 
   public:
-   Idx insert(const SiloString& silo_string);
+   Idx insert(const RhyDBString& silo_string);
 
-   [[nodiscard]] SiloString get(Idx row_id) const;
+   [[nodiscard]] RhyDBString get(Idx row_id) const;
 
    [[nodiscard]] size_t numValues() const {
       if (german_string_pages.empty()) {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1464

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This renames all classes that are prefixed with `Silo` to start with `RhyDB` instead.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
