### PR TITLE
refactor(rhydb): add type() function to columns

### DIFF
--- a/src/rhydb/common/aa_symbols.h
+++ b/src/rhydb/common/aa_symbols.h
@@ -52,6 +52,7 @@ class AminoAcid {
    };
 
    static constexpr schema::ColumnType COLUMN_TYPE = schema::ColumnType::AMINO_ACID_SEQUENCE;
+   static constexpr schema::ValueType VALUE_TYPE = schema::ValueType::AMINO_ACID_SEQUENCE;
    using Column = storage::column::SequenceColumn<AminoAcid>;
 
    static constexpr uint32_t COUNT = 28;

--- a/src/rhydb/common/nucleotide_symbols.h
+++ b/src/rhydb/common/nucleotide_symbols.h
@@ -40,6 +40,7 @@ class Nucleotide {
    };
 
    static constexpr schema::ColumnType COLUMN_TYPE = schema::ColumnType::NUCLEOTIDE_SEQUENCE;
+   static constexpr schema::ValueType VALUE_TYPE = schema::ValueType::NUCLEOTIDE_SEQUENCE;
    using Column = storage::column::SequenceColumn<Nucleotide>;
 
    static constexpr uint32_t COUNT = 16;

--- a/src/rhydb/config/database_config.cpp
+++ b/src/rhydb/config/database_config.cpp
@@ -12,7 +12,7 @@
 
 #include "config/config_exception.h"
 
-using rhydb::config::ValueType;
+using rhydb::schema::ValueType;
 
 ValueType rhydb::config::toDatabaseValueType(std::string_view type) {
    if (type == "string") {
@@ -64,27 +64,6 @@ std::string_view rhydb::config::lineageIndexTypeToString(LineageIndexType type) 
    }
    SILO_UNREACHABLE();
 }
-
-namespace {
-
-std::string toString(ValueType type) {
-   switch (type) {
-      case ValueType::STRING:
-         return "string";
-      case ValueType::DATE:
-         return "date";
-      case ValueType::BOOL:
-         return "boolean";
-      case ValueType::INT32:
-         return "int";
-      case ValueType::INT64:
-         return "int64";
-      case ValueType::FLOAT:
-         return "float";
-   }
-   SILO_UNREACHABLE();
-}
-}  // namespace
 
 bool YAML::convert<rhydb::config::DatabaseConfig>::decode(
    const Node& node,
@@ -166,12 +145,15 @@ bool YAML::convert<rhydb::config::DatabaseMetadata>::decode(
    }
    return true;
 }
+
+using rhydb::schema::valueTypeToString;
+
 YAML::Node YAML::convert<rhydb::config::DatabaseMetadata>::encode(
    const rhydb::config::DatabaseMetadata& metadata
 ) {
    Node node;
    node["name"] = metadata.name;
-   node["type"] = toString(metadata.type);
+   node["type"] = std::string{valueTypeToString(metadata.type)};
    node["generateIndex"] = metadata.generate_index;
    if (metadata.generate_lineage_index) {
       node["generateLineageIndex"] = metadata.generate_lineage_index.value();
@@ -376,28 +358,7 @@ void DatabaseConfig::validateConfig(const DatabaseConfig& config) {
       ctx.out(),
       "{{ name: '{}', type: '{}', generate_index: {} }}",
       database_metadata.name,
-      database_metadata.type,
+      valueTypeToString(database_metadata.type),
       database_metadata.generate_index
    );
-}
-
-[[maybe_unused]] auto fmt::formatter<rhydb::config::ValueType>::format(
-   const rhydb::config::ValueType& value_type,
-   fmt::format_context& ctx
-) -> decltype(ctx.out()) {
-   switch (value_type) {
-      case rhydb::config::ValueType::STRING:
-         return fmt::format_to(ctx.out(), "string");
-      case rhydb::config::ValueType::DATE:
-         return fmt::format_to(ctx.out(), "date");
-      case rhydb::config::ValueType::BOOL:
-         return fmt::format_to(ctx.out(), "bool");
-      case rhydb::config::ValueType::INT32:
-         return fmt::format_to(ctx.out(), "int");
-      case rhydb::config::ValueType::INT64:
-         return fmt::format_to(ctx.out(), "int64");
-      case rhydb::config::ValueType::FLOAT:
-         return fmt::format_to(ctx.out(), "float");
-   }
-   return fmt::format_to(ctx.out(), "unknown");
 }

--- a/src/rhydb/config/database_config.h
+++ b/src/rhydb/config/database_config.h
@@ -13,9 +13,7 @@
 
 namespace rhydb::config {
 
-enum class ValueType : uint8_t { STRING, DATE, BOOL, INT32, INT64, FLOAT };
-
-ValueType toDatabaseValueType(std::string_view type);
+schema::ValueType toDatabaseValueType(std::string_view type);
 
 enum class LineageIndexType : uint8_t { COLUMN_METADATA, TABLE, BOTH };
 
@@ -26,7 +24,7 @@ std::string_view lineageIndexTypeToString(LineageIndexType type);
 class DatabaseMetadata {
   public:
    std::string name;
-   ValueType type;
+   schema::ValueType type;
    bool generate_index;
    std::optional<std::string> generate_lineage_index;
    LineageIndexType lineage_index_type = LineageIndexType::COLUMN_METADATA;
@@ -124,16 +122,6 @@ class [[maybe_unused]] fmt::formatter<rhydb::config::DatabaseMetadata> {
    static constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
    [[maybe_unused]] static auto format(
       const rhydb::config::DatabaseMetadata& database_metadata,
-      format_context& ctx
-   ) -> decltype(ctx.out());
-};
-
-template <>
-class [[maybe_unused]] fmt::formatter<rhydb::config::ValueType> {
-  public:
-   static constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-   [[maybe_unused]] static auto format(
-      const rhydb::config::ValueType& value_type,
       format_context& ctx
    ) -> decltype(ctx.out());
 };

--- a/src/rhydb/config/database_config.test.cpp
+++ b/src/rhydb/config/database_config.test.cpp
@@ -8,8 +8,8 @@
 using rhydb::config::ConfigException;
 using rhydb::config::DatabaseConfig;
 using rhydb::config::toDatabaseValueType;
-using rhydb::config::ValueType;
 using rhydb::schema::ColumnType;
+using rhydb::schema::ValueType;
 
 TEST(DatabaseMetadataType, shouldBeConvertableFromString) {
    ASSERT_TRUE(toDatabaseValueType("string") == ValueType::STRING);

--- a/src/rhydb/schema/database_schema.h
+++ b/src/rhydb/schema/database_schema.h
@@ -30,6 +30,20 @@ enum class ColumnType : uint8_t {
    ZSTD_COMPRESSED_STRING,
 };
 
+/// The logical type of the values a column holds, as opposed to the storage-specific `ColumnType`
+/// (e.g. both `STRING` and `DICTIONARY_ENCODED` columns hold `ValueType::STRING` values). This is
+/// the type a column reports via `type()`.
+enum class ValueType : uint8_t {
+   STRING,
+   DATE,
+   BOOL,
+   INT32,
+   INT64,
+   FLOAT,
+   NUCLEOTIDE_SEQUENCE,
+   AMINO_ACID_SEQUENCE
+};
+
 constexpr std::string_view columnTypeToString(ColumnType type) {
    switch (type) {
       case ColumnType::STRING:
@@ -52,6 +66,28 @@ constexpr std::string_view columnTypeToString(ColumnType type) {
          return "NUCLEOTIDE_SEQUENCE";
       case ColumnType::ZSTD_COMPRESSED_STRING:
          return "ZSTD_COMPRESSED_STRING";
+   }
+   SILO_UNREACHABLE();
+}
+
+constexpr std::string_view valueTypeToString(ValueType type) {
+   switch (type) {
+      case ValueType::STRING:
+         return "string";
+      case ValueType::DATE:
+         return "date";
+      case ValueType::BOOL:
+         return "boolean";
+      case ValueType::INT32:
+         return "int";
+      case ValueType::INT64:
+         return "int64";
+      case ValueType::FLOAT:
+         return "float";
+      case ValueType::NUCLEOTIDE_SEQUENCE:
+         return "nucleotideSequence";
+      case ValueType::AMINO_ACID_SEQUENCE:
+         return "aminoAcidSequence";
    }
    SILO_UNREACHABLE();
 }

--- a/src/rhydb/storage/column/bool_column.h
+++ b/src/rhydb/storage/column/bool_column.h
@@ -23,6 +23,7 @@ class BoolColumn {
    using Buffer = std::vector<std::optional<bool>>;
 
    static constexpr schema::ColumnType TYPE = schema::ColumnType::BOOL;
+   static constexpr schema::ValueType type() { return schema::ValueType::BOOL; }
    using value_type = bool;
 
    roaring::Roaring true_bitmap;

--- a/src/rhydb/storage/column/column.h
+++ b/src/rhydb/storage/column/column.h
@@ -7,7 +7,8 @@
 
 namespace rhydb::schema {
 enum class ColumnType : uint8_t;
-}
+enum class ValueType : uint8_t;
+}  // namespace rhydb::schema
 
 namespace rhydb::storage::column {
 
@@ -35,6 +36,9 @@ concept Column = requires(T column) {
    { column.chunkSize(static_cast<uint32_t>(0)) } -> std::convertible_to<uint32_t>;
 
    { T::TYPE } -> std::convertible_to<schema::ColumnType>;
+
+   // The logical type of the values this column holds (e.g. STRING, INT32, NUCLEOTIDE_SEQUENCE).
+   { column.type() } -> std::convertible_to<schema::ValueType>;
 };
 
 }  // namespace rhydb::storage::column

--- a/src/rhydb/storage/column/date32_column.h
+++ b/src/rhydb/storage/column/date32_column.h
@@ -25,6 +25,7 @@ class Date32Column {
    using Buffer = std::vector<std::optional<common::Date32>>;
 
    static constexpr schema::ColumnType TYPE = schema::ColumnType::DATE32;
+   static constexpr schema::ValueType type() { return schema::ValueType::DATE; }
    using value_type = common::Date32;
 
    [[maybe_unused]] Metadata* metadata;

--- a/src/rhydb/storage/column/dictionary_encoded_column.h
+++ b/src/rhydb/storage/column/dictionary_encoded_column.h
@@ -71,6 +71,7 @@ class DictionaryEncodedColumn {
    using Buffer = std::vector<std::optional<std::string>>;
 
    static constexpr schema::ColumnType TYPE = schema::ColumnType::DICTIONARY_ENCODED;
+   static constexpr schema::ValueType type() { return schema::ValueType::STRING; }
    using value_type = std::string_view;
 
    Metadata* metadata;

--- a/src/rhydb/storage/column/float_column.h
+++ b/src/rhydb/storage/column/float_column.h
@@ -25,6 +25,7 @@ class FloatColumn {
    using Buffer = std::vector<std::optional<double>>;
 
    static constexpr schema::ColumnType TYPE = schema::ColumnType::FLOAT;
+   static constexpr schema::ValueType type() { return schema::ValueType::FLOAT; }
    using value_type = double;
 
   private:

--- a/src/rhydb/storage/column/int_column.h
+++ b/src/rhydb/storage/column/int_column.h
@@ -24,12 +24,14 @@ struct NumericColumnTypeTraits;
 
 template <>
 struct NumericColumnTypeTraits<int32_t> {
-   static constexpr schema::ColumnType TYPE = schema::ColumnType::INT32;
+   static constexpr schema::ColumnType COLUMN_TYPE = schema::ColumnType::INT32;
+   static constexpr schema::ValueType VALUE_TYPE = schema::ValueType::INT32;
 };
 
 template <>
 struct NumericColumnTypeTraits<int64_t> {
-   static constexpr schema::ColumnType TYPE = schema::ColumnType::INT64;
+   static constexpr schema::ColumnType COLUMN_TYPE = schema::ColumnType::INT64;
+   static constexpr schema::ValueType VALUE_TYPE = schema::ValueType::INT64;
 };
 
 template <typename T>
@@ -45,7 +47,8 @@ class NumericColumn {
    using Builder = NumericColumnBuilder<T>;
    using Buffer = std::vector<std::optional<T>>;
 
-   static constexpr schema::ColumnType TYPE = NumericColumnTypeTraits<T>::TYPE;
+   static constexpr schema::ColumnType TYPE = NumericColumnTypeTraits<T>::COLUMN_TYPE;
+   static constexpr schema::ValueType type() { return NumericColumnTypeTraits<T>::VALUE_TYPE; }
    using value_type = T;
 
   private:

--- a/src/rhydb/storage/column/sequence_column.h
+++ b/src/rhydb/storage/column/sequence_column.h
@@ -77,6 +77,7 @@ class SequenceColumn {
    using Buffer = std::vector<BufferedSequence>;
 
    static constexpr schema::ColumnType TYPE = SymbolType::COLUMN_TYPE;
+   static constexpr schema::ValueType type() { return SymbolType::VALUE_TYPE; }
    using value_type = void;
 
   private:

--- a/src/rhydb/storage/column/string_column.h
+++ b/src/rhydb/storage/column/string_column.h
@@ -105,6 +105,7 @@ class StringColumn {
    using Buffer = std::vector<std::optional<std::string>>;
 
    static constexpr schema::ColumnType TYPE = schema::ColumnType::STRING;
+   static constexpr schema::ValueType type() { return schema::ValueType::STRING; }
    // The type with which one can call insert
    using value_type = std::string_view;
 

--- a/src/rhydb/storage/column/zstd_compressed_string_column.h
+++ b/src/rhydb/storage/column/zstd_compressed_string_column.h
@@ -42,6 +42,7 @@ class ZstdCompressedStringColumn {
    using Buffer = std::vector<std::optional<std::string>>;
 
    static constexpr schema::ColumnType TYPE = schema::ColumnType::ZSTD_COMPRESSED_STRING;
+   static constexpr schema::ValueType type() { return schema::ValueType::STRING; }
    using value_type = std::string_view;
 
   private:


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1458

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This minor refactor adds a dynamic type() function to all columns. Also the `ValueTyp` enum is moved to the `schema` namespace from the `config` namespace, because we will need to differentiate `ColumnType` from `ValueType` in the future. Consequently, nucleotide-sequences and amino-acid-sequences have been added to the `ValueType` enum

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
