### PR TITLE
refactor(rhydb): change internal representation in `CopyOnWriteBitmap`

### DIFF
--- a/src/rhydb/query_engine/copy_on_write_bitmap.cpp
+++ b/src/rhydb/query_engine/copy_on_write_bitmap.cpp
@@ -1,95 +1,366 @@
 #include "rhydb/query_engine/copy_on_write_bitmap.h"
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <span>
+#include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <roaring/roaring.hh>
 
 namespace rhydb::query_engine {
 
-CopyOnWriteBitmap::CopyOnWriteBitmap()
-    : mutable_bitmap(std::make_shared<roaring::Roaring>()),
-      immutable_bitmap(nullptr) {}
+using roaring_util::RoaringContainer;
+using roaring_util::RoaringContainerView;
 
-CopyOnWriteBitmap::CopyOnWriteBitmap(const roaring::Roaring* bitmap)
-    : mutable_bitmap(nullptr),
-      immutable_bitmap(bitmap) {}
-
-CopyOnWriteBitmap::CopyOnWriteBitmap(roaring::Roaring&& bitmap)
-    : mutable_bitmap(std::make_shared<roaring::Roaring>(std::move(bitmap))),
-      immutable_bitmap(nullptr) {}
-
-const roaring::Roaring& CopyOnWriteBitmap::getConstReference() const {
-   return immutable_bitmap ? *immutable_bitmap : *mutable_bitmap;
-}
-
-roaring::Roaring& CopyOnWriteBitmap::getMutable() {
-   if (!mutable_bitmap) {
-      mutable_bitmap = std::make_shared<roaring::Roaring>(*immutable_bitmap);
-      immutable_bitmap = nullptr;
+void CopyOnWriteBitmap::pushIfNonEmpty(
+   std::vector<uint16_t>& out_keys,
+   std::vector<Container>& out_containers,
+   uint16_t key,
+   roaring::internal::container_t* container,
+   uint8_t typecode
+) {
+   const auto cardinality =
+      static_cast<uint32_t>(roaring::internal::container_get_cardinality(container, typecode));
+   if (cardinality == 0) {
+      roaring::internal::container_free(container, typecode);
+      return;
    }
-   return *mutable_bitmap;
+   out_keys.push_back(key);
+   out_containers.emplace_back(RoaringContainer{container, cardinality, typecode});
 }
 
-bool CopyOnWriteBitmap::isMutable() const {
-   return mutable_bitmap != nullptr;
+RoaringContainerView CopyOnWriteBitmap::viewOf(const Container& container) {
+   return std::visit([](const auto& held) { return RoaringContainerView{held}; }, container);
+}
+
+CopyOnWriteBitmap::Container CopyOnWriteBitmap::copyContainer(const Container& container) {
+   return std::visit(
+      [](const auto& held) -> Container {
+         using Held = std::decay_t<decltype(held)>;
+         if constexpr (std::is_same_v<Held, RoaringContainerView>) {
+            return held;
+         } else {
+            return RoaringContainer::clonedFrom(held.rawContainer(), held.getTypecode());
+         }
+      },
+      container
+   );
+}
+
+CopyOnWriteBitmap::CopyOnWriteBitmap(const roaring::Roaring* bitmap) {
+   const auto& roaring_array = bitmap->roaring.high_low_container;
+   keys.reserve(roaring_array.size);
+   containers.reserve(roaring_array.size);
+   for (int32_t idx = 0; idx < roaring_array.size; ++idx) {
+      const auto cardinality = static_cast<uint32_t>(roaring::internal::container_get_cardinality(
+         roaring_array.containers[idx], roaring_array.typecodes[idx]
+      ));
+      keys.push_back(roaring_array.keys[idx]);
+      containers.emplace_back(RoaringContainerView{
+         roaring_array.containers[idx], cardinality, roaring_array.typecodes[idx]
+      });
+   }
+}
+
+CopyOnWriteBitmap::CopyOnWriteBitmap(roaring::Roaring&& bitmap) {
+   auto& roaring_array = bitmap.roaring.high_low_container;
+   keys.reserve(roaring_array.size);
+   containers.reserve(roaring_array.size);
+   for (int32_t idx = 0; idx < roaring_array.size; ++idx) {
+      const auto cardinality = static_cast<uint32_t>(roaring::internal::container_get_cardinality(
+         roaring_array.containers[idx], roaring_array.typecodes[idx]
+      ));
+      keys.push_back(roaring_array.keys[idx]);
+      containers.emplace_back(
+         RoaringContainer{roaring_array.containers[idx], cardinality, roaring_array.typecodes[idx]}
+      );
+   }
+   // The containers now belong to this object; drop the source's bookkeeping arrays without
+   // freeing the containers they pointed at.
+   roaring::internal::ra_clear_without_containers(&roaring_array);
+}
+
+CopyOnWriteBitmap::CopyOnWriteBitmap(const CopyOnWriteBitmap& other)
+    : keys(other.keys) {
+   containers.reserve(other.containers.size());
+   for (const auto& container : other.containers) {
+      containers.push_back(copyContainer(container));
+   }
+}
+
+CopyOnWriteBitmap& CopyOnWriteBitmap::operator=(const CopyOnWriteBitmap& other) {
+   if (this != &other) {
+      std::vector<Container> containers_copy;
+      containers_copy.reserve(other.containers.size());
+      for (const auto& container : other.containers) {
+         containers_copy.push_back(copyContainer(container));
+      }
+      keys = other.keys;
+      containers = std::move(containers_copy);
+   }
+   return *this;
 }
 
 uint64_t CopyOnWriteBitmap::cardinality() const {
-   return getConstReference().cardinality();
+   uint64_t total = 0;
+   for (const auto& container : containers) {
+      total += viewOf(container).getCardinality();
+   }
+   return total;
 }
 
 bool CopyOnWriteBitmap::isEmpty() const {
-   return getConstReference().isEmpty();
-}
-
-roaring::Roaring::const_iterator CopyOnWriteBitmap::begin() const {
-   return getConstReference().begin();
-}
-
-roaring::Roaring::const_iterator CopyOnWriteBitmap::end() const {
-   return getConstReference().end();
+   return keys.empty();
 }
 
 uint64_t CopyOnWriteBitmap::andCardinality(const CopyOnWriteBitmap& other) const {
-   return getConstReference().and_cardinality(other.getConstReference());
+   uint64_t total = 0;
+   size_t left = 0;
+   size_t right = 0;
+   while (left < keys.size() && right < other.keys.size()) {
+      if (keys[left] < other.keys[right]) {
+         ++left;
+      } else if (keys[left] > other.keys[right]) {
+         ++right;
+      } else {
+         const auto left_view = viewOf(containers[left]);
+         const auto right_view = viewOf(other.containers[right]);
+         total += static_cast<uint64_t>(roaring::internal::container_and_cardinality(
+            left_view.rawContainer(),
+            left_view.getTypecode(),
+            right_view.rawContainer(),
+            right_view.getTypecode()
+         ));
+         ++left;
+         ++right;
+      }
+   }
+   return total;
 }
 
 CopyOnWriteBitmap& CopyOnWriteBitmap::operator&=(const CopyOnWriteBitmap& other) {
-   getMutable() &= other.getConstReference();
+   std::vector<uint16_t> result_keys;
+   std::vector<Container> result_containers;
+   size_t left = 0;
+   size_t right = 0;
+   while (left < keys.size() && right < other.keys.size()) {
+      if (keys[left] < other.keys[right]) {
+         ++left;
+      } else if (keys[left] > other.keys[right]) {
+         ++right;
+      } else {
+         const auto left_view = viewOf(containers[left]);
+         const auto right_view = viewOf(other.containers[right]);
+         uint8_t result_typecode = 0;
+         auto* result_container = roaring::internal::container_and(
+            left_view.rawContainer(),
+            left_view.getTypecode(),
+            right_view.rawContainer(),
+            right_view.getTypecode(),
+            &result_typecode
+         );
+         pushIfNonEmpty(
+            result_keys, result_containers, keys[left], result_container, result_typecode
+         );
+         ++left;
+         ++right;
+      }
+   }
+   keys = std::move(result_keys);
+   containers = std::move(result_containers);
    return *this;
 }
 
 CopyOnWriteBitmap& CopyOnWriteBitmap::operator-=(const CopyOnWriteBitmap& other) {
-   getMutable() -= other.getConstReference();
+   std::vector<uint16_t> result_keys;
+   std::vector<Container> result_containers;
+   size_t left = 0;
+   size_t right = 0;
+   while (left < keys.size()) {
+      if (right >= other.keys.size() || keys[left] < other.keys[right]) {
+         result_keys.push_back(keys[left]);
+         result_containers.push_back(std::move(containers[left]));
+         ++left;
+      } else if (keys[left] > other.keys[right]) {
+         ++right;
+      } else {
+         const auto left_view = viewOf(containers[left]);
+         const auto right_view = viewOf(other.containers[right]);
+         uint8_t result_typecode = 0;
+         auto* result_container = roaring::internal::container_andnot(
+            left_view.rawContainer(),
+            left_view.getTypecode(),
+            right_view.rawContainer(),
+            right_view.getTypecode(),
+            &result_typecode
+         );
+         pushIfNonEmpty(
+            result_keys, result_containers, keys[left], result_container, result_typecode
+         );
+         ++left;
+         ++right;
+      }
+   }
+   keys = std::move(result_keys);
+   containers = std::move(result_containers);
    return *this;
 }
 
 CopyOnWriteBitmap& CopyOnWriteBitmap::operator|=(const CopyOnWriteBitmap& other) {
-   getMutable() |= other.getConstReference();
+   std::vector<uint16_t> result_keys;
+   std::vector<Container> result_containers;
+   size_t left = 0;
+   size_t right = 0;
+   while (left < keys.size() || right < other.keys.size()) {
+      if (right >= other.keys.size() || (left < keys.size() && keys[left] < other.keys[right])) {
+         result_keys.push_back(keys[left]);
+         result_containers.push_back(std::move(containers[left]));
+         ++left;
+      } else if (left >= keys.size() || keys[left] > other.keys[right]) {
+         result_keys.push_back(other.keys[right]);
+         result_containers.push_back(copyContainer(other.containers[right]));
+         ++right;
+      } else {
+         const auto left_view = viewOf(containers[left]);
+         const auto right_view = viewOf(other.containers[right]);
+         uint8_t result_typecode = 0;
+         auto* result_container = roaring::internal::container_or(
+            left_view.rawContainer(),
+            left_view.getTypecode(),
+            right_view.rawContainer(),
+            right_view.getTypecode(),
+            &result_typecode
+         );
+         pushIfNonEmpty(
+            result_keys, result_containers, keys[left], result_container, result_typecode
+         );
+         ++left;
+         ++right;
+      }
+   }
+   keys = std::move(result_keys);
+   containers = std::move(result_containers);
    return *this;
 }
 
 CopyOnWriteBitmap CopyOnWriteBitmap::operator&(const CopyOnWriteBitmap& other) const {
-   return CopyOnWriteBitmap{getConstReference() & other.getConstReference()};
+   CopyOnWriteBitmap result;
+   size_t left = 0;
+   size_t right = 0;
+   while (left < keys.size() && right < other.keys.size()) {
+      if (keys[left] < other.keys[right]) {
+         ++left;
+      } else if (keys[left] > other.keys[right]) {
+         ++right;
+      } else {
+         const auto left_view = viewOf(containers[left]);
+         const auto right_view = viewOf(other.containers[right]);
+         uint8_t result_typecode = 0;
+         auto* result_container = roaring::internal::container_and(
+            left_view.rawContainer(),
+            left_view.getTypecode(),
+            right_view.rawContainer(),
+            right_view.getTypecode(),
+            &result_typecode
+         );
+         pushIfNonEmpty(
+            result.keys, result.containers, keys[left], result_container, result_typecode
+         );
+         ++left;
+         ++right;
+      }
+   }
+   return result;
 }
 
 CopyOnWriteBitmap CopyOnWriteBitmap::operator-(const CopyOnWriteBitmap& other) const {
-   return CopyOnWriteBitmap{getConstReference() - other.getConstReference()};
+   CopyOnWriteBitmap result = *this;
+   result -= other;
+   return result;
 }
 
 CopyOnWriteBitmap CopyOnWriteBitmap::fastUnion(const std::vector<CopyOnWriteBitmap>& bitmaps) {
-   std::vector<const roaring::Roaring*> inputs;
-   inputs.reserve(bitmaps.size());
-   for (const auto& bitmap : bitmaps) {
-      inputs.push_back(&bitmap.getConstReference());
+   // TODO(#1490) implement with n-way min-heap
+   if (bitmaps.empty()) {
+      return CopyOnWriteBitmap{};
    }
-   return CopyOnWriteBitmap{roaring::Roaring::fastunion(inputs.size(), inputs.data())};
+   std::span<const CopyOnWriteBitmap> bitmaps_span{bitmaps.data(), bitmaps.size()};
+   CopyOnWriteBitmap result = bitmaps_span.front();
+   for (const auto& bitmap : bitmaps_span.subspan(1)) {
+      result |= bitmap;
+   }
+   return result;
+}
+
+CopyOnWriteBitmap CopyOnWriteBitmap::fromContainerViews(
+   std::vector<std::pair<uint16_t, RoaringContainerView>> container_views
+) {
+   std::erase_if(container_views, [](const auto& container_view) {
+      return container_view.second.empty();
+   });
+
+   std::ranges::stable_sort(container_views, [](const auto& lhs, const auto& rhs) {
+      return lhs.first < rhs.first;
+   });
+
+   CopyOnWriteBitmap result;
+   size_t idx = 0;
+   while (idx < container_views.size()) {
+      const uint16_t key = container_views[idx].first;
+      size_t group_end = idx + 1;
+      while (group_end < container_views.size() && container_views[group_end].first == key) {
+         ++group_end;
+      }
+      if (group_end - idx == 1) {
+         // A single container for this key stays a zero-copy view
+         result.keys.push_back(key);
+         result.containers.emplace_back(container_views[idx].second);
+      } else {
+         // Several containers share this key (multiple requested symbols in one 2^16 block): OR
+         // them into one owning container.
+         const auto& first_view = container_views[idx].second;
+         auto* accumulator =
+            roaring::internal::container_clone(first_view.rawContainer(), first_view.getTypecode());
+         uint8_t accumulator_typecode = first_view.getTypecode();
+         for (size_t i = idx + 1; i < group_end; ++i) {
+            const auto& next_view = container_views[i].second;
+            uint8_t result_typecode = 0;
+            auto* result_container = roaring::internal::container_ior(
+               accumulator,
+               accumulator_typecode,
+               next_view.rawContainer(),
+               next_view.getTypecode(),
+               &result_typecode
+            );
+            if (result_container != accumulator) {
+               roaring::internal::container_free(accumulator, accumulator_typecode);
+               accumulator = result_container;
+               accumulator_typecode = result_typecode;
+            }
+         }
+         pushIfNonEmpty(result.keys, result.containers, key, accumulator, accumulator_typecode);
+      }
+      idx = group_end;
+   }
+   return result;
 }
 
 roaring::Roaring CopyOnWriteBitmap::toRoaring() const {
-   return getConstReference();
+   roaring::Roaring result;
+   for (size_t idx = 0; idx < keys.size(); ++idx) {
+      const auto container_view = viewOf(containers[idx]);
+      auto* clone = roaring::internal::container_clone(
+         container_view.rawContainer(), container_view.getTypecode()
+      );
+      roaring::internal::ra_append(
+         &result.roaring.high_low_container, keys[idx], clone, container_view.getTypecode()
+      );
+   }
+   return result;
 }
 
 }  // namespace rhydb::query_engine

--- a/src/rhydb/query_engine/copy_on_write_bitmap.h
+++ b/src/rhydb/query_engine/copy_on_write_bitmap.h
@@ -1,49 +1,123 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
-#include <memory>
+#include <iterator>
+#include <utility>
+#include <variant>
 #include <vector>
 
 #include <roaring/roaring.hh>
 
+#include "rhydb/roaring_util/roaring_container.h"
+
 namespace rhydb::query_engine {
 
-/// The return value of the Operator::evaluate method.
-/// May return either a mutable or immutable bitmap.
+/// The return value of the Operator::evaluate method: a full row-id set represented as a sorted
+/// list of 2^16-keyed containers -- the same decomposition a `roaring::Roaring` uses internally.
+/// Each container is either a non-owning `RoaringContainerView` into a container owned elsewhere (a
+/// column index, or another bitmap that outlives this one) or an owning `RoaringContainer`. A
+/// bitmap constructed from an existing `roaring::Roaring` starts as all views; the first set
+/// operation that has to change a container replaces that view with a private owning copy --
+/// copy-on-write, at the granularity of a single container.
 ///
-/// Set-algebra (AND, OR, ANDNOT and the matching cardinalities) is exposed as member operators so
-/// callers never have to reach for the underlying `roaring::Roaring` -- `toRoaring` materializes a
-/// standalone copy only at the very end of a query, where the result leaves the engine. The
-/// operators are currently thin wrappers over `roaring::Roaring`; keeping every caller on this API
-/// lets the internal representation change later without touching call sites.
+/// Set-algebra (AND, OR, ANDNOT and the matching cardinalities) is computed directly on these
+/// container lists through the roaring container-level C API, so intermediate query results never
+/// round-trip through a `roaring::Roaring`. Materialization back into a `roaring::Roaring`
+/// (`toRoaring`) is meant only for the end of a query, when the result leaves the engine.
 class CopyOnWriteBitmap {
-   std::shared_ptr<roaring::Roaring> mutable_bitmap;
-   const roaring::Roaring* immutable_bitmap;
+   /// A single 2^16 block's container, either a non-owning view or a privately-owned copy.
+   using Container =
+      std::variant<roaring_util::RoaringContainerView, roaring_util::RoaringContainer>;
 
-   [[nodiscard]] roaring::Roaring& getMutable();
+   /// Struct-of-arrays: `keys[i]` is the 2^16 block key of the container held in `containers[i]`,
+   /// so the two vectors always have the same length. `keys` is sorted strictly ascending and no
+   /// container is ever empty
+   std::vector<uint16_t> keys;
+   std::vector<Container> containers;
 
-   [[nodiscard]] const roaring::Roaring& getConstReference() const;
+   /// read-only handle onto a container, regardless of ownership.
+   static roaring_util::RoaringContainerView viewOf(const Container& container);
 
-   [[nodiscard]] bool isMutable() const;
+   /// Deep-copies a container: view alternatives are copied as views, owning alternatives are
+   /// cloned into independent owning containers.
+   static Container copyContainer(const Container& container);
+
+   /// Appends a freshly produced container (and its key) to the parallel output arrays, taking
+   /// ownership -- or frees it if empty, preserving roaring's "no empty containers" invariant.
+   static void pushIfNonEmpty(
+      std::vector<uint16_t>& out_keys,
+      std::vector<Container>& out_containers,
+      uint16_t key,
+      roaring::internal::container_t* container,
+      uint8_t typecode
+   );
 
   public:
-   CopyOnWriteBitmap();
+   CopyOnWriteBitmap() = default;
 
-   // A CopyOnWriteBitmap pointing into an immutable bitmap should only be constructed
-   // when the CopyOnWriteBitmap's lifetime is contained by bitmap
+   /// Views the containers of an externally owned bitmap. The pointee must outlive this object and
+   /// must not be mutated while views onto it exist.
    explicit CopyOnWriteBitmap(const roaring::Roaring* bitmap);
 
+   /// Takes ownership of the containers of `bitmap`, leaving `bitmap` empty.
    explicit CopyOnWriteBitmap(roaring::Roaring&& bitmap);
+
+   CopyOnWriteBitmap(const CopyOnWriteBitmap& other);
+   CopyOnWriteBitmap& operator=(const CopyOnWriteBitmap& other);
+   CopyOnWriteBitmap(CopyOnWriteBitmap&&) noexcept = default;
+   CopyOnWriteBitmap& operator=(CopyOnWriteBitmap&&) noexcept = default;
+   ~CopyOnWriteBitmap() = default;
 
    [[nodiscard]] uint64_t cardinality() const;
 
    [[nodiscard]] bool isEmpty() const;
 
-   /// Iterates the contained row ids in ascending order, enabling range-based for over the bitmap.
-   /// The iterators borrow the underlying bitmap, so it must outlive them and must not be mutated
-   /// while an iteration is in progress.
-   [[nodiscard]] roaring::Roaring::const_iterator begin() const;
-   [[nodiscard]] roaring::Roaring::const_iterator end() const;
+   /// Forward iterator over the bitmap's containers in ascending key order. Dereferencing yields a
+   /// `{key, view}` pair by value - the 2^16 block key (the high 16 bits of the row ids it holds)
+   /// and a non-owning view of its container - without materializing any intermediate collection.
+   /// Iterating the view in turn yields the low 16 bits of each contained row id
+   class ConstIterator {
+      const CopyOnWriteBitmap* bitmap = nullptr;
+      size_t index = 0;
+
+     public:
+      // The dereferenced pair is a value, not an lvalue in a container, so this is an input
+      // iterator; it is nonetheless multi-pass (nothing is consumed) and safe to traverse
+      // repeatedly.
+      using iterator_category = std::input_iterator_tag;
+      using value_type = std::pair<uint16_t, roaring_util::RoaringContainerView>;
+      using difference_type = std::ptrdiff_t;
+      using pointer = void;
+      using reference = value_type;
+
+      ConstIterator() = default;
+
+      ConstIterator(const CopyOnWriteBitmap* bitmap, size_t index)
+          : bitmap(bitmap),
+            index(index) {}
+
+      value_type operator*() const {
+         return {bitmap->keys[index], viewOf(bitmap->containers[index])};
+      }
+
+      ConstIterator& operator++() {
+         ++index;
+         return *this;
+      }
+
+      ConstIterator operator++(int) {
+         ConstIterator copy = *this;
+         ++index;
+         return copy;
+      }
+
+      bool operator==(const ConstIterator& other) const { return index == other.index; }
+      bool operator!=(const ConstIterator& other) const { return index != other.index; }
+   };
+
+   [[nodiscard]] ConstIterator begin() const { return ConstIterator{this, 0}; }
+   [[nodiscard]] ConstIterator end() const { return ConstIterator{this, keys.size()}; }
 
    /// Cardinality of the intersection with `other`, without materializing it.
    [[nodiscard]] uint64_t andCardinality(const CopyOnWriteBitmap& other) const;
@@ -55,8 +129,17 @@ class CopyOnWriteBitmap {
    [[nodiscard]] CopyOnWriteBitmap operator&(const CopyOnWriteBitmap& other) const;
    [[nodiscard]] CopyOnWriteBitmap operator-(const CopyOnWriteBitmap& other) const;
 
-   /// Union of many bitmaps.
+   /// Union of many bitmaps, computed container-by-container in a single k-way merge.
    [[nodiscard]] static CopyOnWriteBitmap fastUnion(const std::vector<CopyOnWriteBitmap>& bitmaps);
+
+   /// Builds a bitmap that *views* externally-owned containers (e.g. a column index's stored
+   /// containers) rather than cloning them: a key with a single container becomes a zero-copy
+   /// view, and keys shared by several containers are OR-ed into one owning container. The viewed
+   /// containers must outlive the returned bitmap and must not be mutated while it exists. Input
+   /// order does not matter.
+   [[nodiscard]] static CopyOnWriteBitmap fromContainerViews(
+      std::vector<std::pair<uint16_t, roaring_util::RoaringContainerView>> container_views
+   );
 
    /// Materializes into a standalone `roaring::Roaring`. Intended for the end of a query only,
    /// where the result is handed to a consumer -- not for intermediate computation.

--- a/src/rhydb/query_engine/copy_on_write_bitmap.test.cpp
+++ b/src/rhydb/query_engine/copy_on_write_bitmap.test.cpp
@@ -1,12 +1,19 @@
 #include "rhydb/query_engine/copy_on_write_bitmap.h"
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
 #include <roaring/roaring.hh>
 
+#include "rhydb/roaring_util/roaring_container.h"
+
 using rhydb::query_engine::CopyOnWriteBitmap;
+using rhydb::roaring_util::RoaringContainer;
+using rhydb::roaring_util::RoaringContainerView;
 
 namespace {
 
@@ -82,18 +89,158 @@ TEST(CopyOnWriteBitmap, unionInPlaceAndFastUnion) {
    EXPECT_EQ(CopyOnWriteBitmap::fastUnion(bitmaps).toRoaring(), first | second | third);
 }
 
-TEST(CopyOnWriteBitmap, iteratesRowIdsInAscendingOrder) {
+TEST(CopyOnWriteBitmap, fastUnionEdgeCases) {
+   EXPECT_TRUE(CopyOnWriteBitmap::fastUnion({}).toRoaring().isEmpty());
+
+   // Inputs that contribute no containers at all must not upset the merge.
+   const roaring::Roaring source = multiContainer();
+   std::vector<CopyOnWriteBitmap> with_empties;
+   with_empties.emplace_back();
+   with_empties.emplace_back(&source);
+   with_empties.emplace_back();
+   EXPECT_EQ(CopyOnWriteBitmap::fastUnion(with_empties).toRoaring(), source);
+
+   std::vector<CopyOnWriteBitmap> only_empties;
+   only_empties.emplace_back();
+   only_empties.emplace_back();
+   EXPECT_TRUE(CopyOnWriteBitmap::fastUnion(only_empties).toRoaring().isEmpty());
+
+   std::vector<CopyOnWriteBitmap> single;
+   single.emplace_back(&source);
+   EXPECT_EQ(CopyOnWriteBitmap::fastUnion(single).toRoaring(), source);
+}
+
+TEST(CopyOnWriteBitmap, fastUnionResultOutlivesItsInputs) {
+   // The inputs of a union are typically temporaries (the evaluated children of a Union operator),
+   // so the result must own its containers rather than view them.
+   const roaring::Roaring first{1, 5};
+   const roaring::Roaring second{5, 9, (2U << 16) + 1};
+   const roaring::Roaring expected = first | second;
+
+   CopyOnWriteBitmap result;
+   {
+      std::vector<CopyOnWriteBitmap> bitmaps;
+      bitmaps.emplace_back(roaring::Roaring{first});
+      bitmaps.emplace_back(roaring::Roaring{second});
+      result = CopyOnWriteBitmap::fastUnion(bitmaps);
+   }
+   EXPECT_EQ(result.toRoaring(), expected);
+}
+
+TEST(CopyOnWriteBitmap, fastUnionMergesManyInputsWithStaggeredKeyRanges) {
+   // Inputs whose key ranges start and end at different points, so cursors enter and leave the
+   // merge in a different order than they were added, and no single input spans every key.
+   std::vector<roaring::Roaring> sources;
+   for (uint32_t bitmap_index = 0; bitmap_index < 8; ++bitmap_index) {
+      roaring::Roaring source;
+      for (uint32_t key = bitmap_index; key < bitmap_index + 5; ++key) {
+         // Dense enough to hit array, bitset and run container representations.
+         source.addRange(
+            (key << 16U) + bitmap_index, (key << 16U) + bitmap_index + 5000 + (key * 100)
+         );
+         source.add((key << 16U) + 60000);
+      }
+      source.runOptimize();
+      sources.push_back(std::move(source));
+   }
+
+   roaring::Roaring expected;
+   std::vector<CopyOnWriteBitmap> bitmaps;
+   for (const auto& source : sources) {
+      expected |= source;
+      bitmaps.emplace_back(&source);
+   }
+
+   const auto united = CopyOnWriteBitmap::fastUnion(bitmaps);
+   EXPECT_EQ(united.toRoaring(), expected);
+   EXPECT_EQ(united.cardinality(), expected.cardinality());
+}
+
+TEST(CopyOnWriteBitmap, fastUnionIsOrderIndependentAndMatchesRepeatedOrEqual) {
+   const roaring::Roaring first{1, 5, 100};
+   const roaring::Roaring second = multiContainer();
+   const roaring::Roaring third{5, (3U << 16) + 7, (4U << 16) + 1};
+   const roaring::Roaring fourth{(4U << 16) + 1, (9U << 16)};
+
+   const std::vector<const roaring::Roaring*> sources{&first, &second, &third, &fourth};
+
+   roaring::Roaring expected;
+   CopyOnWriteBitmap accumulated;
+   for (const auto* source : sources) {
+      expected |= *source;
+      accumulated |= CopyOnWriteBitmap{source};
+   }
+   EXPECT_EQ(accumulated.toRoaring(), expected);
+
+   // Whichever order the inputs arrive in, the merge must produce the same set.
+   std::vector<size_t> order{0, 1, 2, 3};
+   do {
+      std::vector<CopyOnWriteBitmap> bitmaps;
+      bitmaps.reserve(order.size());
+      for (const size_t index : order) {
+         bitmaps.emplace_back(sources[index]);
+      }
+      EXPECT_EQ(CopyOnWriteBitmap::fastUnion(bitmaps).toRoaring(), expected);
+   } while (std::ranges::next_permutation(order).found);
+}
+
+TEST(CopyOnWriteBitmap, iteratingContainersReconstructsRowIdsInAscendingOrder) {
    const roaring::Roaring source = multiContainer();
    const CopyOnWriteBitmap under_test{&source};
 
    std::vector<uint32_t> iterated;
-   for (const uint32_t row : under_test) {
-      iterated.push_back(row);
+   for (const auto& [key, container_view] : under_test) {
+      const uint32_t high = static_cast<uint32_t>(key) << 16U;
+      for (const uint16_t low : container_view) {
+         iterated.push_back(high | low);
+      }
    }
    EXPECT_EQ(iterated, (std::vector<uint32_t>{1, 5, 100, (1U << 16) + 3, (3U << 16) + 7}));
 
    const CopyOnWriteBitmap empty;
    EXPECT_EQ(empty.begin(), empty.end());
+}
+
+TEST(CopyOnWriteBitmap, fromContainerViewsAssemblesAndOrsSharedKeys) {
+   // Owning containers the views borrow from; they must outlive the assembled bitmap.
+   auto block0 = RoaringContainer::withCapacity(4);
+   block0.add(1);
+   block0.add(5);
+   auto block1_first = RoaringContainer::withCapacity(4);
+   block1_first.add(3);
+   auto block1_second = RoaringContainer::withCapacity(4);
+   block1_second.add(9);
+   auto block3 = RoaringContainer::withCapacity(4);
+   block3.add(7);
+
+   // Deliberately out of key order, with key 1 appearing twice (must be OR-ed).
+   std::vector<std::pair<uint16_t, RoaringContainerView>> views;
+   views.emplace_back(3, RoaringContainerView{block3});
+   views.emplace_back(1, RoaringContainerView{block1_first});
+   views.emplace_back(0, RoaringContainerView{block0});
+   views.emplace_back(1, RoaringContainerView{block1_second});
+
+   const CopyOnWriteBitmap under_test = CopyOnWriteBitmap::fromContainerViews(std::move(views));
+
+   roaring::Roaring expected{1, 5};
+   expected.add((1U << 16) + 3);
+   expected.add((1U << 16) + 9);
+   expected.add((3U << 16) + 7);
+   EXPECT_EQ(under_test.toRoaring(), expected);
+}
+
+TEST(CopyOnWriteBitmap, copyOfOwningBitmapIsIndependent) {
+   // An owning bitmap (constructed by move) that is copied and then mutated must not affect the
+   // original: each owning container is deep-cloned on copy.
+   const roaring::Roaring expected = multiContainer();
+   const CopyOnWriteBitmap original{multiContainer()};
+   CopyOnWriteBitmap copy = original;
+
+   const roaring::Roaring other{5};
+   copy &= CopyOnWriteBitmap{&other};
+
+   EXPECT_EQ(copy.toRoaring(), roaring::Roaring{5});
+   EXPECT_EQ(original.toRoaring(), expected);
 }
 
 TEST(CopyOnWriteBitmap, mutatingAViewDoesNotDisturbTheSource) {

--- a/src/rhydb/query_engine/filter/operators/is_in_covered_region.cpp
+++ b/src/rhydb/query_engine/filter/operators/is_in_covered_region.cpp
@@ -46,8 +46,8 @@ bool IsInCoveredRegion::isCovered(uint32_t row_id) const {
    return true;
 }
 
-bool IsInCoveredRegion::match(uint32_t row_id) const {
-   return isCovered(row_id) == (comparator == Comparator::IS_COVERED);
+bool IsInCoveredRegion::match(storage::column::RowId row_id) const {
+   return isCovered(row_id.toGlobal()) == (comparator == Comparator::IS_COVERED);
 }
 
 roaring::Roaring IsInCoveredRegion::makeBitmap(const storage::column::RowLayout& row_layout) const {

--- a/src/rhydb/query_engine/filter/operators/is_in_covered_region.h
+++ b/src/rhydb/query_engine/filter/operators/is_in_covered_region.h
@@ -31,7 +31,7 @@ class IsInCoveredRegion : public Predicate {
 
    [[nodiscard]] std::string toString() const override;
    [[nodiscard]] bool isCovered(uint32_t row_id) const;
-   [[nodiscard]] bool match(uint32_t row_id) const override;
+   [[nodiscard]] bool match(storage::column::RowId row_id) const override;
    [[nodiscard]] roaring::Roaring makeBitmap(const storage::column::RowLayout& row_layout
    ) const override;
    [[nodiscard]] double estimateSelectivity(uint32_t row_count) const override;

--- a/src/rhydb/query_engine/filter/operators/selection.cpp
+++ b/src/rhydb/query_engine/filter/operators/selection.cpp
@@ -18,6 +18,7 @@
 #include "rhydb/query_engine/copy_on_write_bitmap.h"
 #include "rhydb/query_engine/filter/operators/complement.h"
 #include "rhydb/query_engine/filter/operators/operator.h"
+#include "rhydb/roaring_util/roaring_container.h"
 
 namespace rhydb::query_engine::filter::operators {
 
@@ -103,9 +104,14 @@ CopyOnWriteBitmap Selection::evaluate() const {
       // materializing the first predicate over the whole partition.
       if (child_bitmap.cardinality() <= row_layout.numRows() / 10) {
          roaring::Roaring result;
-         for (const uint32_t row : child_bitmap) {
-            if (matchesPredicates(predicates, row)) {
-               result.add(row);
+         for (const auto& [chunk_id, container_view] : child_bitmap) {
+            for (const uint16_t row_in_chunk : container_view) {
+               const storage::column::RowId row_id{
+                  .chunk_id = chunk_id, .row_in_chunk = row_in_chunk
+               };
+               if (matchesPredicates(predicates, row_id)) {
+                  result.add(row_id.toGlobal());
+               }
             }
          }
          return CopyOnWriteBitmap{std::move(result)};
@@ -123,9 +129,12 @@ CopyOnWriteBitmap Selection::evaluate() const {
    const auto remaining_predicates =
       std::ranges::subrange(predicates.begin() + 1, predicates.end());
    roaring::Roaring result;
-   for (const uint32_t row : candidates) {
-      if (matchesPredicates(remaining_predicates, row)) {
-         result.add(row);
+   for (const auto& [chunk_id, container_view] : candidates) {
+      for (const uint16_t row_in_chunk : container_view) {
+         const storage::column::RowId row_id{.chunk_id = chunk_id, .row_in_chunk = row_in_chunk};
+         if (matchesPredicates(remaining_predicates, row_id)) {
+            result.add(row_id.toGlobal());
+         }
       }
    }
    return CopyOnWriteBitmap{std::move(result)};
@@ -162,8 +171,7 @@ bool strongOrderingMatchesComparator(std::strong_ordering strong_ordering, Compa
 }  // namespace
 
 template <>
-bool CompareToValueSelection<StringColumn>::match(uint32_t global_row_id) const {
-   const storage::column::RowId row_id = storage::column::RowId::fromGlobal(global_row_id);
+bool CompareToValueSelection<StringColumn>::match(storage::column::RowId row_id) const {
    if (column.isNull(row_id)) {
       return with_nulls;
    }

--- a/src/rhydb/query_engine/filter/operators/selection.h
+++ b/src/rhydb/query_engine/filter/operators/selection.h
@@ -26,16 +26,15 @@ class Predicate {
    virtual ~Predicate() noexcept = default;
 
    [[nodiscard]] virtual std::string toString() const = 0;
-   [[nodiscard]] virtual bool match(uint32_t row_id) const = 0;
+   [[nodiscard]] virtual bool match(storage::column::RowId row_id) const = 0;
    // Often there are faster ways to generate the results, than calling match on each row.
    // Optimise that case by overriding this method
    [[nodiscard]] virtual roaring::Roaring makeBitmap(const storage::column::RowLayout& row_layout
    ) const {
       roaring::Roaring result;
       for (const storage::column::RowId row_id : row_layout) {
-         const uint32_t row = row_id.toGlobal();
-         if (match(row)) {
-            result.add(row);
+         if (match(row_id)) {
+            result.add(row_id.toGlobal());
          }
       }
       return result;
@@ -110,8 +109,7 @@ class CompareToValueSelection : public Predicate {
       );
    }
 
-   [[nodiscard]] bool match(uint32_t global_row_id) const override {
-      const storage::column::RowId row_id = storage::column::RowId::fromGlobal(global_row_id);
+   [[nodiscard]] bool match(storage::column::RowId row_id) const override {
       if (column.isNull(row_id)) {
          return with_nulls;
       }
@@ -168,7 +166,9 @@ class CompareToValueSelection : public Predicate {
 };
 
 template <>
-bool CompareToValueSelection<rhydb::storage::column::StringColumn>::match(uint32_t row_id) const;
+bool CompareToValueSelection<rhydb::storage::column::StringColumn>::match(
+   rhydb::storage::column::RowId row_id
+) const;
 
 class Selection : public Operator {
    friend class scalar_expressions::And;
@@ -216,9 +216,12 @@ class Selection : public Operator {
 
   private:
    template <std::ranges::range PredicateRange>
-   [[nodiscard]] static bool matchesPredicates(const PredicateRange& predicates, uint32_t row) {
-      return std::ranges::all_of(predicates, [row](const auto& predicate) {
-         return predicate->match(row);
+   [[nodiscard]] static bool matchesPredicates(
+      const PredicateRange& predicates,
+      storage::column::RowId row_id
+   ) {
+      return std::ranges::all_of(predicates, [row_id](const auto& predicate) {
+         return predicate->match(row_id);
       });
    }
 };

--- a/src/rhydb/query_engine/filter/operators/string_in_set.cpp
+++ b/src/rhydb/query_engine/filter/operators/string_in_set.cpp
@@ -39,9 +39,8 @@ std::string StringInSet<ColumnType>::toString() const {
 }
 
 template <Column ColumnType>
-bool StringInSet<ColumnType>::match(uint32_t row_id) const {
-   const bool in_set =
-      values.contains(column->getValueString(storage::column::RowId::fromGlobal(row_id)));
+bool StringInSet<ColumnType>::match(storage::column::RowId row_id) const {
+   const bool in_set = values.contains(column->getValueString(row_id));
    return comparator == Comparator::IN ? in_set : !in_set;
 }
 

--- a/src/rhydb/query_engine/filter/operators/string_in_set.h
+++ b/src/rhydb/query_engine/filter/operators/string_in_set.h
@@ -32,7 +32,7 @@ class StringInSet : public Predicate {
    ~StringInSet() noexcept override;
 
    [[nodiscard]] std::string toString() const override;
-   [[nodiscard]] bool match(uint32_t row_id) const override;
+   [[nodiscard]] bool match(storage::column::RowId row_id) const override;
 
    [[nodiscard]] std::unique_ptr<Predicate> copy() const override;
    [[nodiscard]] std::unique_ptr<Predicate> negate() const override;

--- a/src/rhydb/query_engine/filter/operators/string_in_set.test.cpp
+++ b/src/rhydb/query_engine/filter/operators/string_in_set.test.cpp
@@ -13,6 +13,7 @@ using rhydb::query_engine::filter::operators::Selection;
 using rhydb::query_engine::filter::operators::StringInSet;
 using rhydb::storage::column::DictionaryEncodedColumn;
 using rhydb::storage::column::DictionaryEncodedColumnMetadata;
+using rhydb::storage::column::RowId;
 using rhydb::storage::column::RowLayout;
 using rhydb::storage::column::StringColumn;
 using rhydb::storage::column::StringColumnMetadata;
@@ -195,8 +196,8 @@ TEST(OperatorStringInSet, copyCreatesIndependentCopy) {
    auto copy = original->copy();
 
    ASSERT_EQ(original->toString(), copy->toString());
-   ASSERT_EQ(original->match(0), copy->match(0));
-   ASSERT_EQ(original->match(1), copy->match(1));
+   ASSERT_EQ(original->match(RowId::fromGlobal(0)), copy->match(RowId::fromGlobal(0)));
+   ASSERT_EQ(original->match(RowId::fromGlobal(1)), copy->match(RowId::fromGlobal(1)));
 }
 
 TEST(OperatorStringInSet, matchSingleValue) {

--- a/src/rhydb/query_engine/scalar_expressions/symbol_in_set.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/symbol_in_set.cpp
@@ -135,15 +135,14 @@ std::unique_ptr<filter::operators::Operator> compileWithMissingSymbolAndReferenc
    // as the missing symbol and the reference symbol are included, we can just negate the other
    // symbols
    auto negated_symbols = negateSymbols<SymbolType>(symbols);
-   auto bitmap = sequence_column.vertical_sequence_index.getMatchingContainersAsBitmap(
-      position_idx, negated_symbols
+   auto bitmap = CopyOnWriteBitmap::fromContainerViews(
+      sequence_column.vertical_sequence_index.getMatchingContainerViews(
+         position_idx, negated_symbols
+      )
    );
    return excludeNullSequences(
       std::make_unique<filter::operators::Complement>(
-         std::make_unique<filter::operators::IndexScan>(
-            CopyOnWriteBitmap{std::move(bitmap)}, row_layout
-         ),
-         row_layout
+         std::make_unique<filter::operators::IndexScan>(std::move(bitmap), row_layout), row_layout
       ),
       sequence_column,
       row_layout
@@ -159,8 +158,9 @@ std::unique_ptr<filter::operators::Operator> compileWithMissingSymbol(
 ) {
    // The missing symbol is included, so we start with the sequences with no coverage at this
    // position and then add the sequences with the mutation symbols
-   auto bitmap =
-      sequence_column.vertical_sequence_index.getMatchingContainersAsBitmap(position_idx, symbols);
+   auto bitmap = CopyOnWriteBitmap::fromContainerViews(
+      sequence_column.vertical_sequence_index.getMatchingContainerViews(position_idx, symbols)
+   );
 
    filter::operators::OperatorVector operators_for_union;
    operators_for_union.push_back(std::make_unique<filter::operators::Selection>(
@@ -171,9 +171,9 @@ std::unique_ptr<filter::operators::Operator> compileWithMissingSymbol(
       ),
       row_layout
    ));
-   operators_for_union.push_back(std::make_unique<filter::operators::IndexScan>(
-      CopyOnWriteBitmap{std::move(bitmap)}, row_layout
-   ));
+   operators_for_union.push_back(
+      std::make_unique<filter::operators::IndexScan>(std::move(bitmap), row_layout)
+   );
    return excludeNullSequences(
       std::make_unique<filter::operators::Union>(std::move(operators_for_union), row_layout),
       sequence_column,
@@ -191,8 +191,10 @@ std::unique_ptr<filter::operators::Operator> compileWithReference(
    // The reference symbol is included, so we start with the sequences with coverage at this
    // position and then remove the sequences with the negated mutation symbols
    auto negated_symbols = negateSymbolsExcluding<SymbolType>(symbols, SymbolType::SYMBOL_MISSING);
-   auto bitmap = sequence_column.vertical_sequence_index.getMatchingContainersAsBitmap(
-      position_idx, negated_symbols
+   auto bitmap = CopyOnWriteBitmap::fromContainerViews(
+      sequence_column.vertical_sequence_index.getMatchingContainerViews(
+         position_idx, negated_symbols
+      )
    );
 
    return makeDifference(
@@ -204,9 +206,7 @@ std::unique_ptr<filter::operators::Operator> compileWithReference(
          ),
          row_layout
       ),
-      std::make_unique<filter::operators::IndexScan>(
-         CopyOnWriteBitmap{std::move(bitmap)}, row_layout
-      ),
+      std::make_unique<filter::operators::IndexScan>(std::move(bitmap), row_layout),
       row_layout
    );
 }
@@ -219,11 +219,10 @@ std::unique_ptr<filter::operators::Operator> compileOnlyMutations(
    const storage::column::RowLayout& row_layout
 ) {
    // All our results are fully included in the vertical sequence index
-   auto bitmap =
-      sequence_column.vertical_sequence_index.getMatchingContainersAsBitmap(position_idx, symbols);
-   return std::make_unique<filter::operators::IndexScan>(
-      CopyOnWriteBitmap{std::move(bitmap)}, row_layout
+   auto bitmap = CopyOnWriteBitmap::fromContainerViews(
+      sequence_column.vertical_sequence_index.getMatchingContainerViews(position_idx, symbols)
    );
+   return std::make_unique<filter::operators::IndexScan>(std::move(bitmap), row_layout);
 }
 
 }  // namespace

--- a/src/rhydb/roaring_util/roaring_container.h
+++ b/src/rhydb/roaring_util/roaring_container.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -186,6 +187,73 @@ class RoaringContainerView {
    [[nodiscard]] RoaringContainer toOwning() const {
       return RoaringContainer::clonedFrom(container, typecode);
    }
+
+   /// Forward iterator over the low-16-bit values held by the container, in ascending order. The
+   /// iterator borrows the container, so the view (and its owner) must outlive it and the container
+   /// must not be mutated while an iteration is in progress.
+   class ConstIterator {
+      const roaring::internal::container_t* container = nullptr;
+      uint8_t typecode = 0;
+      roaring::internal::roaring_container_iterator_t internal_iterator{};
+      uint16_t current_value = 0;
+      // An exhausted iterator (past the last value, or a default-constructed `end()`) holds no
+      // position; two exhausted iterators compare equal regardless of which container they came
+      // from.
+      bool exhausted = true;
+
+     public:
+      using iterator_category = std::forward_iterator_tag;
+      using value_type = uint16_t;
+      using difference_type = std::ptrdiff_t;
+      using pointer = const uint16_t*;
+      using reference = uint16_t;
+
+      ConstIterator() = default;
+
+      // The container must be non-empty: `container_init_iterator` assumes a first value exists.
+      ConstIterator(const roaring::internal::container_t* container, uint8_t typecode)
+          : container(container),
+            typecode(typecode),
+            exhausted(false) {
+         internal_iterator =
+            roaring::internal::container_init_iterator(container, typecode, &current_value);
+      }
+
+      uint16_t operator*() const { return current_value; }
+
+      ConstIterator& operator++() {
+         exhausted = !roaring::internal::container_iterator_next(
+            container, typecode, &internal_iterator, &current_value
+         );
+         return *this;
+      }
+
+      ConstIterator operator++(int) {
+         ConstIterator copy = *this;
+         ++*this;
+         return copy;
+      }
+
+      bool operator==(const ConstIterator& other) const {
+         if (exhausted || other.exhausted) {
+            return exhausted && other.exhausted;
+         }
+         return container == other.container && current_value == other.current_value;
+      }
+
+      bool operator!=(const ConstIterator& other) const { return !(*this == other); }
+   };
+
+   [[nodiscard]] ConstIterator begin() const {
+      // An empty container has no first value for `container_init_iterator` to load, so an empty
+      // view iterates as an already-exhausted range.
+      if (empty()) {
+         return ConstIterator{};
+      }
+      return ConstIterator{container, typecode};
+   }
+
+   [[nodiscard]] static ConstIterator end() { return ConstIterator{}; }
 };
 
 }  // namespace rhydb::roaring_util

--- a/src/rhydb/roaring_util/roaring_container.test.cpp
+++ b/src/rhydb/roaring_util/roaring_container.test.cpp
@@ -1,6 +1,10 @@
 #include "rhydb/roaring_util/roaring_container.h"
 
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
 #include <sstream>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <boost/archive/binary_iarchive.hpp>
@@ -21,6 +25,15 @@ roaring::Roaring toRoaring(const RoaringContainer& container) {
    BitmapBuilderByContainer builder;
    builder.addContainer(0, container.rawContainer(), container.getTypecode());
    return std::move(builder).getBitmap();
+}
+
+// Collects the low-16-bit values yielded by iterating a view, in iteration order.
+std::vector<uint16_t> iterate(const RoaringContainerView& view) {
+   std::vector<uint16_t> values;
+   for (const uint16_t value : view) {
+      values.push_back(value);
+   }
+   return values;
 }
 
 }  // namespace
@@ -119,6 +132,115 @@ TEST(RoaringContainerView, toOwningDeepCopies) {
    EXPECT_EQ(owned.getCardinality(), 3);
    EXPECT_EQ(owner.getCardinality(), 2);
    EXPECT_EQ(toRoaring(owner), (roaring::Roaring{1, 2}));
+}
+
+TEST(RoaringContainerView, iteratesArrayContainerValuesAscending) {
+   auto owner = RoaringContainer::withCapacity(4);
+   owner.add(3);
+   owner.add(7);
+   owner.add(9);
+
+   const RoaringContainerView view{owner};
+   EXPECT_EQ(iterate(view), (std::vector<uint16_t>{3, 7, 9}));
+}
+
+TEST(RoaringContainerView, iteratesBitsetContainerValuesAscending) {
+   // Enough values to force the array container to grow into a bitset container.
+   auto owner = RoaringContainer::withCapacity(1);
+   const uint16_t count = 20000;
+   for (uint16_t value = 0; value < count; ++value) {
+      owner.add(value);
+   }
+   ASSERT_EQ(owner.getTypecode(), BITSET_CONTAINER_TYPE);
+
+   const auto values = iterate(RoaringContainerView{owner});
+   ASSERT_EQ(values.size(), count);
+   for (uint16_t value = 0; value < count; ++value) {
+      EXPECT_EQ(values[value], value);
+   }
+}
+
+TEST(RoaringContainerView, iteratesRunContainerValuesAscending) {
+   // A dense contiguous range run-optimizes into a run container.
+   auto owner = RoaringContainer::withCapacity(4);
+   for (uint16_t value = 100; value < 200; ++value) {
+      owner.add(value);
+   }
+   owner.runOptimizeAndShrink();
+   ASSERT_EQ(owner.getTypecode(), RUN_CONTAINER_TYPE);
+
+   const auto values = iterate(RoaringContainerView{owner});
+   ASSERT_EQ(values.size(), 100);
+   for (uint16_t offset = 0; offset < 100; ++offset) {
+      EXPECT_EQ(values[offset], 100 + offset);
+   }
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST(RoaringContainerView, iteratorsAtDifferentValuesOfOneRunCompareUnequal) {
+   // A single contiguous run: every value of the container lives in run index 0, so an iterator
+   // position is only distinguishable by its current value, not by the internal run index.
+   auto owner = RoaringContainer::withCapacity(4);
+   for (uint16_t value = 100; value < 200; ++value) {
+      owner.add(value);
+   }
+   owner.runOptimizeAndShrink();
+   ASSERT_EQ(owner.getTypecode(), RUN_CONTAINER_TYPE);
+
+   const RoaringContainerView view{owner};
+   auto first = view.begin();
+   auto second = view.begin();
+   ++second;
+
+   ASSERT_EQ(*first, 100);
+   ASSERT_EQ(*second, 101);
+   EXPECT_NE(first, second);
+   EXPECT_FALSE(first == second);
+
+   // Advancing a copy must not move the original, and equality must hold again once the copy has
+   // been caught up.
+   ++first;
+   EXPECT_EQ(first, second);
+   EXPECT_EQ(*first, *second);
+
+   // Every position within the run must be distinct from every other one.
+   for (auto left = view.begin(); left != RoaringContainerView::end(); ++left) {
+      for (auto right = view.begin(); right != RoaringContainerView::end(); ++right) {
+         EXPECT_EQ(left == right, *left == *right);
+      }
+   }
+}
+
+TEST(RoaringContainerView, algorithmsTerminateCorrectlyWithinOneRun) {
+   // Standard algorithms compare iterators for equality; if positions inside a run collapsed onto
+   // one another they would stop early or miscount.
+   auto owner = RoaringContainer::withCapacity(4);
+   for (uint16_t value = 100; value < 200; ++value) {
+      owner.add(value);
+   }
+   owner.runOptimizeAndShrink();
+   ASSERT_EQ(owner.getTypecode(), RUN_CONTAINER_TYPE);
+
+   const RoaringContainerView view{owner};
+   EXPECT_EQ(std::distance(view.begin(), RoaringContainerView::end()), 100);
+
+   const auto found = std::find(view.begin(), RoaringContainerView::end(), uint16_t{150});
+   ASSERT_NE(found, RoaringContainerView::end());
+   EXPECT_EQ(*found, 150);
+   EXPECT_EQ(std::distance(view.begin(), found), 50);
+
+   EXPECT_EQ(
+      std::find(view.begin(), RoaringContainerView::end(), uint16_t{250}),
+      RoaringContainerView::end()
+   );
+}
+
+TEST(RoaringContainerView, emptyViewIteratesAsEmptyRange) {
+   const auto owner = RoaringContainer::withCapacity(4);
+   const RoaringContainerView view{owner};
+   ASSERT_TRUE(view.empty());
+   EXPECT_EQ(view.begin(), view.end());
+   EXPECT_TRUE(iterate(view).empty());
 }
 
 TEST(RoaringContainer, serializationRoundTrip) {

--- a/src/rhydb/storage/column/vertical_sequence_index.cpp
+++ b/src/rhydb/storage/column/vertical_sequence_index.cpp
@@ -202,6 +202,30 @@ roaring::Roaring VerticalSequenceIndex<SymbolType>::getMatchingContainersAsBitma
    return std::move(builder).getBitmap();
 }
 
+template <typename SymbolType>
+std::vector<std::pair<uint16_t, rhydb::roaring_util::RoaringContainerView>> VerticalSequenceIndex<
+   SymbolType>::
+   getMatchingContainerViews(
+      uint32_t position_idx,
+      const std::vector<typename SymbolType::Symbol>& symbols
+   ) const {
+   auto [start, end] = getRangeForPosition(position_idx);
+
+   std::vector<std::pair<uint16_t, roaring_util::RoaringContainerView>> result;
+   for (auto it = start; it != end; ++it) {
+      const auto& [sequence_diff_key, sequence_diff] = *it;
+      SILO_ASSERT(!sequence_diff.empty());
+
+      if (std::find(symbols.begin(), symbols.end(), sequence_diff_key.symbol) == symbols.end()) {
+         continue;
+      }
+      result.emplace_back(
+         sequence_diff_key.v_index, roaring_util::RoaringContainerView{sequence_diff}
+      );
+   }
+   return result;
+}
+
 using rhydb::roaring_util::roaringSubsetRanks;
 
 template <typename SymbolType>

--- a/src/rhydb/storage/column/vertical_sequence_index.h
+++ b/src/rhydb/storage/column/vertical_sequence_index.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include <boost/serialization/access.hpp>
@@ -85,6 +86,17 @@ class VerticalSequenceIndex {
    [[nodiscard]] roaring::Roaring getMatchingContainersAsBitmap(
       uint32_t position_idx,
       std::vector<typename SymbolType::Symbol> symbol
+   ) const;
+
+   /// Non-owning views of the stored containers at `position_idx` whose symbol is in `symbols`,
+   /// paired with their `v_index` (the high 16 bits of the row id). Unlike
+   /// `getMatchingContainersAsBitmap` this clones nothing: the caller can assemble the row set
+   /// container-by-container as views into this index, which must outlive them. A `v_index` may
+   /// appear more than once when several requested symbols occur in the same 2^16 block.
+   [[nodiscard]] std::vector<std::pair<uint16_t, roaring_util::RoaringContainerView>>
+   getMatchingContainerViews(
+      uint32_t position_idx,
+      const std::vector<typename SymbolType::Symbol>& symbols
    ) const;
 
    void overwriteSymbolsInSequences(


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1191, also progress to #1404

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This changes the internal representation of "RowId sets" in `CopyOnWriteBitmap`. Instead of always storing a `roaring::Roaring` bitmap, we instead store individual container (views). This allows zero-copy filtering by just containing a view into existing column-containers. Also, more efficient algorithms can be implemented by having access to the containers directly

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
