### PR TITLE
build: explicit pyproject.toml version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rhydb"
-dynamic = ["version"]
+version = "0.13.3"
 description = "Python bindings for RhyDB - high-performance sequence database"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -49,6 +49,3 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "--import-mode=importlib"
-
-[tool.setuptools.dynamic]
-version = {file = "version.txt"}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,7 @@
                 {
                     "type": "toml",
                     "path": "pyproject.toml",
-                    "tomlpath": "project.version"
+                    "jsonpath": "$.project.version"
                 }
             ]
         }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,11 @@
                     "type": "json",
                     "path": "wasm/package.json",
                     "jsonpath": "$.version"
+                },
+                {
+                    "type": "toml",
+                    "path": "pyproject.toml",
+                    "tomlpath": "project.version"
                 }
             ]
         }


### PR DESCRIPTION
explicitly specify the pyproject.toml version and let it be managed by release please. Analogous to wasm version