### PR TITLE
feat(rhydb): add `transitiveClosure` table function

### DIFF
--- a/buildScripts/install-dependencies
+++ b/buildScripts/install-dependencies
@@ -4,11 +4,25 @@ set -euo pipefail
 
 ./buildScripts/ensure-uv
 
+# For correct ASAN instrumentation, we also need to build arrow with ASAN
+asan_confs=(
+  --conf 'arrow/*:tools.build:cflags=["-fsanitize=address"]'
+  --conf 'arrow/*:tools.build:cxxflags=["-fsanitize=address"]'
+  --conf 'arrow/*:tools.build:sharedlinkflags=["-fsanitize=address"]'
+  --conf 'arrow/*:tools.build:exelinkflags=["-fsanitize=address"]'
+  --conf 'gtest/*:tools.build:cflags=["-fsanitize=address"]'
+  --conf 'gtest/*:tools.build:cxxflags=["-fsanitize=address"]'
+  --conf 'gtest/*:tools.build:sharedlinkflags=["-fsanitize=address"]'
+  --conf 'gtest/*:tools.build:exelinkflags=["-fsanitize=address"]'
+  --conf 'tools.info.package_id:confs=["tools.build:cflags","tools.build:cxxflags","tools.build:sharedlinkflags","tools.build:exelinkflags"]'
+)
+
 # TODO(#986) remove setting 'arrow/*:compiler.cppstd=20' when arrow compilation for C++23 is fixed
 uv run --project buildScripts conan install . --update \
   --build=missing \
   --profile ./conanprofile --profile:build ./conanprofile \
   --settings '&:build_type=Debug' --settings 'arrow/*:compiler.cppstd=20' \
+  "${asan_confs[@]}" \
   --output-folder=build/Debug/generators
 # TODO(#986) remove setting 'arrow/*:compiler.cppstd=20' when arrow compilation for C++23 is fixed
 uv run --project buildScripts conan install . --update \

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -495,16 +495,13 @@ so nucleotide and amino acid sequences cannot be distinguished from ordinary str
 Computes the transitive closure of a directed relation. The `input` is any relation-producing
 pipeline whose rows describe edges: each row contributes an edge from the value in its `from`
 column to the value in its `to` column (`from` and `to` name string columns of the input, and
-rows with a null endpoint are ignored). The result is a two-column relation with columns named
+rows with a null vertex are ignored). The result is a two-column relation with columns named
 `from` and `to`, holding one row for every ordered pair `(a, b)` where `b` is reachable from
 `a` by following one or more edges.
 
 With `includeVertices:=true` (default `false`), the reflexive pair `(v, v)` is additionally
 emitted for every vertex `v` that appears in the relation, yielding the *reflexive*-transitive
 closure.
-
-`transitiveClosure` is a *pipeline breaker*: like `groupBy` and `schema`, it materializes its
-input into a fresh result relation rather than forwarding its child's rows.
 
 A typical input is a **lineage relation table**. When a column is configured with
 `lineageIndexType: table` (or `both`), preprocessing materializes a companion table (named after

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -490,6 +490,58 @@ so nucleotide and amino acid sequences cannot be distinguished from ordinary str
 
 **Limitation:** `filter(...)` cannot be applied to `schema()`. A filter is only realizable when it can be pushed into a table scan, and there is none above `schema()`.
 
+### `transitiveClosure(input, from, to [, includeVertices:=bool])`
+
+Computes the transitive closure of a directed relation. The `input` is any relation-producing
+pipeline whose rows describe edges: each row contributes an edge from the value in its `from`
+column to the value in its `to` column (`from` and `to` name string columns of the input, and
+rows with a null endpoint are ignored). The result is a two-column relation with columns named
+`from` and `to`, holding one row for every ordered pair `(a, b)` where `b` is reachable from
+`a` by following one or more edges.
+
+With `includeVertices:=true` (default `false`), the reflexive pair `(v, v)` is additionally
+emitted for every vertex `v` that appears in the relation, yielding the *reflexive*-transitive
+closure.
+
+`transitiveClosure` is a *pipeline breaker*: like `groupBy` and `schema`, it materializes its
+input into a fresh result relation rather than forwarding its child's rows.
+
+A typical input is a **lineage relation table**. When a column is configured with
+`lineageIndexType: table` (or `both`), preprocessing materializes a companion table (named after
+that column) with one row per direct edge, holding the child lineage in a `lineage` column and
+its direct parent in a `parent` column (null for roots). Its closure pairs every lineage with
+each of its descendants:
+
+```
+pango_lineage.transitiveClosure('parent', 'lineage').orderBy({from, to})
+```
+
+**Counting a lineage together with all of its sublineages.** Joining the reflexive closure's
+`to` column against a data table's lineage column and grouping by `from` sums, for each lineage,
+all sequences below it in the hierarchy (and — thanks to the reflexive pair — the lineage's own
+sequences):
+
+```
+pango_lineage.transitiveClosure('parent', 'lineage', includeVertices:=true)
+  .join(default, to = lineage_column)
+  .groupBy({count := count()}, {from})
+  .orderBy({from})
+```
+
+Here `lineage_column` is a `STRING` column of `default` holding each sequence's lineage. Because
+`join` requires both key columns to have the same type and the closure emits `STRING` columns,
+the joined-against column must itself be `STRING` (a lineage column configured with an index is
+dictionary-encoded and cannot be used as the join key directly).
+
+**Restrictions:**
+
+- `from` and `to` must be `STRING` columns of the input.
+- `filter(...)` cannot be applied to the output of `transitiveClosure()`; it is a source
+  operator with nowhere to push a predicate. Filter the input instead.
+
+**Output:** the reachable `{from, to}` pairs. The order of rows is not guaranteed; use
+`orderBy(...)` for a deterministic order.
+
 ---
 
 ## Writing query results to a table

--- a/src/rhydb/query_engine/operator_visitor.h
+++ b/src/rhydb/query_engine/operator_visitor.h
@@ -19,6 +19,7 @@
 #include "rhydb/query_engine/operators/project_node.h"
 #include "rhydb/query_engine/operators/schema_node.h"
 #include "rhydb/query_engine/operators/table_scan_node.h"
+#include "rhydb/query_engine/operators/transitive_closure_node.h"
 #include "rhydb/query_engine/operators/union_all_node.h"
 #include "rhydb/query_engine/operators/unresolved_insertions_node.h"
 #include "rhydb/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
@@ -90,6 +91,8 @@ decltype(auto) visit(QueryNode& node, Func&& func) {
          return std::forward<Func>(func)(static_cast<SchemaNode&>(node));
       case NodeKind::BITMAP_AGGREGATION:
          return std::forward<Func>(func)(static_cast<BitmapAggregationNode&>(node));
+      case NodeKind::TRANSITIVE_CLOSURE:
+         return std::forward<Func>(func)(static_cast<TransitiveClosureNode&>(node));
    }
    SILO_UNREACHABLE();
 }

--- a/src/rhydb/query_engine/operators/query_node.cpp
+++ b/src/rhydb/query_engine/operators/query_node.cpp
@@ -62,6 +62,8 @@ std::string_view nodeKindToString(NodeKind kind) {
          return "Schema";
       case NodeKind::BITMAP_AGGREGATION:
          return "BitmapAggregation";
+      case NodeKind::TRANSITIVE_CLOSURE:
+         return "TransitiveClosure";
    }
    SILO_UNREACHABLE();
 }

--- a/src/rhydb/query_engine/operators/query_node.h
+++ b/src/rhydb/query_engine/operators/query_node.h
@@ -41,6 +41,7 @@ enum class NodeKind : uint8_t {
    JOIN,
    SCHEMA,
    BITMAP_AGGREGATION,
+   TRANSITIVE_CLOSURE,
 };
 
 class QueryNode {

--- a/src/rhydb/query_engine/operators/transitive_closure_node.cpp
+++ b/src/rhydb/query_engine/operators/transitive_closure_node.cpp
@@ -1,0 +1,267 @@
+#include "rhydb/query_engine/operators/transitive_closure_node.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <queue>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/acero/options.h>
+#include <arrow/array/array_binary.h>
+#include <arrow/builder.h>
+#include <arrow/compute/exec.h>
+#include <arrow/util/async_generator.h>
+#include <nlohmann/json.hpp>
+
+#include "rhydb/query_engine/exec_node/arrow_util.h"
+#include "rhydb/query_engine/illegal_query_exception.h"
+#include "rhydb/schema/database_schema.h"
+
+namespace rhydb::query_engine::operators {
+
+namespace {
+
+/// The interned directed relation: `vertex_names[i]` is the name of vertex `i`, and
+/// `adjacency[i]` holds the vertices directly reachable from `i` via a single edge.
+struct Relation {
+   std::vector<std::string> vertex_names;
+   std::vector<std::vector<uint32_t>> adjacency;
+};
+
+/// Validates that `column_name` is a STRING column of the input and returns its position, which
+/// is also its index into the input's exec batches.
+uint32_t validateAndFindColumn(
+   const std::vector<schema::ColumnIdentifier>& child_schema,
+   const std::string& column_name
+) {
+   const auto found = std::ranges::find_if(child_schema, [&](const auto& column) {
+      return column.name == column_name;
+   });
+   CHECK_SILO_QUERY(
+      found != child_schema.end(),
+      "transitiveClosure() column '{}' is not present in the input's output schema",
+      column_name
+   );
+   CHECK_SILO_QUERY(
+      found->type == schema::ColumnType::STRING,
+      "transitiveClosure() can only be applied to STRING columns, but column '{}' has type {}",
+      column_name,
+      schema::columnTypeToString(found->type)
+   );
+   return static_cast<uint32_t>(std::distance(child_schema.begin(), found));
+}
+
+arrow::Status appendStringColumn(
+   const arrow::Datum& datum,
+   std::vector<std::optional<std::string>>& out
+) {
+   if (!datum.is_array()) {
+      return arrow::Status::Invalid("transitiveClosure() expected an array-typed input column");
+   }
+   const auto array = datum.make_array();
+   const auto& string_array = static_cast<const arrow::StringArray&>(*array);
+   for (int64_t row = 0; row < string_array.length(); ++row) {
+      if (string_array.IsNull(row)) {
+         out.emplace_back(std::nullopt);
+      } else {
+         out.emplace_back(string_array.GetString(row));
+      }
+   }
+   return arrow::Status::OK();
+}
+
+/// Builds the interned relation from the child's exec batches, reading the edge endpoints from
+/// the given column indices. Rows with a null endpoint are skipped.
+arrow::Result<Relation> buildRelation(
+   const std::vector<std::optional<arrow::ExecBatch>>& batches,
+   uint32_t from_index,
+   uint32_t to_index
+) {
+   std::vector<std::optional<std::string>> from_values;
+   std::vector<std::optional<std::string>> to_values;
+   for (const auto& batch : batches) {
+      if (!batch.has_value()) {
+         continue;
+      }
+      ARROW_RETURN_NOT_OK(appendStringColumn(batch->values[from_index], from_values));
+      ARROW_RETURN_NOT_OK(appendStringColumn(batch->values[to_index], to_values));
+   }
+
+   std::vector<std::string> vertex_names;
+   std::unordered_map<std::string, uint32_t> vertex_ids;
+   const auto intern = [&](const std::string& value) {
+      const auto [iterator, inserted] =
+         vertex_ids.try_emplace(value, static_cast<uint32_t>(vertex_names.size()));
+      if (inserted) {
+         vertex_names.push_back(iterator->first);
+      }
+      return iterator->second;
+   };
+
+   std::vector<std::pair<uint32_t, uint32_t>> edges;
+   for (size_t row = 0; row < from_values.size(); ++row) {
+      if (!from_values[row].has_value() || !to_values[row].has_value()) {
+         continue;
+      }
+      edges.emplace_back(intern(*from_values[row]), intern(*to_values[row]));
+   }
+
+   std::vector<std::vector<uint32_t>> adjacency(vertex_names.size());
+   for (const auto& [from, to] : edges) {
+      adjacency[from].push_back(to);
+   }
+   return Relation{.vertex_names = std::move(vertex_names), .adjacency = std::move(adjacency)};
+}
+
+/// Computes the transitive closure of `relation`, returning the reachable pairs sorted by
+/// (from, to) name so the output is deterministic. If `include_vertices` is set, the reflexive
+/// pair (v, v) is added for every vertex.
+std::vector<std::pair<std::string, std::string>> computeClosure(
+   const Relation& relation,
+   bool include_vertices
+) {
+   const auto num_vertices = static_cast<uint32_t>(relation.vertex_names.size());
+   std::vector<std::pair<std::string, std::string>> pairs;
+
+   for (uint32_t source = 0; source < num_vertices; ++source) {
+      std::vector<bool> reached(num_vertices, false);
+      std::queue<uint32_t> to_visit;
+      for (const uint32_t successor : relation.adjacency[source]) {
+         if (!reached[successor]) {
+            reached[successor] = true;
+            to_visit.push(successor);
+         }
+      }
+      while (!to_visit.empty()) {
+         const uint32_t current = to_visit.front();
+         to_visit.pop();
+         for (const uint32_t successor : relation.adjacency[current]) {
+            if (!reached[successor]) {
+               reached[successor] = true;
+               to_visit.push(successor);
+            }
+         }
+      }
+      for (uint32_t destination = 0; destination < num_vertices; ++destination) {
+         if (reached[destination]) {
+            pairs.emplace_back(relation.vertex_names[source], relation.vertex_names[destination]);
+         }
+      }
+      // Add the reflexive pair unless the vertex already reaches itself through a cycle.
+      if (include_vertices && !reached[source]) {
+         pairs.emplace_back(relation.vertex_names[source], relation.vertex_names[source]);
+      }
+   }
+
+   std::ranges::sort(pairs);
+   return pairs;
+}
+
+arrow::Result<std::optional<arrow::ExecBatch>> buildClosureBatch(
+   const std::vector<std::pair<std::string, std::string>>& pairs
+) {
+   arrow::StringBuilder from_builder{};
+   arrow::StringBuilder to_builder{};
+   for (const auto& [from, to] : pairs) {
+      ARROW_RETURN_NOT_OK(from_builder.Append(from));
+      ARROW_RETURN_NOT_OK(to_builder.Append(to));
+   }
+   arrow::Datum from_datum;
+   ARROW_ASSIGN_OR_RAISE(from_datum, from_builder.Finish());
+   arrow::Datum to_datum;
+   ARROW_ASSIGN_OR_RAISE(to_datum, to_builder.Finish());
+   ARROW_ASSIGN_OR_RAISE(auto batch, arrow::ExecBatch::Make({from_datum, to_datum}));
+   return std::optional<arrow::ExecBatch>{std::move(batch)};
+}
+
+}  // namespace
+
+TransitiveClosureNode::TransitiveClosureNode(
+   QueryNodePtr child,
+   std::string from_column,
+   std::string to_column,
+   bool include_vertices
+)
+    : child(std::move(child)),
+      from_column(std::move(from_column)),
+      to_column(std::move(to_column)),
+      include_vertices(include_vertices) {}
+
+std::vector<schema::ColumnIdentifier> TransitiveClosureNode::getOutputSchema() const {
+   return {
+      {.name = std::string{FROM_COLUMN}, .type = schema::ColumnType::STRING},
+      {.name = std::string{TO_COLUMN}, .type = schema::ColumnType::STRING},
+   };
+}
+
+arrow::Result<arrow::acero::ExecNode*> TransitiveClosureNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
+   const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
+   const config::QueryOptions& query_options
+) const {
+   const auto child_schema = child->getOutputSchema();
+   const uint32_t from_index = validateAndFindColumn(child_schema, from_column);
+   const uint32_t to_index = validateAndFindColumn(child_schema, to_column);
+
+   ARROW_ASSIGN_OR_RAISE(auto* child_node, child->addToExecPlan(plan, tables, query_options));
+
+   // The child runs within this same plan. A sink drains its batches into `child_generator`;
+   // the source node below collects them, computes the closure, and emits the result
+   // downstream. This is the same sink -> generator -> source shape that orderBy() uses.
+   arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> child_generator;
+   ARROW_RETURN_NOT_OK(
+      arrow::acero::MakeExecNode(
+         "sink", &plan, {child_node}, arrow::acero::SinkNodeOptions{&child_generator}
+      )
+         .status()
+   );
+
+   const bool include_vertices_copy = include_vertices;
+   std::function<arrow::Future<std::optional<arrow::ExecBatch>>()> producer =
+      [child_generator = std::move(child_generator),
+       from_index,
+       to_index,
+       include_vertices_copy,
+       already_produced = false]() mutable -> arrow::Future<std::optional<arrow::ExecBatch>> {
+      if (already_produced) {
+         const std::optional<arrow::ExecBatch> end_of_stream = std::nullopt;
+         return arrow::Future{end_of_stream};
+      }
+      already_produced = true;
+      return arrow::CollectAsyncGenerator(child_generator)
+         .Then(
+            [from_index, to_index, include_vertices_copy](
+               const std::vector<std::optional<arrow::ExecBatch>>& batches
+            ) -> arrow::Result<std::optional<arrow::ExecBatch>> {
+               ARROW_ASSIGN_OR_RAISE(
+                  const Relation relation, buildRelation(batches, from_index, to_index)
+               );
+               return buildClosureBatch(computeClosure(relation, include_vertices_copy));
+            }
+         );
+   };
+
+   const arrow::acero::SourceNodeOptions options{
+      exec_node::columnsToArrowSchema(getOutputSchema()),
+      std::move(producer),
+      arrow::Ordering::Implicit()
+   };
+   return arrow::acero::MakeExecNode("source", &plan, {}, options);
+}
+
+nlohmann::json TransitiveClosureNode::toJson() const {
+   return {
+      {"type", nodeKindToString(kind())},
+      {"child", child->toJson()},
+      {"from", from_column},
+      {"to", to_column},
+      {"includeVertices", include_vertices},
+   };
+}
+
+}  // namespace rhydb::query_engine::operators

--- a/src/rhydb/query_engine/operators/transitive_closure_node.cpp
+++ b/src/rhydb/query_engine/operators/transitive_closure_node.cpp
@@ -43,12 +43,12 @@ uint32_t validateAndFindColumn(
    const auto found = std::ranges::find_if(child_schema, [&](const auto& column) {
       return column.name == column_name;
    });
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       found != child_schema.end(),
       "transitiveClosure() column '{}' is not present in the input's output schema",
       column_name
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       found->type == schema::ColumnType::STRING,
       "transitiveClosure() can only be applied to STRING columns, but column '{}' has type {}",
       column_name,

--- a/src/rhydb/query_engine/operators/transitive_closure_node.cpp
+++ b/src/rhydb/query_engine/operators/transitive_closure_node.cpp
@@ -72,7 +72,7 @@ arrow::Result<std::shared_ptr<arrow::StringArray>> asStringArray(const arrow::Da
 }
 
 /// Builds the interned relation from the child's exec batches, reading the edge endpoints from
-/// the given column indices. Rows with a null endpoint are skipped. Only the interned form is
+/// the given column indices. Edges with a null endpoint are skipped. Only the interned form is
 /// retained: the endpoint strings are interned as the batches are scanned, so each distinct
 /// vertex name is held once instead of once per edge.
 arrow::Result<Relation> buildRelation(
@@ -100,12 +100,17 @@ arrow::Result<Relation> buildRelation(
       ARROW_ASSIGN_OR_RAISE(const auto from_array, asStringArray(batch->values[from_index]));
       ARROW_ASSIGN_OR_RAISE(const auto to_array, asStringArray(batch->values[to_index]));
       for (int64_t row = 0; row < from_array->length(); ++row) {
-         if (from_array->IsNull(row) || to_array->IsNull(row)) {
-            continue;
+         std::optional<uint32_t> from;
+         std::optional<uint32_t> to;
+         if (!from_array->IsNull(row)) {
+            from = intern(from_array->GetString(row));
          }
-         const uint32_t from = intern(from_array->GetString(row));
-         const uint32_t to = intern(to_array->GetString(row));
-         adjacency[from].push_back(to);
+         if (!to_array->IsNull(row)) {
+            to = intern(to_array->GetString(row));
+         }
+         if (from.has_value() && to.has_value()) {
+            adjacency[*from].push_back(*to);
+         }
       }
    }
 

--- a/src/rhydb/query_engine/operators/transitive_closure_node.cpp
+++ b/src/rhydb/query_engine/operators/transitive_closure_node.cpp
@@ -1,10 +1,11 @@
 #include "rhydb/query_engine/operators/transitive_closure_node.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
-#include <queue>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -56,128 +57,153 @@ uint32_t validateAndFindColumn(
    return static_cast<uint32_t>(std::distance(child_schema.begin(), found));
 }
 
-arrow::Status appendStringColumn(
-   const arrow::Datum& datum,
-   std::vector<std::optional<std::string>>& out
-) {
+arrow::Result<std::shared_ptr<arrow::StringArray>> asStringArray(const arrow::Datum& datum) {
    if (!datum.is_array()) {
       return arrow::Status::Invalid("transitiveClosure() expected an array-typed input column");
    }
-   const auto array = datum.make_array();
-   const auto& string_array = static_cast<const arrow::StringArray&>(*array);
-   for (int64_t row = 0; row < string_array.length(); ++row) {
-      if (string_array.IsNull(row)) {
-         out.emplace_back(std::nullopt);
-      } else {
-         out.emplace_back(string_array.GetString(row));
-      }
+   auto array = datum.make_array();
+   if (array->type_id() != arrow::Type::STRING) {
+      return arrow::Status::Invalid(
+         "transitiveClosure() expected a string-typed input column, but got ",
+         array->type()->ToString()
+      );
    }
-   return arrow::Status::OK();
+   return std::static_pointer_cast<arrow::StringArray>(std::move(array));
 }
 
 /// Builds the interned relation from the child's exec batches, reading the edge endpoints from
-/// the given column indices. Rows with a null endpoint are skipped.
+/// the given column indices. Rows with a null endpoint are skipped. Only the interned form is
+/// retained: the endpoint strings are interned as the batches are scanned, so each distinct
+/// vertex name is held once instead of once per edge.
 arrow::Result<Relation> buildRelation(
    const std::vector<std::optional<arrow::ExecBatch>>& batches,
    uint32_t from_index,
    uint32_t to_index
 ) {
-   std::vector<std::optional<std::string>> from_values;
-   std::vector<std::optional<std::string>> to_values;
-   for (const auto& batch : batches) {
-      if (!batch.has_value()) {
-         continue;
-      }
-      ARROW_RETURN_NOT_OK(appendStringColumn(batch->values[from_index], from_values));
-      ARROW_RETURN_NOT_OK(appendStringColumn(batch->values[to_index], to_values));
-   }
-
    std::vector<std::string> vertex_names;
+   std::vector<std::vector<uint32_t>> adjacency;
    std::unordered_map<std::string, uint32_t> vertex_ids;
-   const auto intern = [&](const std::string& value) {
+   const auto intern = [&](std::string value) {
       const auto [iterator, inserted] =
-         vertex_ids.try_emplace(value, static_cast<uint32_t>(vertex_names.size()));
+         vertex_ids.try_emplace(std::move(value), static_cast<uint32_t>(vertex_names.size()));
       if (inserted) {
          vertex_names.push_back(iterator->first);
+         adjacency.emplace_back();
       }
       return iterator->second;
    };
 
-   std::vector<std::pair<uint32_t, uint32_t>> edges;
-   for (size_t row = 0; row < from_values.size(); ++row) {
-      if (!from_values[row].has_value() || !to_values[row].has_value()) {
+   for (const auto& batch : batches) {
+      if (!batch.has_value()) {
          continue;
       }
-      edges.emplace_back(intern(*from_values[row]), intern(*to_values[row]));
+      ARROW_ASSIGN_OR_RAISE(const auto from_array, asStringArray(batch->values[from_index]));
+      ARROW_ASSIGN_OR_RAISE(const auto to_array, asStringArray(batch->values[to_index]));
+      for (int64_t row = 0; row < from_array->length(); ++row) {
+         if (from_array->IsNull(row) || to_array->IsNull(row)) {
+            continue;
+         }
+         const uint32_t from = intern(from_array->GetString(row));
+         const uint32_t to = intern(to_array->GetString(row));
+         adjacency[from].push_back(to);
+      }
    }
 
-   std::vector<std::vector<uint32_t>> adjacency(vertex_names.size());
-   for (const auto& [from, to] : edges) {
-      adjacency[from].push_back(to);
-   }
    return Relation{.vertex_names = std::move(vertex_names), .adjacency = std::move(adjacency)};
 }
 
-/// Computes the transitive closure of `relation`, returning the reachable pairs sorted by
-/// (from, to) name so the output is deterministic. If `include_vertices` is set, the reflexive
-/// pair (v, v) is added for every vertex.
-std::vector<std::pair<std::string, std::string>> computeClosure(
-   const Relation& relation,
-   bool include_vertices
-) {
-   const auto num_vertices = static_cast<uint32_t>(relation.vertex_names.size());
-   std::vector<std::pair<std::string, std::string>> pairs;
+/// Emits the transitive closure of a relation in batches
+class ClosureProducer {
+  public:
+   ClosureProducer(Relation relation, bool include_vertices, size_t batch_size)
+       : relation(std::move(relation)),
+         include_vertices(include_vertices),
+         batch_size(batch_size),
+         reached(this->relation.vertex_names.size(), false) {}
 
-   for (uint32_t source = 0; source < num_vertices; ++source) {
-      std::vector<bool> reached(num_vertices, false);
-      std::queue<uint32_t> to_visit;
+   /// Returns the next batch of reachable pairs, or `std::nullopt` once the closure is exhausted.
+   /// The order of the pairs is unspecified beyond being grouped by source vertex; callers that
+   /// need an order sort the result downstream.
+   arrow::Result<std::optional<arrow::ExecBatch>> nextBatch() {
+      const auto num_vertices = static_cast<uint32_t>(relation.vertex_names.size());
+      while (buffer.size() - buffer_offset < batch_size && next_source < num_vertices) {
+         bufferPairsOfSource(next_source++);
+      }
+      if (buffer_offset == buffer.size()) {
+         return std::nullopt;
+      }
+      const size_t end = std::min(buffer_offset + batch_size, buffer.size());
+      ARROW_ASSIGN_OR_RAISE(auto batch, buildBatch(buffer_offset, end));
+      buffer_offset = end;
+      if (buffer_offset == buffer.size()) {
+         buffer.clear();
+         buffer_offset = 0;
+      }
+      return std::optional<arrow::ExecBatch>{std::move(batch)};
+   }
+
+  private:
+   /// Appends every pair `(source, destination)` with `destination` reachable from `source` to the
+   /// buffer, by searching the graph from `source`.
+   void bufferPairsOfSource(uint32_t source) {
+      std::ranges::fill(reached, false);
+      frontier.clear();
       for (const uint32_t successor : relation.adjacency[source]) {
          if (!reached[successor]) {
             reached[successor] = true;
-            to_visit.push(successor);
+            frontier.push_back(successor);
          }
       }
-      while (!to_visit.empty()) {
-         const uint32_t current = to_visit.front();
-         to_visit.pop();
+      while (!frontier.empty()) {
+         const uint32_t current = frontier.back();
+         frontier.pop_back();
          for (const uint32_t successor : relation.adjacency[current]) {
             if (!reached[successor]) {
                reached[successor] = true;
-               to_visit.push(successor);
+               frontier.push_back(successor);
             }
          }
       }
+      const auto num_vertices = static_cast<uint32_t>(reached.size());
       for (uint32_t destination = 0; destination < num_vertices; ++destination) {
          if (reached[destination]) {
-            pairs.emplace_back(relation.vertex_names[source], relation.vertex_names[destination]);
+            buffer.emplace_back(source, destination);
          }
       }
       // Add the reflexive pair unless the vertex already reaches itself through a cycle.
       if (include_vertices && !reached[source]) {
-         pairs.emplace_back(relation.vertex_names[source], relation.vertex_names[source]);
+         buffer.emplace_back(source, source);
       }
    }
 
-   std::ranges::sort(pairs);
-   return pairs;
-}
-
-arrow::Result<std::optional<arrow::ExecBatch>> buildClosureBatch(
-   const std::vector<std::pair<std::string, std::string>>& pairs
-) {
-   arrow::StringBuilder from_builder{};
-   arrow::StringBuilder to_builder{};
-   for (const auto& [from, to] : pairs) {
-      ARROW_RETURN_NOT_OK(from_builder.Append(from));
-      ARROW_RETURN_NOT_OK(to_builder.Append(to));
+   arrow::Result<arrow::ExecBatch> buildBatch(size_t begin, size_t end) const {
+      arrow::StringBuilder from_builder{};
+      arrow::StringBuilder to_builder{};
+      ARROW_RETURN_NOT_OK(from_builder.Reserve(static_cast<int64_t>(end - begin)));
+      ARROW_RETURN_NOT_OK(to_builder.Reserve(static_cast<int64_t>(end - begin)));
+      for (size_t index = begin; index < end; ++index) {
+         const auto [from, to] = buffer[index];
+         ARROW_RETURN_NOT_OK(from_builder.Append(relation.vertex_names[from]));
+         ARROW_RETURN_NOT_OK(to_builder.Append(relation.vertex_names[to]));
+      }
+      arrow::Datum from_datum;
+      ARROW_ASSIGN_OR_RAISE(from_datum, from_builder.Finish());
+      arrow::Datum to_datum;
+      ARROW_ASSIGN_OR_RAISE(to_datum, to_builder.Finish());
+      return arrow::ExecBatch::Make({from_datum, to_datum});
    }
-   arrow::Datum from_datum;
-   ARROW_ASSIGN_OR_RAISE(from_datum, from_builder.Finish());
-   arrow::Datum to_datum;
-   ARROW_ASSIGN_OR_RAISE(to_datum, to_builder.Finish());
-   ARROW_ASSIGN_OR_RAISE(auto batch, arrow::ExecBatch::Make({from_datum, to_datum}));
-   return std::optional<arrow::ExecBatch>{std::move(batch)};
-}
+
+   Relation relation;
+   bool include_vertices;
+   size_t batch_size;
+   /// Scratch state of a single-source search, kept across sources to avoid reallocating it.
+   std::vector<bool> reached;
+   std::vector<uint32_t> frontier;
+   /// The pairs found but not yet emitted, as `(source, destination)` vertex ids.
+   std::vector<std::pair<uint32_t, uint32_t>> buffer;
+   size_t buffer_offset = 0;
+   uint32_t next_source = 0;
+};
 
 }  // namespace
 
@@ -221,27 +247,35 @@ arrow::Result<arrow::acero::ExecNode*> TransitiveClosureNode::addToExecPlan(
          .status()
    );
 
+   // `materialization_cutoff` is the batch-size-minus-one
+   const size_t batch_size = query_options.materialization_cutoff + 1;
    const bool include_vertices_copy = include_vertices;
+   // The first call builds the relation from the child's batches and hands it to the producer,
+   // which then streams the closure one batch at a time as the downstream pulls.
+   const auto closure = std::make_shared<std::optional<ClosureProducer>>();
+
    std::function<arrow::Future<std::optional<arrow::ExecBatch>>()> producer =
       [child_generator = std::move(child_generator),
+       closure,
        from_index,
        to_index,
        include_vertices_copy,
-       already_produced = false]() mutable -> arrow::Future<std::optional<arrow::ExecBatch>> {
-      if (already_produced) {
-         const std::optional<arrow::ExecBatch> end_of_stream = std::nullopt;
-         return arrow::Future{end_of_stream};
+       batch_size]() mutable -> arrow::Future<std::optional<arrow::ExecBatch>> {
+      if (closure->has_value()) {
+         return arrow::Future<std::optional<arrow::ExecBatch>>::MakeFinished(
+            closure->value().nextBatch()
+         );
       }
-      already_produced = true;
       return arrow::CollectAsyncGenerator(child_generator)
          .Then(
-            [from_index, to_index, include_vertices_copy](
+            [closure, from_index, to_index, include_vertices_copy, batch_size](
                const std::vector<std::optional<arrow::ExecBatch>>& batches
             ) -> arrow::Result<std::optional<arrow::ExecBatch>> {
                ARROW_ASSIGN_OR_RAISE(
-                  const Relation relation, buildRelation(batches, from_index, to_index)
+                  Relation relation, buildRelation(batches, from_index, to_index)
                );
-               return buildClosureBatch(computeClosure(relation, include_vertices_copy));
+               closure->emplace(std::move(relation), include_vertices_copy, batch_size);
+               return closure->value().nextBatch();
             }
          );
    };

--- a/src/rhydb/query_engine/operators/transitive_closure_node.cpp
+++ b/src/rhydb/query_engine/operators/transitive_closure_node.cpp
@@ -146,7 +146,7 @@ class ClosureProducer {
    /// Appends every pair `(source, destination)` with `destination` reachable from `source` to the
    /// buffer, by searching the graph from `source`.
    void bufferPairsOfSource(uint32_t source) {
-      std::ranges::fill(reached, false);
+      reached.assign(reached.size(), false);
       frontier.clear();
       for (const uint32_t successor : relation.adjacency[source]) {
          if (!reached[successor]) {

--- a/src/rhydb/query_engine/operators/transitive_closure_node.h
+++ b/src/rhydb/query_engine/operators/transitive_closure_node.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <arrow/result.h>
+
+#include "rhydb/query_engine/operators/query_node.h"
+#include "rhydb/schema/database_schema.h"
+#include "rhydb/storage/table.h"
+
+namespace rhydb::query_engine::operators {
+
+/// The `child` is a subquery that produces the columns `to_column` and `from_column`.
+/// It is materialized and interpreted as a set of directed edges: every input row contributes an
+/// edge from the value in its `from_column` to the value in its `to_column`. Both must be
+/// string-typed columns of the child's output. Rows with a null value in either endpoint are
+/// ignored (a lineage relation table, for example, stores a null parent for each root). The node
+/// emits one output row `{from, to}` for every ordered pair of vertices `(a, b)` such that `b` is
+/// reachable from `a` by following one or more edges.
+///
+/// When `include_vertices` is true, the reflexive pair `(v, v)` is additionally emitted for
+/// every vertex `v` appearing in the relation, yielding the reflexive-transitive closure. This
+/// is what lets a lineage be counted together with all of its sublineages: joining the
+/// closure's `to` column against a data table's lineage column and grouping by `from` sums, for
+/// each lineage, all of its descendants and — thanks to the reflexive pair — itself.
+class TransitiveClosureNode final : public QueryNode {
+  public:
+   static constexpr std::string_view FROM_COLUMN = "from";
+   static constexpr std::string_view TO_COLUMN = "to";
+
+   QueryNodePtr child;
+   std::string from_column;
+   std::string to_column;
+   bool include_vertices;
+
+   TransitiveClosureNode(
+      QueryNodePtr child,
+      std::string from_column,
+      std::string to_column,
+      bool include_vertices
+   );
+
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
+
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
+      const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
+      const config::QueryOptions& query_options
+   ) const override;
+
+   [[nodiscard]] NodeKind kind() const override { return NodeKind::TRANSITIVE_CLOSURE; }
+
+   [[nodiscard]] nlohmann::json toJson() const override;
+};
+
+}  // namespace rhydb::query_engine::operators

--- a/src/rhydb/query_engine/operators/transitive_closure_node.test.cpp
+++ b/src/rhydb/query_engine/operators/transitive_closure_node.test.cpp
@@ -337,6 +337,67 @@ const QueryTestScenario INT_COLUMN_SCENARIO = {
       "column 'weight' has type INT32"
 };
 
+nlohmann::json createDataWithSingleLineageColumn(
+   const std::string& primaryKey,
+   const nlohmann::json& value
+) {
+   return {
+      {"primaryKey", primaryKey},
+      {"pango_lineage", value},
+      {"segment1", nullptr},
+      {"unaligned_segment1", nullptr},
+      {"gene1", nullptr}
+   };
+}
+
+// A single lineage column with `lineageIndexType: both`, i.e. the realistic shape of a lineage
+// config: there is no plain STRING copy of the lineage to join against, since a lineage-indexed
+// column is necessarily dictionary-encoded. The closure emits STRING columns and join() compares
+// join keys by the arrow type both sides materialize, so the two still join.
+const auto SINGLE_LINEAGE_COLUMN_DATABASE_CONFIG =
+   R"(
+schema:
+  instanceName: "dummy name"
+  metadata:
+    - name: "primaryKey"
+      type: "string"
+    - name: "pango_lineage"
+      type: "string"
+      generateIndex: true
+      generateLineageIndex: test_lineage_index
+      lineageIndexType: both
+  primaryKey: "primaryKey"
+)";
+
+const QueryTestData SINGLE_LINEAGE_COLUMN_TEST_DATA{
+   .ndjson_input_data =
+      {createDataWithSingleLineageColumn("id_0", "BASE.1"),
+       createDataWithSingleLineageColumn("id_1", "CHILD"),
+       createDataWithSingleLineageColumn("id_2", "CHILD"),
+       createDataWithSingleLineageColumn("id_3", "CHILD.2"),
+       createDataWithSingleLineageColumn("id_4", "GRANDCHILD"),
+       createDataWithSingleLineageColumn("id_5", nullptr)},
+   .database_config = SINGLE_LINEAGE_COLUMN_DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES,
+   .lineage_trees = {{"test_lineage_index", LINEAGE_TREE}}
+};
+
+// The motivating query, joining the closure against the dictionary-encoded lineage column itself.
+const QueryTestScenario COUNT_SUBLINEAGES_ON_DICTIONARY_ENCODED_COLUMN_SCENARIO = {
+   .name = "COUNT_SUBLINEAGES_ON_DICTIONARY_ENCODED_COLUMN_SCENARIO",
+   .query =
+      "pango_lineage.transitiveClosure('parent', 'lineage', includeVertices:=true)"
+      ".join(default, to = pango_lineage)"
+      ".groupBy({count := count()}, {from})"
+      ".orderBy({from})",
+   .expected_query_result = nlohmann::json(
+      {{{"from", "BASE.1"}, {"count", 5}},
+       {{"from", "CHILD"}, {"count", 3}},
+       {{"from", "CHILD.2"}, {"count", 1}},
+       {{"from", "GRANDCHILD"}, {"count", 1}}}
+   )
+};
+
 }  // namespace
 
 QUERY_TEST(
@@ -367,4 +428,10 @@ QUERY_TEST(
       CYCLIC_RELATION_INCLUDE_VERTICES_SCENARIO,
       INT_COLUMN_SCENARIO
    )
+);
+
+QUERY_TEST(
+   TransitiveClosureSingleLineageColumnTest,
+   SINGLE_LINEAGE_COLUMN_TEST_DATA,
+   ::testing::Values(COUNT_SUBLINEAGES_ON_DICTIONARY_ENCODED_COLUMN_SCENARIO)
 );

--- a/src/rhydb/query_engine/operators/transitive_closure_node.test.cpp
+++ b/src/rhydb/query_engine/operators/transitive_closure_node.test.cpp
@@ -191,6 +191,152 @@ const QueryTestScenario UNKNOWN_COLUMN_SCENARIO = {
       "transitiveClosure() column 'does_not_exist' is not present in the input's output schema"
 };
 
+// A lineage-indexed column is dictionary-encoded, not STRING, so it cannot be an edge endpoint.
+const QueryTestScenario NON_STRING_COLUMN_SCENARIO = {
+   .name = "NON_STRING_COLUMN_SCENARIO",
+   .query = "default.transitiveClosure('pango_lineage_indexed', 'primaryKey')",
+   .expected_error_message =
+      "transitiveClosure() can only be applied to STRING columns, but "
+      "column 'pango_lineage_indexed' has type DICTIONARY_ENCODED"
+};
+
+//   ROOT
+//   └── KID
+//   ORPHAN
+// ORPHAN is parentless and childless, so its row in the relation table has a null `parent` and
+// contributes no edge at all - it is still a vertex of the relation.
+const auto LINEAGE_TREE_WITH_ISOLATED_VERTEX =
+   LineageTreeAndIdMap::fromLineageDefinitionFile(LineageDefinitionFile::fromYAMLString(R"(
+ROOT:
+  parents: []
+KID:
+  parents:
+  - ROOT
+ORPHAN:
+  parents: []
+)"));
+
+const QueryTestData TEST_DATA_WITH_ISOLATED_VERTEX{
+   .ndjson_input_data = {createDataWithLineageValue("id_0", "KID")},
+   .database_config = DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES,
+   .lineage_trees = {{"test_lineage_index", LINEAGE_TREE_WITH_ISOLATED_VERTEX}}
+};
+
+// An edge row with a null endpoint carries no edge, so the isolated vertex appears in no pair.
+const QueryTestScenario ISOLATED_VERTEX_SCENARIO = {
+   .name = "ISOLATED_VERTEX_SCENARIO",
+   .query = "pango_lineage_indexed.transitiveClosure('parent', 'lineage').orderBy({from, to})",
+   .expected_query_result = nlohmann::json({{{"from", "ROOT"}, {"to", "KID"}}})
+};
+
+// ... but it is a vertex, so includeVertices still pairs it with itself.
+const QueryTestScenario ISOLATED_VERTEX_INCLUDE_VERTICES_SCENARIO = {
+   .name = "ISOLATED_VERTEX_INCLUDE_VERTICES_SCENARIO",
+   .query =
+      "pango_lineage_indexed.transitiveClosure('parent', 'lineage', includeVertices:=true)"
+      ".orderBy({from, to})",
+   .expected_query_result = nlohmann::json(
+      {{{"from", "KID"}, {"to", "KID"}},
+       {{"from", "ORPHAN"}, {"to", "ORPHAN"}},
+       {{"from", "ROOT"}, {"to", "KID"}},
+       {{"from", "ROOT"}, {"to", "ROOT"}}}
+   )
+};
+
+nlohmann::json createEdge(
+   const std::string& primaryKey,
+   const nlohmann::json& edge_from,
+   const nlohmann::json& edge_to
+) {
+   return {
+      {"primaryKey", primaryKey},
+      {"edge_from", edge_from},
+      {"edge_to", edge_to},
+      {"weight", 1},
+      {"segment1", nullptr},
+      {"unaligned_segment1", nullptr},
+      {"gene1", nullptr}
+   };
+}
+
+// The relation is an arbitrary directed graph, not just a tree:
+//   A <-> B  (a two-vertex cycle)   C -> C  (a self loop)   D -> E  (acyclic)   F -> null
+const std::vector<nlohmann::json> GRAPH_DATA = {
+   createEdge("id_0", "A", "B"),
+   createEdge("id_1", "B", "A"),
+   createEdge("id_2", "C", "C"),
+   createEdge("id_3", "D", "E"),
+   createEdge("id_4", "F", nullptr),
+};
+
+const auto GRAPH_DATABASE_CONFIG =
+   R"(
+schema:
+  instanceName: "dummy name"
+  metadata:
+    - name: "primaryKey"
+      type: "string"
+    - name: "edge_from"
+      type: "string"
+    - name: "edge_to"
+      type: "string"
+    - name: "weight"
+      type: "int"
+  primaryKey: "primaryKey"
+)";
+
+const QueryTestData GRAPH_TEST_DATA{
+   .ndjson_input_data = GRAPH_DATA,
+   .database_config = GRAPH_DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES
+};
+
+// A vertex on a cycle reaches itself, so it is paired with itself even without includeVertices.
+const QueryTestScenario CYCLIC_RELATION_SCENARIO = {
+   .name = "CYCLIC_RELATION_SCENARIO",
+   .query =
+      "default.project({edge_from, edge_to})"
+      ".transitiveClosure('edge_from', 'edge_to').orderBy({from, to})",
+   .expected_query_result = nlohmann::json(
+      {{{"from", "A"}, {"to", "A"}},
+       {{"from", "A"}, {"to", "B"}},
+       {{"from", "B"}, {"to", "A"}},
+       {{"from", "B"}, {"to", "B"}},
+       {{"from", "C"}, {"to", "C"}},
+       {{"from", "D"}, {"to", "E"}}}
+   )
+};
+
+// includeVertices adds the reflexive pair only for the vertices that no cycle already covers:
+// (D, D), (E, E) and (F, F), but no second (A, A) / (B, B) / (C, C).
+const QueryTestScenario CYCLIC_RELATION_INCLUDE_VERTICES_SCENARIO = {
+   .name = "CYCLIC_RELATION_INCLUDE_VERTICES_SCENARIO",
+   .query =
+      "default.project({edge_from, edge_to})"
+      ".transitiveClosure('edge_from', 'edge_to', includeVertices:=true)"
+      ".orderBy({from, to})",
+   .expected_query_result = nlohmann::json(
+      {{{"from", "A"}, {"to", "A"}},
+       {{"from", "A"}, {"to", "B"}},
+       {{"from", "B"}, {"to", "A"}},
+       {{"from", "B"}, {"to", "B"}},
+       {{"from", "C"}, {"to", "C"}},
+       {{"from", "D"}, {"to", "D"}},
+       {{"from", "D"}, {"to", "E"}},
+       {{"from", "E"}, {"to", "E"}},
+       {{"from", "F"}, {"to", "F"}}}
+   )
+};
+
+const QueryTestScenario INT_COLUMN_SCENARIO = {
+   .name = "INT_COLUMN_SCENARIO",
+   .query = "default.transitiveClosure('edge_from', 'weight')",
+   .expected_error_message =
+      "transitiveClosure() can only be applied to STRING columns, but "
+      "column 'weight' has type INT32"
+};
+
 }  // namespace
 
 QUERY_TEST(
@@ -202,6 +348,23 @@ QUERY_TEST(
       TRANSITIVE_CLOSURE_ONE_PAIR_PER_BATCH_SCENARIO,
       COUNT_LINEAGE_INCLUDING_SUBLINEAGES_SCENARIO,
       SUBQUERY_INPUT_SCENARIO,
-      UNKNOWN_COLUMN_SCENARIO
+      UNKNOWN_COLUMN_SCENARIO,
+      NON_STRING_COLUMN_SCENARIO
+   )
+);
+
+QUERY_TEST(
+   TransitiveClosureIsolatedVertexTest,
+   TEST_DATA_WITH_ISOLATED_VERTEX,
+   ::testing::Values(ISOLATED_VERTEX_SCENARIO, ISOLATED_VERTEX_INCLUDE_VERTICES_SCENARIO)
+);
+
+QUERY_TEST(
+   TransitiveClosureGraphTest,
+   GRAPH_TEST_DATA,
+   ::testing::Values(
+      CYCLIC_RELATION_SCENARIO,
+      CYCLIC_RELATION_INCLUDE_VERTICES_SCENARIO,
+      INT_COLUMN_SCENARIO
    )
 );

--- a/src/rhydb/query_engine/operators/transitive_closure_node.test.cpp
+++ b/src/rhydb/query_engine/operators/transitive_closure_node.test.cpp
@@ -1,0 +1,186 @@
+#include <nlohmann/json.hpp>
+
+#include "rhydb/preprocessing/lineage_definition_file.h"
+#include "rhydb/test/query_fixture.test.h"
+
+namespace {
+using rhydb::ReferenceGenomes;
+using rhydb::common::LineageTreeAndIdMap;
+using rhydb::preprocessing::LineageDefinitionFile;
+using rhydb::test::QueryTestData;
+using rhydb::test::QueryTestScenario;
+
+nlohmann::json createDataWithLineageValue(const std::string& primaryKey, const std::string& value) {
+   return {
+      {"primaryKey", primaryKey},
+      {"pango_lineage", value},
+      {"pango_lineage_indexed", value},
+      {"segment1", nullptr},
+      {"unaligned_segment1", nullptr},
+      {"gene1", nullptr}
+   };
+}
+
+nlohmann::json createDataWithLineageNullValue(const std::string& primaryKey) {
+   return {
+      {"primaryKey", primaryKey},
+      {"pango_lineage", nullptr},
+      {"pango_lineage_indexed", nullptr},
+      {"segment1", nullptr},
+      {"unaligned_segment1", nullptr},
+      {"gene1", nullptr}
+   };
+}
+
+const std::vector<nlohmann::json> DATA = {
+   createDataWithLineageValue("id_0", "BASE.1"),
+   createDataWithLineageValue("id_1", "CHILD"),
+   createDataWithLineageValue("id_2", "CHILD"),
+   createDataWithLineageValue("id_3", "CHILD.2"),
+   createDataWithLineageValue("id_4", "GRANDCHILD"),
+   createDataWithLineageNullValue("id_5"),
+};
+
+// Two lineage columns:
+//   * `pango_lineage` is a plain STRING column (no index) that carries each sequence's lineage.
+//     transitiveClosure emits STRING from/to columns, and join() requires matching column
+//     types, so the value we join the closure against must itself be STRING.
+//   * `pango_lineage_indexed` has `generateLineageIndex` + `lineageIndexType: table`, which
+//     materializes the companion `pango_lineage_indexed` relation table (columns
+//     `lineage`/`parent`) whose closure we compute. A lineage-indexed column is necessarily
+//     dictionary-encoded (generateIndex is required), which is why it cannot double as the
+//     STRING join key.
+const auto DATABASE_CONFIG =
+   R"(
+schema:
+  instanceName: "dummy name"
+  metadata:
+    - name: "primaryKey"
+      type: "string"
+    - name: "pango_lineage"
+      type: "string"
+    - name: "pango_lineage_indexed"
+      type: "string"
+      generateIndex: true
+      generateLineageIndex: test_lineage_index
+      lineageIndexType: table
+  primaryKey: "primaryKey"
+)";
+
+const auto REFERENCE_GENOMES = ReferenceGenomes{
+   {{"segment1", "A"}},
+   {{"gene1", "*"}},
+};
+
+//   BASE.1
+//   ├── CHILD
+//   │   └── GRANDCHILD
+//   └── CHILD.2
+const auto LINEAGE_TREE =
+   LineageTreeAndIdMap::fromLineageDefinitionFile(LineageDefinitionFile::fromYAMLString(R"(
+BASE.1:
+  parents: []
+CHILD:
+  parents:
+  - BASE.1
+CHILD.2:
+  parents:
+  - BASE.1
+GRANDCHILD:
+  parents:
+  - CHILD
+)"));
+
+const QueryTestData TEST_DATA{
+   .ndjson_input_data = DATA,
+   .database_config = DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES,
+   .lineage_trees = {{"test_lineage_index", LINEAGE_TREE}}
+};
+
+// Plain transitive closure of the parent -> lineage edges: every (ancestor, descendant) pair.
+const QueryTestScenario TRANSITIVE_CLOSURE_SCENARIO = {
+   .name = "TRANSITIVE_CLOSURE_SCENARIO",
+   .query = "pango_lineage_indexed.transitiveClosure('parent', 'lineage').orderBy({from, to})",
+   .expected_query_result = nlohmann::json(
+      {{{"from", "BASE.1"}, {"to", "CHILD"}},
+       {{"from", "BASE.1"}, {"to", "CHILD.2"}},
+       {{"from", "BASE.1"}, {"to", "GRANDCHILD"}},
+       {{"from", "CHILD"}, {"to", "GRANDCHILD"}}}
+   )
+};
+
+// Reflexive-transitive closure: additionally pairs every lineage with itself.
+const QueryTestScenario TRANSITIVE_CLOSURE_INCLUDE_VERTICES_SCENARIO = {
+   .name = "TRANSITIVE_CLOSURE_INCLUDE_VERTICES_SCENARIO",
+   .query =
+      "pango_lineage_indexed.transitiveClosure('parent', 'lineage', includeVertices:=true)"
+      ".orderBy({from, to})",
+   .expected_query_result = nlohmann::json(
+      {{{"from", "BASE.1"}, {"to", "BASE.1"}},
+       {{"from", "BASE.1"}, {"to", "CHILD"}},
+       {{"from", "BASE.1"}, {"to", "CHILD.2"}},
+       {{"from", "BASE.1"}, {"to", "GRANDCHILD"}},
+       {{"from", "CHILD"}, {"to", "CHILD"}},
+       {{"from", "CHILD"}, {"to", "GRANDCHILD"}},
+       {{"from", "CHILD.2"}, {"to", "CHILD.2"}},
+       {{"from", "GRANDCHILD"}, {"to", "GRANDCHILD"}}}
+   )
+};
+
+// The motivating use case: count every lineage together with all of its sublineages.
+// transitiveClosure (reflexive) -> join default on `to` = pango_lineage -> groupBy `from`.
+//   BASE.1     : id_0, id_1, id_2, id_3, id_4 -> 5
+//   CHILD      : id_1, id_2, id_4             -> 3
+//   CHILD.2    : id_3                         -> 1
+//   GRANDCHILD : id_4                         -> 1
+const QueryTestScenario COUNT_LINEAGE_INCLUDING_SUBLINEAGES_SCENARIO = {
+   .name = "COUNT_LINEAGE_INCLUDING_SUBLINEAGES_SCENARIO",
+   .query =
+      "pango_lineage_indexed.transitiveClosure('parent', 'lineage', includeVertices:=true)"
+      ".join(default, to = pango_lineage)"
+      ".groupBy({count := count()}, {from})"
+      ".orderBy({from})",
+   .expected_query_result = nlohmann::json(
+      {{{"from", "BASE.1"}, {"count", 5}},
+       {{"from", "CHILD"}, {"count", 3}},
+       {{"from", "CHILD.2"}, {"count", 1}},
+       {{"from", "GRANDCHILD"}, {"count", 1}}}
+   )
+};
+
+// The input is any relation-producing subquery, not just a bare table: here a project() feeds
+// transitiveClosure the two edge columns it reads.
+const QueryTestScenario SUBQUERY_INPUT_SCENARIO = {
+   .name = "SUBQUERY_INPUT_SCENARIO",
+   .query =
+      "pango_lineage_indexed.project({parent, lineage})"
+      ".transitiveClosure('parent', 'lineage').orderBy({from, to})",
+   .expected_query_result = nlohmann::json(
+      {{{"from", "BASE.1"}, {"to", "CHILD"}},
+       {{"from", "BASE.1"}, {"to", "CHILD.2"}},
+       {{"from", "BASE.1"}, {"to", "GRANDCHILD"}},
+       {{"from", "CHILD"}, {"to", "GRANDCHILD"}}}
+   )
+};
+
+const QueryTestScenario UNKNOWN_COLUMN_SCENARIO = {
+   .name = "UNKNOWN_COLUMN_SCENARIO",
+   .query = "pango_lineage_indexed.transitiveClosure('parent', 'does_not_exist')",
+   .expected_error_message =
+      "transitiveClosure() column 'does_not_exist' is not present in the input's output schema"
+};
+
+}  // namespace
+
+QUERY_TEST(
+   TransitiveClosureTest,
+   TEST_DATA,
+   ::testing::Values(
+      TRANSITIVE_CLOSURE_SCENARIO,
+      TRANSITIVE_CLOSURE_INCLUDE_VERTICES_SCENARIO,
+      COUNT_LINEAGE_INCLUDING_SUBLINEAGES_SCENARIO,
+      SUBQUERY_INPUT_SCENARIO,
+      UNKNOWN_COLUMN_SCENARIO
+   )
+);

--- a/src/rhydb/query_engine/operators/transitive_closure_node.test.cpp
+++ b/src/rhydb/query_engine/operators/transitive_closure_node.test.cpp
@@ -164,6 +164,26 @@ const QueryTestScenario SUBQUERY_INPUT_SCENARIO = {
    )
 };
 
+// The closure is emitted in `materialization_cutoff + 1`-sized batches; with a cutoff of 0 every
+// pair ends up in a batch of its own, which exercises the streaming path across several batches.
+const QueryTestScenario TRANSITIVE_CLOSURE_ONE_PAIR_PER_BATCH_SCENARIO = {
+   .name = "TRANSITIVE_CLOSURE_ONE_PAIR_PER_BATCH_SCENARIO",
+   .query =
+      "pango_lineage_indexed.transitiveClosure('parent', 'lineage', includeVertices:=true)"
+      ".orderBy({from, to})",
+   .expected_query_result = nlohmann::json(
+      {{{"from", "BASE.1"}, {"to", "BASE.1"}},
+       {{"from", "BASE.1"}, {"to", "CHILD"}},
+       {{"from", "BASE.1"}, {"to", "CHILD.2"}},
+       {{"from", "BASE.1"}, {"to", "GRANDCHILD"}},
+       {{"from", "CHILD"}, {"to", "CHILD"}},
+       {{"from", "CHILD"}, {"to", "GRANDCHILD"}},
+       {{"from", "CHILD.2"}, {"to", "CHILD.2"}},
+       {{"from", "GRANDCHILD"}, {"to", "GRANDCHILD"}}}
+   ),
+   .query_options = rhydb::config::QueryOptions{.materialization_cutoff = 0}
+};
+
 const QueryTestScenario UNKNOWN_COLUMN_SCENARIO = {
    .name = "UNKNOWN_COLUMN_SCENARIO",
    .query = "pango_lineage_indexed.transitiveClosure('parent', 'does_not_exist')",
@@ -179,6 +199,7 @@ QUERY_TEST(
    ::testing::Values(
       TRANSITIVE_CLOSURE_SCENARIO,
       TRANSITIVE_CLOSURE_INCLUDE_VERTICES_SCENARIO,
+      TRANSITIVE_CLOSURE_ONE_PAIR_PER_BATCH_SCENARIO,
       COUNT_LINEAGE_INCLUDING_SUBLINEAGES_SCENARIO,
       SUBQUERY_INPUT_SCENARIO,
       UNKNOWN_COLUMN_SCENARIO

--- a/src/rhydb/query_engine/optimizer/column_narrowing_pass.cpp
+++ b/src/rhydb/query_engine/optimizer/column_narrowing_pass.cpp
@@ -190,11 +190,11 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::SchemaNode& n
 
 // NOLINTNEXTLINE(misc-no-recursion,readability-make-member-function-const)
 operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::TransitiveClosureNode& node) {
-   // transitiveClosure() re-materializes its child into a fresh from/to relation, so this
-   // pass's `required` set (which describes the closure's own output) does not map onto the
-   // child's columns. Recurse into the child with a fresh pass seeded with its complete output
-   // schema: nothing is pruned directly below the node, while deeper simplifications still run.
-   ColumnNarrowingPass child_pass{node.child->getOutputSchema()};
+   auto child_required = node.child->getOutputSchema();
+   std::erase_if(child_required, [&node](const auto& column) {
+      return column.name != node.from_column && column.name != node.to_column;
+   });
+   ColumnNarrowingPass child_pass{std::move(child_required)};
    child_pass.propagateToNode(node.child);
    return nullptr;
 }

--- a/src/rhydb/query_engine/optimizer/column_narrowing_pass.cpp
+++ b/src/rhydb/query_engine/optimizer/column_narrowing_pass.cpp
@@ -11,6 +11,7 @@
 #include "rhydb/query_engine/operators/project_node.h"
 #include "rhydb/query_engine/operators/schema_node.h"
 #include "rhydb/query_engine/operators/table_scan_node.h"
+#include "rhydb/query_engine/operators/transitive_closure_node.h"
 #include "rhydb/query_engine/operators/union_all_node.h"
 
 namespace rhydb::query_engine::optimizer {
@@ -182,6 +183,17 @@ operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::SchemaNode& n
    // reported schema). We still recurse with a fresh pass seeded with the child's complete
    // output schema as "required": this keeps every column while still allowing the pass's
    // structural simplifications to run.
+   ColumnNarrowingPass child_pass{node.child->getOutputSchema()};
+   child_pass.propagateToNode(node.child);
+   return nullptr;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion,readability-make-member-function-const)
+operators::QueryNodePtr ColumnNarrowingPass::operator()(operators::TransitiveClosureNode& node) {
+   // transitiveClosure() re-materializes its child into a fresh from/to relation, so this
+   // pass's `required` set (which describes the closure's own output) does not map onto the
+   // child's columns. Recurse into the child with a fresh pass seeded with its complete output
+   // schema: nothing is pruned directly below the node, while deeper simplifications still run.
    ColumnNarrowingPass child_pass{node.child->getOutputSchema()};
    child_pass.propagateToNode(node.child);
    return nullptr;

--- a/src/rhydb/query_engine/optimizer/column_narrowing_pass.h
+++ b/src/rhydb/query_engine/optimizer/column_narrowing_pass.h
@@ -16,6 +16,7 @@ class OrderByNode;
 class UnionAllNode;
 class JoinNode;
 class SchemaNode;
+class TransitiveClosureNode;
 }  // namespace rhydb::query_engine::operators
 
 namespace rhydb::query_engine::optimizer {
@@ -47,6 +48,7 @@ class ColumnNarrowingPass : public PipelinePassBase<ColumnNarrowingPass> {
    operators::QueryNodePtr operator()(operators::UnionAllNode& node);
    operators::QueryNodePtr operator()(operators::JoinNode& node);
    operators::QueryNodePtr operator()(operators::SchemaNode& node);
+   operators::QueryNodePtr operator()(operators::TransitiveClosureNode& node);
 };
 
 }  // namespace rhydb::query_engine::optimizer

--- a/src/rhydb/query_engine/optimizer/filter_pushdown_pass.cpp
+++ b/src/rhydb/query_engine/optimizer/filter_pushdown_pass.cpp
@@ -180,7 +180,7 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::TransitiveClos
    // transitiveClosure() re-materializes its child into a fresh from/to relation; it is a
    // source operator with no place to push a predicate into. A filter() applied to its output
    // therefore cannot be realized -> reject the query.
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       current_filters.empty(),
       "filter() cannot be applied to the output of transitiveClosure(); transitiveClosure() is "
       "a source operator and its result cannot be filtered. Apply filter() to its input instead."

--- a/src/rhydb/query_engine/optimizer/filter_pushdown_pass.cpp
+++ b/src/rhydb/query_engine/optimizer/filter_pushdown_pass.cpp
@@ -17,6 +17,7 @@
 #include "rhydb/query_engine/operators/phylo_subtree_node.h"
 #include "rhydb/query_engine/operators/schema_node.h"
 #include "rhydb/query_engine/operators/table_scan_node.h"
+#include "rhydb/query_engine/operators/transitive_closure_node.h"
 #include "rhydb/query_engine/operators/union_all_node.h"
 #include "rhydb/query_engine/scalar_expressions/and.h"
 #include "rhydb/query_engine/scalar_expressions/field_ref.h"
@@ -169,6 +170,23 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::SchemaNode& no
    // NodeResolutionPass requires this: it expects a bare table scan beneath
    // mutations()/insertions(). A separate instance is used so the filters from above schema()
    // cannot leak into the child.
+   FilterPushdownPass child_pass;
+   child_pass.propagateToNode(node.child);
+   return nullptr;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr FilterPushdownPass::operator()(operators::TransitiveClosureNode& node) {
+   // transitiveClosure() re-materializes its child into a fresh from/to relation; it is a
+   // source operator with no place to push a predicate into. A filter() applied to its output
+   // therefore cannot be realized -> reject the query.
+   CHECK_SILO_QUERY(
+      current_filters.empty(),
+      "filter() cannot be applied to the output of transitiveClosure(); transitiveClosure() is "
+      "a source operator and its result cannot be filtered. Apply filter() to its input instead."
+   );
+   // Push filters down within the child subtree using a fresh pass so nothing leaks across the
+   // materialization boundary (e.g. `relation.filter(...).transitiveClosure(...)`).
    FilterPushdownPass child_pass;
    child_pass.propagateToNode(node.child);
    return nullptr;

--- a/src/rhydb/query_engine/optimizer/filter_pushdown_pass.h
+++ b/src/rhydb/query_engine/optimizer/filter_pushdown_pass.h
@@ -17,6 +17,7 @@ class MostRecentCommonAncestorNode;
 class UnionAllNode;
 class JoinNode;
 class SchemaNode;
+class TransitiveClosureNode;
 }  // namespace rhydb::query_engine::operators
 
 namespace rhydb::query_engine::optimizer {
@@ -40,6 +41,7 @@ class FilterPushdownPass : public PipelinePassBase<FilterPushdownPass> {
    operators::QueryNodePtr operator()(operators::PhyloSubtreeNode& node);
    operators::QueryNodePtr operator()(operators::MostRecentCommonAncestorNode& node);
    operators::QueryNodePtr operator()(operators::SchemaNode& node);
+   operators::QueryNodePtr operator()(operators::TransitiveClosureNode& node);
 
    operators::QueryNodePtr operator()(operators::UnionAllNode& node);
 

--- a/src/rhydb/query_engine/optimizer/pipeline_pass_base.h
+++ b/src/rhydb/query_engine/optimizer/pipeline_pass_base.h
@@ -12,6 +12,7 @@
 #include "rhydb/query_engine/operators/order_by_with_limit_node.h"
 #include "rhydb/query_engine/operators/project_node.h"
 #include "rhydb/query_engine/operators/query_node.h"
+#include "rhydb/query_engine/operators/transitive_closure_node.h"
 #include "rhydb/query_engine/operators/union_all_node.h"
 #include "rhydb/query_engine/operators/unresolved_insertions_node.h"
 #include "rhydb/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
@@ -138,6 +139,15 @@ class PipelinePassBase {
    operators::QueryNodePtr operator()(operators::JoinNode& node) {
       propagateToNode(node.left);
       propagateToNode(node.right);
+      return nullptr;
+   }
+
+   // Default propagation for the transitive-closure operator, which re-materializes its child
+   // into a fresh from/to relation. The child is walked by the same pass instance, so this
+   // default is only correct for stateless passes; a stateful pass MUST override this.
+   // NOLINTNEXTLINE(misc-no-recursion)
+   operators::QueryNodePtr operator()(operators::TransitiveClosureNode& node) {
+      propagateToNode(node.child);
       return nullptr;
    }
 

--- a/src/rhydb/query_engine/saneql/ast_to_query.cpp
+++ b/src/rhydb/query_engine/saneql/ast_to_query.cpp
@@ -25,6 +25,7 @@
 #include "rhydb/query_engine/operators/project_node.h"
 #include "rhydb/query_engine/operators/schema_node.h"
 #include "rhydb/query_engine/operators/table_scan_node.h"
+#include "rhydb/query_engine/operators/transitive_closure_node.h"
 #include "rhydb/query_engine/operators/union_all_node.h"
 #include "rhydb/query_engine/operators/unresolved_insertions_node.h"
 #include "rhydb/query_engine/operators/unresolved_most_recent_common_ancestor_node.h"
@@ -1508,6 +1509,25 @@ operators::QueryNodePtr handleUnionAll(
    return std::make_unique<operators::UnionAllNode>(std::move(left), std::move(right));
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
+operators::QueryNodePtr handleTransitiveClosure(
+   const BoundArguments& args,
+   const Tables& tables,
+   const ChildConverter& convert_child
+) {
+   auto child = convert_child(args.at("input"), tables);
+   auto from_column = extractStringLiteral(args.at("from"));
+   auto to_column = extractStringLiteral(args.at("to"));
+   bool include_vertices = false;
+   if (const auto* expr = args.get("includeVertices")) {
+      include_vertices = extractBoolLiteral(*expr);
+   }
+
+   return std::make_unique<operators::TransitiveClosureNode>(
+      std::move(child), std::move(from_column), std::move(to_column), include_vertices
+   );
+}
+
 }  // namespace
 
 // NOLINTNEXTLINE(misc-no-recursion)
@@ -1634,6 +1654,12 @@ FunctionRegistry::FunctionRegistry() {
 
    registerFunction(
       "join", {{pos("left"), pos("right"), pos("on"), named("type", false)}}, handleJoin
+   );
+
+   registerFunction(
+      "transitiveClosure",
+      {{pos("input"), pos("from"), pos("to"), named("includeVertices", false)}},
+      handleTransitiveClosure
    );
 }
 

--- a/src/rhydb/query_engine/saneql/ast_to_query.cpp
+++ b/src/rhydb/query_engine/saneql/ast_to_query.cpp
@@ -15,6 +15,7 @@
 #include "rhydb/common/aa_symbols.h"
 #include "rhydb/common/lineage_tree.h"
 #include "rhydb/common/nucleotide_symbols.h"
+#include "rhydb/query_engine/exec_node/arrow_util.h"
 #include "rhydb/query_engine/illegal_query_exception.h"
 #include "rhydb/query_engine/operators/aggregate_node.h"
 #include "rhydb/query_engine/operators/fetch_node.h"
@@ -1388,7 +1389,8 @@ void collectJoinKeys(
       on_expression.location.toString()
    );
    CHECK_RHYDB_QUERY(
-      first.column.type == second.column.type,
+      exec_node::columnTypeToArrowType(first.column.type)
+         ->Equals(*exec_node::columnTypeToArrowType(second.column.type)),
       "join() on-expression equality must reference equal column types from each input, but "
       "'{}' and '{}' have mismatching types {} and {} at {}",
       binary.left->toString(),

--- a/src/rhydb/query_engine/saneql/ast_to_query.test.cpp
+++ b/src/rhydb/query_engine/saneql/ast_to_query.test.cpp
@@ -13,6 +13,7 @@
 #include "rhydb/query_engine/saneql/ast.h"
 #include "rhydb/query_engine/saneql/parser.h"
 #include "rhydb/schema/database_schema.h"
+#include "rhydb/storage/column/dictionary_encoded_column.h"
 #include "rhydb/storage/column/string_column.h"
 #include "rhydb/storage/table.h"
 
@@ -50,6 +51,27 @@ Tables makeTablesWithDefault() {
    std::map<ColumnIdentifier, std::shared_ptr<ColumnMetadata>> col_meta{
       {primary_key, std::make_shared<StringColumnMetadata>(primary_key.name)},
       {date_column, std::make_shared<ColumnMetadata>(date_column.name)}
+   };
+   auto schema = std::make_shared<rhydb::schema::TableSchema>(std::move(col_meta), primary_key);
+   Tables tables;
+   const rhydb::schema::TableName table_name("default");
+   tables[table_name] = std::make_shared<rhydb::storage::Table>(table_name, schema);
+   return tables;
+}
+
+/// A table whose `lineage` column is dictionary-encoded, next to the plain string `id` column.
+Tables makeTablesWithDictionaryEncodedColumn() {
+   using rhydb::schema::ColumnIdentifier;
+   using rhydb::schema::ColumnType;
+   using rhydb::storage::column::ColumnMetadata;
+   using rhydb::storage::column::DictionaryEncodedColumnMetadata;
+   using rhydb::storage::column::StringColumnMetadata;
+
+   ColumnIdentifier primary_key{.name = "id", .type = ColumnType::STRING};
+   ColumnIdentifier lineage_column{.name = "lineage", .type = ColumnType::DICTIONARY_ENCODED};
+   std::map<ColumnIdentifier, std::shared_ptr<ColumnMetadata>> col_meta{
+      {primary_key, std::make_shared<StringColumnMetadata>(primary_key.name)},
+      {lineage_column, std::make_shared<DictionaryEncodedColumnMetadata>(lineage_column.name)}
    };
    auto schema = std::make_shared<rhydb::schema::TableSchema>(std::move(col_meta), primary_key);
    Tables tables;
@@ -760,7 +782,7 @@ TEST(AstToQueryJoin, onExpressionEqualityOfMismatchingColumnTypesThrows) {
    auto tables = makeTablesWithDefault();
    EXPECT_THAT(
       [&tables]() {
-         (void)parseAndConvertToQueryTree(
+         auto query_tree = parseAndConvertToQueryTree(
             "join(default.project({id}), default.map({num := 3}).project({num}), id = num)", tables
          );
       },
@@ -769,6 +791,16 @@ TEST(AstToQueryJoin, onExpressionEqualityOfMismatchingColumnTypesThrows) {
          "'id' and 'num' have mismatching types STRING and INT64"
       ))
    );
+}
+
+// A dictionary-encoded column and a plain string column both materialize as an arrow utf8 array,
+// so they are interchangeable as join keys - e.g. joining a transitiveClosure() result (always
+// plain STRING) against an indexed lineage column, which is necessarily dictionary-encoded.
+TEST(AstToQueryJoin, onExpressionEqualityOfStringAndDictionaryEncodedColumnsSucceeds) {
+   auto tables = makeTablesWithDictionaryEncodedColumn();
+   EXPECT_NO_THROW((void)parseAndConvertToQueryTree(
+      "join(default.project({id}), default.map({lin := lineage}).project({lin}), id = lin)", tables
+   ));
 }
 
 // --- resolveJoinColumn ---


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1192

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This adds the table function `transitiveClosure` which computes the transitive closure of a set of edges. These edges are given as an input table.

The motivation for this change is issue #1192, which requires outputting the number of sublineages for every lineage. This can now be formulated as:
```
pango_lineage.transitiveClosure('parent', 'lineage', includeVertices:=true)
  .join(default, to = lineage_column)
  .groupBy({count := count()}, {from})
  .orderBy({from})
```

This produces the desired result:

for each lineage, `pango_lineage.transitiveClosure('parent', 'lineage', includeVertices:=true)` will contain one row for each descendent of this lineage. e.g. for lineage system `A -> A.1 -> A.1.1`, the transitive closure will be:
```
A | A
A | A.1
A | A.1.1
A.1 | A.1
A.1 | A.1.1
A.1.1 | A.1.1
```

The resulting join and group-by will for each lineage contain the count of all its descendents in the data


## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
