### PR TITLE
build: remove default docker config files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,4 @@
 *
-!docker_default_preprocessing_config.yaml
-!docker_runtime_config.yaml
 !CMakeLists.txt
 !buildScripts/
 !Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,15 @@ RUN  \
 FROM ubuntu:26.04 AS server
 
 WORKDIR /app
-COPY docker_default_preprocessing_config.yaml ./default_preprocessing_config.yaml
-COPY docker_runtime_config.yaml ./default_runtime_config.yaml
+COPY <<EOF ./default_preprocessing_config.yaml
+inputDirectory: "/preprocessing/input/"
+outputDirectory: "/preprocessing/output/"
+EOF
+
+COPY <<EOF ./default_runtime_config.yaml
+dataDirectory: /data/
+EOF
+
 COPY --from=builder /src/rhydb ./
 
 # Deprecation compatibility: the binary was renamed silo -> rhydb. Keep a

--- a/docker_default_preprocessing_config.yaml
+++ b/docker_default_preprocessing_config.yaml
@@ -1,2 +1,0 @@
-inputDirectory: "/preprocessing/input/"
-outputDirectory: "/preprocessing/output/"

--- a/docker_runtime_config.yaml
+++ b/docker_runtime_config.yaml
@@ -1,1 +1,0 @@
-dataDirectory: /data/


### PR DESCRIPTION
clean more of the top-level directory. These 2 files were quite unnecessary to keep at the top-level. This instead moves the three lines directly into the `Dockerfile` itself