### PR TITLE
refactor(query_engine): extract scalarToArrowExpression into a shared exec_node helper

### DIFF
--- a/src/rhydb/query_engine/exec_node/scalar_to_arrow_expression.cpp
+++ b/src/rhydb/query_engine/exec_node/scalar_to_arrow_expression.cpp
@@ -1,0 +1,92 @@
+#include "rhydb/query_engine/exec_node/scalar_to_arrow_expression.h"
+
+#include <cstdint>
+
+#include <arrow/compute/api.h>
+#include <arrow/datum.h>
+#include <arrow/type.h>
+
+#include "rhydb/query_engine/exec_node/zstd_decompress_expression.h"
+#include "rhydb/query_engine/scalar_expressions/at.h"
+#include "rhydb/query_engine/scalar_expressions/field_ref.h"
+#include "rhydb/query_engine/scalar_expressions/iso_week.h"
+#include "rhydb/query_engine/scalar_expressions/literal.h"
+#include "rhydb/query_engine/scalar_expressions/zstd_decompress_scalar.h"
+
+namespace rhydb::query_engine::exec_node {
+
+using scalar_expressions::At;
+using scalar_expressions::BoolLiteral;
+using scalar_expressions::dynCast;
+using scalar_expressions::FieldRef;
+using scalar_expressions::FloatLiteral;
+using scalar_expressions::Int32Literal;
+using scalar_expressions::Int64Literal;
+using scalar_expressions::IsoWeek;
+using scalar_expressions::ScalarExpression;
+using scalar_expressions::StringLiteral;
+using scalar_expressions::ZstdDecompressScalar;
+
+// NOLINTNEXTLINE(misc-no-recursion)
+arrow::Result<arrow::compute::Expression> scalarToArrowExpression(const ScalarExpression& expression
+) {
+   if (const auto* literal = dynCast<Int32Literal>(&expression)) {
+      return arrow::compute::literal(arrow::Datum(literal->value));
+   }
+   if (const auto* literal = dynCast<Int64Literal>(&expression)) {
+      return arrow::compute::literal(arrow::Datum(literal->value));
+   }
+   if (const auto* literal = dynCast<FloatLiteral>(&expression)) {
+      return arrow::compute::literal(arrow::Datum(literal->value));
+   }
+   if (const auto* literal = dynCast<StringLiteral>(&expression)) {
+      return arrow::compute::literal(arrow::Datum(literal->value));
+   }
+   if (const auto* literal = dynCast<BoolLiteral>(&expression)) {
+      return arrow::compute::literal(arrow::Datum(literal->value));
+   }
+   if (const auto* field_ref = dynCast<FieldRef>(&expression)) {
+      return arrow::compute::field_ref(field_ref->column.name);
+   }
+   if (const auto* zstd = dynCast<ZstdDecompressScalar>(&expression)) {
+      ARROW_ASSIGN_OR_RAISE(auto input, scalarToArrowExpression(*zstd->input));
+      return ZstdDecompressExpression::make(input, zstd->dictionary_string);
+   }
+   if (const auto* at_function = dynCast<At>(&expression)) {
+      // `at` is 1-indexed; utf8_slice_codeunits takes a 0-indexed, half-open
+      // [start, stop) range of code units, so extract the single character at
+      // position-1.
+      const int64_t start = static_cast<int64_t>(at_function->position) - 1;
+      const auto stop = static_cast<int64_t>(at_function->position);
+      ARROW_ASSIGN_OR_RAISE(auto input, scalarToArrowExpression(*at_function->input));
+      return arrow::compute::call(
+         "utf8_slice_codeunits", {input}, arrow::compute::SliceOptions(start, stop)
+      );
+   }
+   if (const auto* iso_week = dynCast<IsoWeek>(&expression)) {
+      ARROW_ASSIGN_OR_RAISE(auto input, scalarToArrowExpression(*iso_week->input));
+      // Render the ISO 8601 week date `<ISO-year>-W<ISO-week>`, e.g. `2026-W12`
+      const auto year_string = arrow::compute::call(
+         "cast",
+         {arrow::compute::call("iso_year", {input})},
+         arrow::compute::CastOptions::Safe(arrow::utf8())
+      );
+      const auto week_string = arrow::compute::call(
+         "cast",
+         {arrow::compute::call("iso_week", {input})},
+         arrow::compute::CastOptions::Safe(arrow::utf8())
+      );
+      // Zero-pad the week to two digits so `2021-W02` sorts before `2021-W10`.
+      const auto week_padded =
+         arrow::compute::call("utf8_lpad", {week_string}, arrow::compute::PadOptions(2, "0"));
+      // Join `<year> + "-W" + <week>` -- third argument is separator
+      return arrow::compute::call(
+         "binary_join_element_wise", {year_string, week_padded, arrow::compute::literal("-W")}
+      );
+   }
+   return arrow::Status::NotImplemented(
+      "the scalar expression ", expression.toString(), " has no Arrow compute translation"
+   );
+}
+
+}  // namespace rhydb::query_engine::exec_node

--- a/src/rhydb/query_engine/exec_node/scalar_to_arrow_expression.h
+++ b/src/rhydb/query_engine/exec_node/scalar_to_arrow_expression.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <arrow/compute/expression.h>
+#include <arrow/result.h>
+
+#include "rhydb/query_engine/scalar_expressions/scalar_expression.h"
+
+namespace rhydb::query_engine::exec_node {
+
+/// Translates a scalar expression into an Arrow compute expression, e.g. for use in a projection or
+/// for direct evaluation over a materialized batch. Field references become named `field_ref`s
+/// (resolved when the expression is bound to a schema); function calls like `at`, `isoWeek` and
+/// zstd-decompress map to the corresponding Arrow compute calls. Returns `NotImplemented` for
+/// expressions with no Arrow translation.
+arrow::Result<arrow::compute::Expression> scalarToArrowExpression(
+   const scalar_expressions::ScalarExpression& expression
+);
+
+}  // namespace rhydb::query_engine::exec_node

--- a/src/rhydb/query_engine/operators/map_node.cpp
+++ b/src/rhydb/query_engine/operators/map_node.cpp
@@ -11,97 +11,26 @@
 #include <arrow/acero/options.h>
 #include <arrow/compute/api.h>
 #include <arrow/datum.h>
-#include <arrow/type.h>
 #include <nlohmann/json_fwd.hpp>
 
 #include "rhydb/common/size_constants.h"
+#include "rhydb/query_engine/exec_node/scalar_to_arrow_expression.h"
 #include "rhydb/query_engine/exec_node/throttled_batch_reslicer.h"
-#include "rhydb/query_engine/exec_node/zstd_decompress_expression.h"
 #include "rhydb/query_engine/scalar_expressions/at.h"
-#include "rhydb/query_engine/scalar_expressions/field_ref.h"
 #include "rhydb/query_engine/scalar_expressions/iso_week.h"
-#include "rhydb/query_engine/scalar_expressions/literal.h"
 #include "rhydb/query_engine/scalar_expressions/zstd_decompress_scalar.h"
 
 namespace rhydb::query_engine::operators {
 
 using scalar_expressions::At;
-using scalar_expressions::BoolLiteral;
 using scalar_expressions::dynCast;
-using scalar_expressions::FieldRef;
-using scalar_expressions::FloatLiteral;
-using scalar_expressions::Int32Literal;
-using scalar_expressions::Int64Literal;
 using scalar_expressions::IsoWeek;
 using scalar_expressions::ScalarExpression;
-using scalar_expressions::StringLiteral;
 using scalar_expressions::ZstdDecompressScalar;
 
-namespace {
+using exec_node::scalarToArrowExpression;
 
-/// Translates a scalar expression into an Arrow compute expression for use in a
-/// projection.
-// NOLINTNEXTLINE(misc-no-recursion)
-arrow::Result<arrow::compute::Expression> scalarToArrowExpression(const ScalarExpression& expression
-) {
-   if (const auto* literal = dynCast<Int32Literal>(&expression)) {
-      return arrow::compute::literal(arrow::Datum(literal->value));
-   }
-   if (const auto* literal = dynCast<Int64Literal>(&expression)) {
-      return arrow::compute::literal(arrow::Datum(literal->value));
-   }
-   if (const auto* literal = dynCast<FloatLiteral>(&expression)) {
-      return arrow::compute::literal(arrow::Datum(literal->value));
-   }
-   if (const auto* literal = dynCast<StringLiteral>(&expression)) {
-      return arrow::compute::literal(arrow::Datum(literal->value));
-   }
-   if (const auto* literal = dynCast<BoolLiteral>(&expression)) {
-      return arrow::compute::literal(arrow::Datum(literal->value));
-   }
-   if (const auto* field_ref = dynCast<FieldRef>(&expression)) {
-      return arrow::compute::field_ref(field_ref->column.name);
-   }
-   if (const auto* zstd = dynCast<ZstdDecompressScalar>(&expression)) {
-      ARROW_ASSIGN_OR_RAISE(auto input, scalarToArrowExpression(*zstd->input));
-      return exec_node::ZstdDecompressExpression::make(input, zstd->dictionary_string);
-   }
-   if (const auto* at_function = dynCast<At>(&expression)) {
-      // `at` is 1-indexed; utf8_slice_codeunits takes a 0-indexed, half-open
-      // [start, stop) range of code units, so extract the single character at
-      // position-1.
-      const int64_t start = static_cast<int64_t>(at_function->position) - 1;
-      const auto stop = static_cast<int64_t>(at_function->position);
-      ARROW_ASSIGN_OR_RAISE(auto input, scalarToArrowExpression(*at_function->input));
-      return arrow::compute::call(
-         "utf8_slice_codeunits", {input}, arrow::compute::SliceOptions(start, stop)
-      );
-   }
-   if (const auto* iso_week = dynCast<IsoWeek>(&expression)) {
-      ARROW_ASSIGN_OR_RAISE(auto input, scalarToArrowExpression(*iso_week->input));
-      // Render the ISO 8601 week date `<ISO-year>-W<ISO-week>`, e.g. `2026-W12`
-      const auto year_string = arrow::compute::call(
-         "cast",
-         {arrow::compute::call("iso_year", {input})},
-         arrow::compute::CastOptions::Safe(arrow::utf8())
-      );
-      const auto week_string = arrow::compute::call(
-         "cast",
-         {arrow::compute::call("iso_week", {input})},
-         arrow::compute::CastOptions::Safe(arrow::utf8())
-      );
-      // Zero-pad the week to two digits so `2021-W02` sorts before `2021-W10`.
-      const auto week_padded =
-         arrow::compute::call("utf8_lpad", {week_string}, arrow::compute::PadOptions(2, "0"));
-      // Join `<year> + "-W" + <week>` -- third argument is separator
-      return arrow::compute::call(
-         "binary_join_element_wise", {year_string, week_padded, arrow::compute::literal("-W")}
-      );
-   }
-   return arrow::Status::NotImplemented(
-      "the scalar expression ", expression.toString(), " is not supported in map() assignments"
-   );
-}
+namespace {
 
 /// Sums the dictionary sizes of every `ZstdDecompressScalar` anywhere in `expression`'s tree. A
 /// decompress may be nested inside another scalar expression (e.g. `At(ZstdDecompress(...))` after


### PR DESCRIPTION
another minor refactor before #1404. This moves the `scalarToArrowExpression` function to its own class, so that classes other than `MapNode` can execute scalar expressions