### PR TITLE
feat(rhydb): add function `insertInto` and `/admin/query` endpoint

### DIFF
--- a/app/src/admin_query_handler.cpp
+++ b/app/src/admin_query_handler.cpp
@@ -19,8 +19,12 @@
 
 namespace rhydb_app {
 
-AdminQueryHandler::AdminQueryHandler(std::shared_ptr<ActiveDatabase> database_handle)
-    : database_handle(std::move(database_handle)) {}
+AdminQueryHandler::AdminQueryHandler(
+   std::shared_ptr<ActiveDatabase> database_handle,
+   rhydb::config::QueryOptions query_options
+)
+    : query_options(query_options),
+      database_handle(std::move(database_handle)) {}
 
 void AdminQueryHandler::post(
    Poco::Net::HTTPServerRequest& request,
@@ -40,7 +44,7 @@ void AdminQueryHandler::post(
    SPDLOG_INFO("Request Id [{}] - received admin query: {}", request_id, query_string);
 
    try {
-      const nlohmann::json result = database->executeWrite(query_string);
+      const nlohmann::json result = database->executeWrite(query_string, query_options);
 
       SPDLOG_INFO(
          "Request Id [{}] - admin write statement applied: {}; new data version {}",

--- a/app/src/admin_query_handler.cpp
+++ b/app/src/admin_query_handler.cpp
@@ -14,7 +14,7 @@
 #include <nlohmann/json.hpp>
 
 #include <rhydb/append/append_exception.h>
-#include <rhydb/common/silo_directory.h>
+#include <rhydb/common/rhydb_directory.h>
 #include <rhydb/database.h>
 #include <rhydb/query_engine/illegal_query_exception.h>
 #include <rhydb/query_engine/saneql/parse_exception.h>

--- a/app/src/admin_query_handler.cpp
+++ b/app/src/admin_query_handler.cpp
@@ -1,16 +1,21 @@
 #include "admin_query_handler.h"
 
+#include <filesystem>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/Net/HTTPServerResponse.h>
 #include <Poco/StreamCopier.h>
+#include <fmt/format.h>
 #include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
 
 #include <rhydb/append/append_exception.h>
+#include <rhydb/common/silo_directory.h>
+#include <rhydb/database.h>
 #include <rhydb/query_engine/illegal_query_exception.h>
 #include <rhydb/query_engine/saneql/parse_exception.h>
 #include <evobench/evobench.hpp>
@@ -23,20 +28,53 @@ namespace rhydb_app {
 AdminQueryHandler::AdminQueryHandler(
    std::shared_ptr<ActiveDatabase> database_handle,
    rhydb::config::QueryOptions query_options,
+   std::filesystem::path data_directory,
    std::shared_ptr<std::mutex> write_mutex
 )
     : query_options(query_options),
+      data_directory(std::move(data_directory)),
       database_handle(std::move(database_handle)),
       write_mutex(std::move(write_mutex)) {}
+
+rhydb::Database AdminQueryHandler::loadDatabaseToWriteTo() const {
+   EVOBENCH_SCOPE("AdminQueryHandler", "loadDatabaseToWriteTo");
+
+   const auto data_source = rhydb::RhyDBDirectory{data_directory}.getMostRecentDataDirectory();
+   if (!data_source.has_value()) {
+      throw std::runtime_error(fmt::format(
+         "the data directory '{}' holds no loadable database state to apply the write to",
+         data_directory.string()
+      ));
+   }
+
+   const auto served_version = database_handle->getActiveDatabase()->getDataVersionTimestamp();
+   const auto version_to_write_to = data_source->data_version.getTimestamp();
+   if (version_to_write_to < served_version) {
+      throw std::runtime_error(fmt::format(
+         "the most recent state in the data directory '{}' has data version {}, which is older "
+         "than the data version {} that is being served. Please resolve this conflict manually",
+         data_directory.string(),
+         version_to_write_to.value,
+         served_version.value
+      ));
+   }
+   if (served_version < version_to_write_to) {
+      SPDLOG_WARN(
+         "Admin write applies to data version {} from the data directory, which is newer than the "
+         "data version {} currently being served",
+         version_to_write_to.value,
+         served_version.value
+      );
+   }
+
+   return rhydb::Database::loadDatabaseState(data_source.value());
+}
 
 void AdminQueryHandler::post(
    Poco::Net::HTTPServerRequest& request,
    Poco::Net::HTTPServerResponse& response
 ) {
    EVOBENCH_SCOPE("AdminQueryHandler", "post");
-
-   // Pin the database so it outlives the append, mirroring QueryHandler.
-   const auto database = database_handle->getActiveDatabase();
 
    const auto request_id = response.get("X-Request-Id");
 
@@ -47,19 +85,25 @@ void AdminQueryHandler::post(
    SPDLOG_INFO("Request Id [{}] - received admin query: {}", request_id, query_string);
 
    try {
-      // One write at a time: an in-place mutation is not safe to run next to another one.
+      // One write at a time
       const std::lock_guard<std::mutex> write_lock{*write_mutex};
 
-      const nlohmann::json result = database->executeWrite(query_string, query_options);
+      rhydb::Database staged_database = loadDatabaseToWriteTo();
+
+      const nlohmann::json result = staged_database.executeWrite(query_string, query_options);
+
+      staged_database.saveDatabaseState(data_directory);
+
+      const auto data_version = staged_database.getDataVersionTimestamp();
 
       SPDLOG_INFO(
          "Request Id [{}] - admin write statement applied: {}; new data version {}",
          request_id,
          result.dump(),
-         database->getDataVersionTimestamp().value
+         data_version.value
       );
 
-      response.set("data-version", database->getDataVersionTimestamp().value);
+      response.set("data-version", data_version.value);
       response.setContentType("application/json");
       std::ostream& output_stream = response.send();
       output_stream << result.dump();

--- a/app/src/admin_query_handler.cpp
+++ b/app/src/admin_query_handler.cpp
@@ -1,0 +1,65 @@
+#include "admin_query_handler.h"
+
+#include <string>
+#include <utility>
+
+#include <Poco/Net/HTTPServerRequest.h>
+#include <Poco/Net/HTTPServerResponse.h>
+#include <Poco/StreamCopier.h>
+#include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
+
+#include <rhydb/append/append_exception.h>
+#include <rhydb/query_engine/illegal_query_exception.h>
+#include <rhydb/query_engine/saneql/parse_exception.h>
+#include <evobench/evobench.hpp>
+
+#include "active_database.h"
+#include "bad_request.h"
+
+namespace rhydb_app {
+
+AdminQueryHandler::AdminQueryHandler(std::shared_ptr<ActiveDatabase> database_handle)
+    : database_handle(std::move(database_handle)) {}
+
+void AdminQueryHandler::post(
+   Poco::Net::HTTPServerRequest& request,
+   Poco::Net::HTTPServerResponse& response
+) {
+   EVOBENCH_SCOPE("AdminQueryHandler", "post");
+
+   // Pin the database so it outlives the append, mirroring QueryHandler.
+   const auto database = database_handle->getActiveDatabase();
+
+   const auto request_id = response.get("X-Request-Id");
+
+   std::string query_string;
+   std::istream& istream = request.stream();
+   Poco::StreamCopier::copyToString(istream, query_string);
+
+   SPDLOG_INFO("Request Id [{}] - received admin query: {}", request_id, query_string);
+
+   try {
+      const nlohmann::json result = database->executeWrite(query_string);
+
+      SPDLOG_INFO(
+         "Request Id [{}] - admin write statement applied: {}; new data version {}",
+         request_id,
+         result.dump(),
+         database->getDataVersionTimestamp().value
+      );
+
+      response.set("data-version", database->getDataVersionTimestamp().value);
+      response.setContentType("application/json");
+      std::ostream& output_stream = response.send();
+      output_stream << result.dump();
+   } catch (const rhydb::query_engine::saneql::ParseException& ex) {
+      throw BadRequest(ex.what());
+   } catch (const rhydb::query_engine::IllegalQueryException& ex) {
+      throw BadRequest(ex.what());
+   } catch (const rhydb::append::AppendException& ex) {
+      throw BadRequest(ex.what());
+   }
+}
+
+}  // namespace rhydb_app

--- a/app/src/admin_query_handler.cpp
+++ b/app/src/admin_query_handler.cpp
@@ -90,7 +90,8 @@ void AdminQueryHandler::post(
 
       rhydb::Database staged_database = loadDatabaseToWriteTo();
 
-      const nlohmann::json result = staged_database.executeWrite(query_string, query_options);
+      const nlohmann::json result =
+         staged_database.executeWrite(query_string, query_options, request_id);
 
       staged_database.saveDatabaseState(data_directory);
 

--- a/app/src/admin_query_handler.cpp
+++ b/app/src/admin_query_handler.cpp
@@ -1,5 +1,6 @@
 #include "admin_query_handler.h"
 
+#include <mutex>
 #include <string>
 #include <utility>
 
@@ -21,10 +22,12 @@ namespace rhydb_app {
 
 AdminQueryHandler::AdminQueryHandler(
    std::shared_ptr<ActiveDatabase> database_handle,
-   rhydb::config::QueryOptions query_options
+   rhydb::config::QueryOptions query_options,
+   std::shared_ptr<std::mutex> write_mutex
 )
     : query_options(query_options),
-      database_handle(std::move(database_handle)) {}
+      database_handle(std::move(database_handle)),
+      write_mutex(std::move(write_mutex)) {}
 
 void AdminQueryHandler::post(
    Poco::Net::HTTPServerRequest& request,
@@ -44,6 +47,9 @@ void AdminQueryHandler::post(
    SPDLOG_INFO("Request Id [{}] - received admin query: {}", request_id, query_string);
 
    try {
+      // One write at a time: an in-place mutation is not safe to run next to another one.
+      const std::lock_guard<std::mutex> write_lock{*write_mutex};
+
       const nlohmann::json result = database->executeWrite(query_string, query_options);
 
       SPDLOG_INFO(

--- a/app/src/admin_query_handler.h
+++ b/app/src/admin_query_handler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <memory>
 #include <mutex>
 
@@ -7,19 +8,18 @@
 #include <Poco/Net/HTTPServerResponse.h>
 
 #include <rhydb/config/runtime_config.h>
+#include <rhydb/database.h>
 
 #include "active_database.h"
 #include "rest_resource.h"
 
 namespace rhydb_app {
 
-/// Handles `POST /admin/query`: a write-enabled SaneQL endpoint for append queries of the form
-/// `<query>.insertInto(<targetTable>)`. Unlike `POST /query`, which only reads, this mutates the
-/// active database in place. It is intentionally kept on a separate `/admin` path because in-place
-/// mutation is not safe to run concurrently with other queries against the same database. It is
-/// only routed to when `api.allowAdminEndpoint` is enabled; otherwise the path 404s.
+/// Handles write-enabled endpoint `POST /admin/query`.
+/// Only routed to when `api.allowAdminEndpoint` is enabled.
 class AdminQueryHandler : public RestResource {
    rhydb::config::QueryOptions query_options;
+   std::filesystem::path data_directory;
    std::shared_ptr<ActiveDatabase> database_handle;
    std::shared_ptr<std::mutex> write_mutex;
 
@@ -27,11 +27,15 @@ class AdminQueryHandler : public RestResource {
    AdminQueryHandler(
       std::shared_ptr<ActiveDatabase> database_handle,
       rhydb::config::QueryOptions query_options,
+      std::filesystem::path data_directory,
       std::shared_ptr<std::mutex> write_mutex
    );
 
    void post(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response)
       override;
+
+  private:
+   [[nodiscard]] rhydb::Database loadDatabaseToWriteTo() const;
 };
 
 }  // namespace rhydb_app

--- a/app/src/admin_query_handler.h
+++ b/app/src/admin_query_handler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/Net/HTTPServerResponse.h>
@@ -18,14 +19,15 @@ namespace rhydb_app {
 /// mutation is not safe to run concurrently with other queries against the same database. It is
 /// only routed to when `api.allowAdminEndpoint` is enabled; otherwise the path 404s.
 class AdminQueryHandler : public RestResource {
-  private:
    rhydb::config::QueryOptions query_options;
    std::shared_ptr<ActiveDatabase> database_handle;
+   std::shared_ptr<std::mutex> write_mutex;
 
   public:
    AdminQueryHandler(
       std::shared_ptr<ActiveDatabase> database_handle,
-      rhydb::config::QueryOptions query_options
+      rhydb::config::QueryOptions query_options,
+      std::shared_ptr<std::mutex> write_mutex
    );
 
    void post(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response)

--- a/app/src/admin_query_handler.h
+++ b/app/src/admin_query_handler.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <memory>
+
+#include <Poco/Net/HTTPServerRequest.h>
+#include <Poco/Net/HTTPServerResponse.h>
+
+#include "active_database.h"
+#include "rest_resource.h"
+
+namespace rhydb_app {
+
+/// Handles `POST /admin/query`: a write-enabled SaneQL endpoint for append queries of the form
+/// `<query>.insertInto(<targetTable>)`. Unlike `POST /query`, which only reads, this mutates the
+/// active database in place. It is intentionally kept on a separate `/admin` path because in-place
+/// mutation is not safe to run concurrently with other queries against the same database.
+class AdminQueryHandler : public RestResource {
+  private:
+   std::shared_ptr<ActiveDatabase> database_handle;
+
+  public:
+   explicit AdminQueryHandler(std::shared_ptr<ActiveDatabase> database_handle);
+
+   void post(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response)
+      override;
+};
+
+}  // namespace rhydb_app

--- a/app/src/admin_query_handler.h
+++ b/app/src/admin_query_handler.h
@@ -5,6 +5,8 @@
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/Net/HTTPServerResponse.h>
 
+#include <rhydb/config/runtime_config.h>
+
 #include "active_database.h"
 #include "rest_resource.h"
 
@@ -13,13 +15,18 @@ namespace rhydb_app {
 /// Handles `POST /admin/query`: a write-enabled SaneQL endpoint for append queries of the form
 /// `<query>.insertInto(<targetTable>)`. Unlike `POST /query`, which only reads, this mutates the
 /// active database in place. It is intentionally kept on a separate `/admin` path because in-place
-/// mutation is not safe to run concurrently with other queries against the same database.
+/// mutation is not safe to run concurrently with other queries against the same database. It is
+/// only routed to when `api.allowAdminEndpoint` is enabled; otherwise the path 404s.
 class AdminQueryHandler : public RestResource {
   private:
+   rhydb::config::QueryOptions query_options;
    std::shared_ptr<ActiveDatabase> database_handle;
 
   public:
-   explicit AdminQueryHandler(std::shared_ptr<ActiveDatabase> database_handle);
+   AdminQueryHandler(
+      std::shared_ptr<ActiveDatabase> database_handle,
+      rhydb::config::QueryOptions query_options
+   );
 
    void post(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response)
       override;

--- a/app/src/admin_query_handler.test.cpp
+++ b/app/src/admin_query_handler.test.cpp
@@ -59,12 +59,21 @@ std::shared_ptr<rhydb_app::ActiveDatabase> makeActiveDatabaseWithSourceData() {
    return handle;
 }
 
+// The runtime config the API is served with in these tests: the write-enabled admin endpoint is
+// opt-in, so it has to be switched on explicitly.
+rhydb::config::RuntimeConfig configWithAdminEndpoint(bool allow_admin_endpoint) {
+   auto runtime_config = rhydb::config::RuntimeConfig::withDefaults();
+   runtime_config.api_options.allow_admin_endpoint = allow_admin_endpoint;
+   return runtime_config;
+}
+
 // Routes `POST /admin/query` with the given body through the full handler factory (so request-id
 // assignment and exception-to-status mapping are exercised) and returns the populated response.
 void postAdminQuery(
    const std::shared_ptr<rhydb_app::ActiveDatabase>& handle,
    const std::string& query,
-   rhydb_app::test::MockResponse& response
+   rhydb_app::test::MockResponse& response,
+   bool allow_admin_endpoint = true
 ) {
    rhydb_app::test::MockRequest request(response);
    request.setMethod("POST");
@@ -72,7 +81,7 @@ void postAdminQuery(
    request.in_stream << query;
 
    rhydb_app::RhyDBRequestHandlerFactory factory{
-      rhydb::config::RuntimeConfig::withDefaults(), handle
+      configWithAdminEndpoint(allow_admin_endpoint), handle
    };
    std::unique_ptr<Poco::Net::HTTPRequestHandler> handler{factory.createRequestHandler(request)};
    handler->handleRequest(request, response);
@@ -125,6 +134,25 @@ TEST(AdminQueryHandler, rejectsUnknownTargetTableWithBadRequest) {
    );
 }
 
+// The admin endpoint is opt-in: with `api.allowAdminEndpoint` left at its default the path is not
+// routed at all, so an instance that does not enable it stays read-only.
+TEST(AdminQueryHandler, isNotServedWhenNotEnabled) {
+   auto handle = makeActiveDatabaseWithSourceData();
+
+   rhydb_app::test::MockResponse response;
+   postAdminQuery(
+      handle,
+      "source.filter(country='CH').insertInto(archive)",
+      response,
+      /*allow_admin_endpoint=*/false
+   );
+
+   EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_NOT_FOUND);
+   EXPECT_EQ(
+      handle->getActiveDatabase()->tables.at(TableName{"archive"})->row_layout.numRows(), 0U
+   );
+}
+
 // The read-only `/query` endpoint must reject a write (insert) statement (it parses to a
 // WriteCommand, not a QueryNode), respond 400, and leave the target table untouched.
 TEST(QueryHandler, rejectsInsertQueryOnReadOnlyEndpointWithBadRequest) {
@@ -136,9 +164,7 @@ TEST(QueryHandler, rejectsInsertQueryOnReadOnlyEndpointWithBadRequest) {
    request.setURI("/query");
    request.in_stream << "source.filter(country='CH').insertInto(archive)";
 
-   rhydb_app::RhyDBRequestHandlerFactory factory{
-      rhydb::config::RuntimeConfig::withDefaults(), handle
-   };
+   rhydb_app::RhyDBRequestHandlerFactory factory{configWithAdminEndpoint(true), handle};
    std::unique_ptr<Poco::Net::HTTPRequestHandler> handler{factory.createRequestHandler(request)};
    handler->handleRequest(request, response);
 

--- a/app/src/admin_query_handler.test.cpp
+++ b/app/src/admin_query_handler.test.cpp
@@ -3,6 +3,8 @@
 #include <map>
 #include <memory>
 #include <sstream>
+#include <thread>
+#include <vector>
 
 #include <Poco/Net/HTTPResponse.h>
 #include <gmock/gmock.h>
@@ -150,6 +152,48 @@ TEST(AdminQueryHandler, isNotServedWhenNotEnabled) {
    EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_NOT_FOUND);
    EXPECT_EQ(
       handle->getActiveDatabase()->tables.at(TableName{"archive"})->row_layout.numRows(), 0U
+   );
+}
+
+// Two admin requests must never mutate the database at the same time. All requests go through one
+// factory here (as they do in the server), so they share the write mutex; without it the concurrent
+// inserts race on the target table's columns.
+TEST(AdminQueryHandler, serializesConcurrentWrites) {
+   auto handle = makeActiveDatabaseWithSourceData();
+
+   rhydb_app::RhyDBRequestHandlerFactory factory{configWithAdminEndpoint(true), handle};
+
+   constexpr size_t NUMBER_OF_THREADS = 4;
+   constexpr size_t REQUESTS_PER_THREAD = 3;
+
+   std::vector<std::thread> writers;
+   writers.reserve(NUMBER_OF_THREADS);
+   for (size_t thread_index = 0; thread_index < NUMBER_OF_THREADS; ++thread_index) {
+      writers.emplace_back([&factory]() {
+         for (size_t request_index = 0; request_index < REQUESTS_PER_THREAD; ++request_index) {
+            rhydb_app::test::MockResponse response;
+            rhydb_app::test::MockRequest request(response);
+            request.setMethod("POST");
+            request.setURI("/admin/query");
+            request.in_stream << "source.filter(country='CH').insertInto(archive)";
+
+            std::unique_ptr<Poco::Net::HTTPRequestHandler> handler{
+               factory.createRequestHandler(request)
+            };
+            handler->handleRequest(request, response);
+
+            EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_OK);
+         }
+      });
+   }
+   for (auto& writer : writers) {
+      writer.join();
+   }
+
+   // Every request inserted the two matching rows, none of them lost to a race.
+   EXPECT_EQ(
+      handle->getActiveDatabase()->tables.at(TableName{"archive"})->row_layout.numRows(),
+      NUMBER_OF_THREADS * REQUESTS_PER_THREAD * 2
    );
 }
 

--- a/app/src/admin_query_handler.test.cpp
+++ b/app/src/admin_query_handler.test.cpp
@@ -14,7 +14,7 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
-#include <rhydb/common/silo_directory.h>
+#include <rhydb/common/rhydb_directory.h>
 #include <rhydb/config/runtime_config.h>
 #include <rhydb/database.h>
 #include <rhydb/schema/database_schema.h>

--- a/app/src/admin_query_handler.test.cpp
+++ b/app/src/admin_query_handler.test.cpp
@@ -1,0 +1,151 @@
+#include "admin_query_handler.h"
+
+#include <map>
+#include <memory>
+#include <sstream>
+
+#include <Poco/Net/HTTPResponse.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <rhydb/config/runtime_config.h>
+#include <rhydb/database.h>
+#include <rhydb/schema/database_schema.h>
+#include <rhydb/storage/column/string_column.h>
+
+#include "active_database.h"
+#include "manual_poco_mocks.test.h"
+#include "request_handler_factory.h"
+
+namespace {
+
+using rhydb::schema::ColumnIdentifier;
+using rhydb::schema::ColumnType;
+using rhydb::schema::TableName;
+using rhydb::schema::TableSchema;
+using rhydb::storage::column::ColumnMetadata;
+using rhydb::storage::column::StringColumnMetadata;
+
+// A metadata-only schema (string primary key + a string and an int32 column) shared by the source
+// and target tables of the test fixture.
+std::shared_ptr<TableSchema> makeValueSchema() {
+   const ColumnIdentifier key{.name = "key", .type = ColumnType::STRING};
+   const ColumnIdentifier country{.name = "country", .type = ColumnType::STRING};
+   const ColumnIdentifier age{.name = "age", .type = ColumnType::INT32};
+   std::map<ColumnIdentifier, std::shared_ptr<ColumnMetadata>> column_metadata{
+      {key, std::make_shared<StringColumnMetadata>(key.name)},
+      {country, std::make_shared<StringColumnMetadata>(country.name)},
+      {age, std::make_shared<ColumnMetadata>(age.name)},
+   };
+   return std::make_shared<TableSchema>(std::move(column_metadata), key);
+}
+
+// Active database holding a `source` table with three rows (two country='CH', one 'US') and an
+// empty `archive` table with the same schema.
+std::shared_ptr<rhydb_app::ActiveDatabase> makeActiveDatabaseWithSourceData() {
+   rhydb::Database database;
+   database.createTable(TableName{"source"}, makeValueSchema());
+   database.createTable(TableName{"archive"}, makeValueSchema());
+
+   std::stringstream source_data;
+   source_data << R"({"key":"a","country":"CH","age":1})" << "\n"
+               << R"({"key":"b","country":"US","age":2})" << "\n"
+               << R"({"key":"c","country":"CH","age":3})" << "\n";
+   database.appendData(TableName{"source"}, source_data);
+
+   auto handle = std::make_shared<rhydb_app::ActiveDatabase>();
+   handle->setActiveDatabase(std::move(database));
+   return handle;
+}
+
+// Routes `POST /admin/query` with the given body through the full handler factory (so request-id
+// assignment and exception-to-status mapping are exercised) and returns the populated response.
+void postAdminQuery(
+   const std::shared_ptr<rhydb_app::ActiveDatabase>& handle,
+   const std::string& query,
+   rhydb_app::test::MockResponse& response
+) {
+   rhydb_app::test::MockRequest request(response);
+   request.setMethod("POST");
+   request.setURI("/admin/query");
+   request.in_stream << query;
+
+   rhydb_app::RhyDBRequestHandlerFactory factory{
+      rhydb::config::RuntimeConfig::withDefaults(), handle
+   };
+   std::unique_ptr<Poco::Net::HTTPRequestHandler> handler{factory.createRequestHandler(request)};
+   handler->handleRequest(request, response);
+}
+
+}  // namespace
+
+TEST(AdminQueryHandler, insertsQueryResultAndReportsRowCount) {
+   auto handle = makeActiveDatabaseWithSourceData();
+
+   rhydb_app::test::MockResponse response;
+   postAdminQuery(handle, "source.filter(country='CH').insertInto(archive)", response);
+
+   EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_OK);
+
+   const auto body = nlohmann::json::parse(response.out_stream.str());
+   EXPECT_EQ(body.at("insertedRows").get<size_t>(), 2);
+
+   // The rows really landed in the target table.
+   EXPECT_EQ(
+      handle->getActiveDatabase()->tables.at(TableName{"archive"})->row_layout.numRows(), 2U
+   );
+   // The source table is untouched.
+   EXPECT_EQ(handle->getActiveDatabase()->tables.at(TableName{"source"})->row_layout.numRows(), 3U);
+}
+
+TEST(AdminQueryHandler, rejectsPlainReadQueryWithBadRequest) {
+   auto handle = makeActiveDatabaseWithSourceData();
+
+   rhydb_app::test::MockResponse response;
+   postAdminQuery(handle, "source.filter(country='CH')", response);
+
+   EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+   EXPECT_THAT(response.out_stream.str(), testing::HasSubstr("expected a write statement"));
+   // Nothing was inserted.
+   EXPECT_EQ(
+      handle->getActiveDatabase()->tables.at(TableName{"archive"})->row_layout.numRows(), 0U
+   );
+}
+
+TEST(AdminQueryHandler, rejectsUnknownTargetTableWithBadRequest) {
+   auto handle = makeActiveDatabaseWithSourceData();
+
+   rhydb_app::test::MockResponse response;
+   postAdminQuery(handle, "source.insertInto(does_not_exist)", response);
+
+   EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+   EXPECT_THAT(
+      response.out_stream.str(), testing::HasSubstr("target table 'does_not_exist' not found")
+   );
+}
+
+// The read-only `/query` endpoint must reject a write (insert) statement (it parses to a
+// WriteCommand, not a QueryNode), respond 400, and leave the target table untouched.
+TEST(QueryHandler, rejectsInsertQueryOnReadOnlyEndpointWithBadRequest) {
+   auto handle = makeActiveDatabaseWithSourceData();
+
+   rhydb_app::test::MockResponse response;
+   rhydb_app::test::MockRequest request(response);
+   request.setMethod("POST");
+   request.setURI("/query");
+   request.in_stream << "source.filter(country='CH').insertInto(archive)";
+
+   rhydb_app::RhyDBRequestHandlerFactory factory{
+      rhydb::config::RuntimeConfig::withDefaults(), handle
+   };
+   std::unique_ptr<Poco::Net::HTTPRequestHandler> handler{factory.createRequestHandler(request)};
+   handler->handleRequest(request, response);
+
+   EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+   EXPECT_THAT(response.out_stream.str(), testing::HasSubstr("POST /admin/query"));
+   // The guard fires before planning, so nothing is written.
+   EXPECT_EQ(
+      handle->getActiveDatabase()->tables.at(TableName{"archive"})->row_layout.numRows(), 0U
+   );
+}

--- a/app/src/admin_query_handler.test.cpp
+++ b/app/src/admin_query_handler.test.cpp
@@ -1,5 +1,7 @@
 #include "admin_query_handler.h"
 
+#include <atomic>
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <sstream>
@@ -7,10 +9,12 @@
 #include <vector>
 
 #include <Poco/Net/HTTPResponse.h>
+#include <fmt/format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
+#include <rhydb/common/silo_directory.h>
 #include <rhydb/config/runtime_config.h>
 #include <rhydb/database.h>
 #include <rhydb/schema/database_schema.h>
@@ -43,9 +47,47 @@ std::shared_ptr<TableSchema> makeValueSchema() {
    return std::make_shared<TableSchema>(std::move(column_metadata), key);
 }
 
+// A data directory of its own for each test: the admin endpoint loads the state it writes to from
+// there and saves the result back, so the tests need a real, writable directory.
+class TemporaryDataDirectory {
+   std::filesystem::path directory;
+
+  public:
+   TemporaryDataDirectory() {
+      static std::atomic<size_t> next_id{0};
+      directory = std::filesystem::temp_directory_path() /
+                  fmt::format("rhydb_admin_query_test_{}", next_id++);
+      std::filesystem::remove_all(directory);
+      std::filesystem::create_directories(directory);
+   }
+
+   TemporaryDataDirectory(const TemporaryDataDirectory&) = delete;
+   TemporaryDataDirectory(TemporaryDataDirectory&&) = delete;
+   TemporaryDataDirectory& operator=(const TemporaryDataDirectory&) = delete;
+   TemporaryDataDirectory& operator=(TemporaryDataDirectory&&) = delete;
+
+   ~TemporaryDataDirectory() { std::filesystem::remove_all(directory); }
+
+   [[nodiscard]] const std::filesystem::path& path() const { return directory; }
+
+   /// The data versions saved in the directory, oldest first. One entry per saved state, so this
+   /// also tells whether a request wrote a new state at all.
+   [[nodiscard]] std::vector<std::string> savedDataVersions() const {
+      std::vector<std::string> versions;
+      for (const auto& entry : std::filesystem::directory_iterator{directory}) {
+         versions.push_back(entry.path().filename().string());
+      }
+      std::ranges::sort(versions);
+      return versions;
+   }
+};
+
 // Active database holding a `source` table with three rows (two country='CH', one 'US') and an
-// empty `archive` table with the same schema.
-std::shared_ptr<rhydb_app::ActiveDatabase> makeActiveDatabaseWithSourceData() {
+// empty `archive` table with the same schema. It is saved to `data_directory` as well, because that
+// is the state the admin endpoint applies its write to.
+std::shared_ptr<rhydb_app::ActiveDatabase> makeActiveDatabaseWithSourceData(
+   const std::filesystem::path& data_directory
+) {
    rhydb::Database database;
    database.createTable(TableName{"source"}, makeValueSchema());
    database.createTable(TableName{"archive"}, makeValueSchema());
@@ -56,6 +98,8 @@ std::shared_ptr<rhydb_app::ActiveDatabase> makeActiveDatabaseWithSourceData() {
                << R"({"key":"c","country":"CH","age":3})" << "\n";
    database.appendData(TableName{"source"}, source_data);
 
+   database.saveDatabaseState(data_directory);
+
    auto handle = std::make_shared<rhydb_app::ActiveDatabase>();
    handle->setActiveDatabase(std::move(database));
    return handle;
@@ -63,8 +107,12 @@ std::shared_ptr<rhydb_app::ActiveDatabase> makeActiveDatabaseWithSourceData() {
 
 // The runtime config the API is served with in these tests: the write-enabled admin endpoint is
 // opt-in, so it has to be switched on explicitly.
-rhydb::config::RuntimeConfig configWithAdminEndpoint(bool allow_admin_endpoint) {
+rhydb::config::RuntimeConfig configWithAdminEndpoint(
+   const std::filesystem::path& data_directory,
+   bool allow_admin_endpoint
+) {
    auto runtime_config = rhydb::config::RuntimeConfig::withDefaults();
+   runtime_config.data_directory = data_directory;
    runtime_config.api_options.allow_admin_endpoint = allow_admin_endpoint;
    return runtime_config;
 }
@@ -73,6 +121,7 @@ rhydb::config::RuntimeConfig configWithAdminEndpoint(bool allow_admin_endpoint) 
 // assignment and exception-to-status mapping are exercised) and returns the populated response.
 void postAdminQuery(
    const std::shared_ptr<rhydb_app::ActiveDatabase>& handle,
+   const std::filesystem::path& data_directory,
    const std::string& query,
    rhydb_app::test::MockResponse& response,
    bool allow_admin_endpoint = true
@@ -83,46 +132,164 @@ void postAdminQuery(
    request.in_stream << query;
 
    rhydb_app::RhyDBRequestHandlerFactory factory{
-      configWithAdminEndpoint(allow_admin_endpoint), handle
+      configWithAdminEndpoint(data_directory, allow_admin_endpoint), handle
    };
    std::unique_ptr<Poco::Net::HTTPRequestHandler> handler{factory.createRequestHandler(request)};
    handler->handleRequest(request, response);
 }
 
+// The state the data directory would be reloaded from on a restart.
+rhydb::Database reloadFromDataDirectory(const std::filesystem::path& data_directory) {
+   return rhydb::Database::loadDatabaseState(
+      rhydb::RhyDBDirectory{data_directory}.getMostRecentDataDirectory().value()
+   );
+}
+
 }  // namespace
 
 TEST(AdminQueryHandler, insertsQueryResultAndReportsRowCount) {
-   auto handle = makeActiveDatabaseWithSourceData();
+   const TemporaryDataDirectory data_directory;
+   auto handle = makeActiveDatabaseWithSourceData(data_directory.path());
 
    rhydb_app::test::MockResponse response;
-   postAdminQuery(handle, "source.filter(country='CH').insertInto(archive)", response);
+   postAdminQuery(
+      handle, data_directory.path(), "source.filter(country='CH').insertInto(archive)", response
+   );
 
    EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_OK);
 
    const auto body = nlohmann::json::parse(response.out_stream.str());
    EXPECT_EQ(body.at("insertedRows").get<size_t>(), 2);
 
-   // A successful write reports the data version of the database as it is after the write, so that
-   // a client can tell that the data it queries next is the mutated data.
+   // A successful write reports the data version it produced, so that a client can tell which
+   // version it has to wait for to query the data it just wrote.
    ASSERT_TRUE(response.has("data-version"));
    EXPECT_THAT(response.get("data-version"), testing::MatchesRegex("[0-9]{10}"));
+
+   // The rows really landed in the target table, and the source table is untouched.
+   auto written = reloadFromDataDirectory(data_directory.path());
+   EXPECT_EQ(written.getDataVersionTimestamp().value, response.get("data-version"));
+   EXPECT_EQ(written.tables.at(TableName{"archive"})->row_layout.numRows(), 2U);
+   EXPECT_EQ(written.tables.at(TableName{"source"})->row_layout.numRows(), 3U);
+}
+
+// The write is not only applied in memory: it is saved to the data directory as a new data version
+// before it is published, so it is still there after a restart.
+TEST(AdminQueryHandler, persistsTheWriteToTheDataDirectory) {
+   const TemporaryDataDirectory data_directory;
+   auto handle = makeActiveDatabaseWithSourceData(data_directory.path());
+   const auto versions_before = data_directory.savedDataVersions();
+   ASSERT_EQ(versions_before.size(), 1U);
+
+   rhydb_app::test::MockResponse response;
+   postAdminQuery(
+      handle, data_directory.path(), "source.filter(country='CH').insertInto(archive)", response
+   );
+   ASSERT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_OK);
+
+   // A second state was saved, under the data version the response reports, and the state that was
+   // written to is left as it was.
+   const auto versions_after = data_directory.savedDataVersions();
+   ASSERT_EQ(versions_after.size(), 2U);
+   EXPECT_EQ(versions_after.at(0), versions_before.at(0));
+   EXPECT_EQ(versions_after.at(1), response.get("data-version"));
+
+   // Reloading the directory - what a restarted server does - gets the inserted rows back.
+   auto reloaded = reloadFromDataDirectory(data_directory.path());
+   EXPECT_EQ(reloaded.getDataVersionTimestamp().value, response.get("data-version"));
+   EXPECT_EQ(reloaded.tables.at(TableName{"archive"})->row_layout.numRows(), 2U);
+   EXPECT_EQ(reloaded.tables.at(TableName{"source"})->row_layout.numRows(), 3U);
+}
+
+// Publishing the new state is left to the directory watcher, the only writer of the active
+// database. The handler must not swap it in itself: the watcher decides whether to load before it
+// loads, so a load that started before such a swap would publish its stale database over the state
+// the write just saved. The served database is therefore untouched when the response is sent (no
+// watcher runs in this test) and is only replaced on the watcher's next poll.
+TEST(AdminQueryHandler, leavesPublishingTheNewStateToTheDirectoryWatcher) {
+   const TemporaryDataDirectory data_directory;
+   auto handle = makeActiveDatabaseWithSourceData(data_directory.path());
+   const auto database_before = handle->getActiveDatabase();
+   const auto data_version_before = database_before->getDataVersionTimestamp();
+
+   rhydb_app::test::MockResponse response;
+   postAdminQuery(
+      handle, data_directory.path(), "source.filter(country='CH').insertInto(archive)", response
+   );
+   ASSERT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_OK);
+
+   EXPECT_EQ(handle->getActiveDatabase(), database_before);
    EXPECT_EQ(
-      response.get("data-version"), handle->getActiveDatabase()->getDataVersionTimestamp().value
+      handle->getActiveDatabase()->getDataVersionTimestamp().value, data_version_before.value
+   );
+   EXPECT_EQ(database_before->tables.at(TableName{"archive"})->row_layout.numRows(), 0U);
+   // The state the watcher will pick up is a newer one, and it holds the inserted rows.
+   EXPECT_GT(response.get("data-version"), data_version_before.value);
+   EXPECT_EQ(
+      reloadFromDataDirectory(data_directory.path())
+         .tables.at(TableName{"archive"})
+         ->row_layout.numRows(),
+      2U
+   );
+}
+
+// A statement that only fails once the append is under way must leave no trace: it ran against the
+// loaded database, which is then dropped instead of being saved.
+TEST(AdminQueryHandler, discardsAFailedWriteWithoutSavingIt) {
+   const TemporaryDataDirectory data_directory;
+   auto handle = makeActiveDatabaseWithSourceData(data_directory.path());
+   const auto database_before = handle->getActiveDatabase();
+   const auto data_version_before = database_before->getDataVersionTimestamp();
+   const auto versions_before = data_directory.savedDataVersions();
+
+   rhydb_app::test::MockResponse response;
+   // The projection drops `age`, which the target table requires, so the append rejects the batch
+   // after the statement has been parsed and planned.
+   postAdminQuery(
+      handle, data_directory.path(), "source.project({key}).insertInto(archive)", response
    );
 
-   // The rows really landed in the target table.
-   EXPECT_EQ(
-      handle->getActiveDatabase()->tables.at(TableName{"archive"})->row_layout.numRows(), 2U
+   EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+   EXPECT_THAT(
+      response.out_stream.str(),
+      testing::HasSubstr("the column 'age' is not contained in the object")
    );
-   // The source table is untouched.
-   EXPECT_EQ(handle->getActiveDatabase()->tables.at(TableName{"source"})->row_layout.numRows(), 3U);
+   // Still the very same database, at the very same data version, and nothing new on disk.
+   EXPECT_EQ(handle->getActiveDatabase(), database_before);
+   EXPECT_EQ(
+      handle->getActiveDatabase()->getDataVersionTimestamp().value, data_version_before.value
+   );
+   EXPECT_EQ(
+      handle->getActiveDatabase()->tables.at(TableName{"archive"})->row_layout.numRows(), 0U
+   );
+   EXPECT_EQ(data_directory.savedDataVersions(), versions_before);
+}
+
+// The endpoint writes through the data directory, so it cannot serve a database that is not in
+// there. Rather than writing to a state that is not the one being served, it reports the problem.
+TEST(AdminQueryHandler, failsWhenTheDataDirectoryHoldsNoState) {
+   const TemporaryDataDirectory data_directory;
+   const TemporaryDataDirectory empty_directory;
+   auto handle = makeActiveDatabaseWithSourceData(data_directory.path());
+
+   rhydb_app::test::MockResponse response;
+   postAdminQuery(
+      handle, empty_directory.path(), "insertInto(source.filter(country='CH'), archive)", response
+   );
+
+   EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR);
+   EXPECT_THAT(response.out_stream.str(), testing::HasSubstr("holds no loadable database state"));
+   EXPECT_EQ(
+      handle->getActiveDatabase()->tables.at(TableName{"archive"})->row_layout.numRows(), 0U
+   );
 }
 
 TEST(AdminQueryHandler, rejectsPlainReadQueryWithBadRequest) {
-   auto handle = makeActiveDatabaseWithSourceData();
+   const TemporaryDataDirectory data_directory;
+   auto handle = makeActiveDatabaseWithSourceData(data_directory.path());
 
    rhydb_app::test::MockResponse response;
-   postAdminQuery(handle, "source.filter(country='CH')", response);
+   postAdminQuery(handle, data_directory.path(), "source.filter(country='CH')", response);
 
    EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
    EXPECT_THAT(response.out_stream.str(), testing::HasSubstr("expected a write statement"));
@@ -133,10 +300,11 @@ TEST(AdminQueryHandler, rejectsPlainReadQueryWithBadRequest) {
 }
 
 TEST(AdminQueryHandler, rejectsUnknownTargetTableWithBadRequest) {
-   auto handle = makeActiveDatabaseWithSourceData();
+   const TemporaryDataDirectory data_directory;
+   auto handle = makeActiveDatabaseWithSourceData(data_directory.path());
 
    rhydb_app::test::MockResponse response;
-   postAdminQuery(handle, "source.insertInto(does_not_exist)", response);
+   postAdminQuery(handle, data_directory.path(), "source.insertInto(does_not_exist)", response);
 
    EXPECT_EQ(response.getStatus(), Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
    EXPECT_THAT(
@@ -147,11 +315,13 @@ TEST(AdminQueryHandler, rejectsUnknownTargetTableWithBadRequest) {
 // The admin endpoint is opt-in: with `api.allowAdminEndpoint` left at its default the path is not
 // routed at all, so an instance that does not enable it stays read-only.
 TEST(AdminQueryHandler, isNotServedWhenNotEnabled) {
-   auto handle = makeActiveDatabaseWithSourceData();
+   const TemporaryDataDirectory data_directory;
+   auto handle = makeActiveDatabaseWithSourceData(data_directory.path());
 
    rhydb_app::test::MockResponse response;
    postAdminQuery(
       handle,
+      data_directory.path(),
       "source.filter(country='CH').insertInto(archive)",
       response,
       /*allow_admin_endpoint=*/false
@@ -163,13 +333,16 @@ TEST(AdminQueryHandler, isNotServedWhenNotEnabled) {
    );
 }
 
-// Two admin requests must never mutate the database at the same time. All requests go through one
-// factory here (as they do in the server), so they share the write mutex; without it the concurrent
-// inserts race on the target table's columns.
+// Two admin requests must never write at the same time. All requests go through one factory here
+// (as they do in the server), so they share the write mutex; without it the concurrent writes would
+// load the same state and the last swap would drop everything the others inserted.
 TEST(AdminQueryHandler, serializesConcurrentWrites) {
-   auto handle = makeActiveDatabaseWithSourceData();
+   const TemporaryDataDirectory data_directory;
+   auto handle = makeActiveDatabaseWithSourceData(data_directory.path());
 
-   rhydb_app::RhyDBRequestHandlerFactory factory{configWithAdminEndpoint(true), handle};
+   rhydb_app::RhyDBRequestHandlerFactory factory{
+      configWithAdminEndpoint(data_directory.path(), true), handle
+   };
 
    constexpr size_t NUMBER_OF_THREADS = 4;
    constexpr size_t REQUESTS_PER_THREAD = 3;
@@ -198,17 +371,26 @@ TEST(AdminQueryHandler, serializesConcurrentWrites) {
       writer.join();
    }
 
-   // Every request inserted the two matching rows, none of them lost to a race.
+   // Every request built on the state that the one before it saved, so the rows accumulate and
+   // none of them are lost to a race.
    EXPECT_EQ(
-      handle->getActiveDatabase()->tables.at(TableName{"archive"})->row_layout.numRows(),
+      reloadFromDataDirectory(data_directory.path())
+         .tables.at(TableName{"archive"})
+         ->row_layout.numRows(),
       NUMBER_OF_THREADS * REQUESTS_PER_THREAD * 2
+   );
+   // Each of them saved a state of its own: the data versions of writes within the same second do
+   // not collide, which they would if the second-resolution timestamp were used as-is.
+   EXPECT_EQ(
+      data_directory.savedDataVersions().size(), 1 + (NUMBER_OF_THREADS * REQUESTS_PER_THREAD)
    );
 }
 
 // The read-only `/query` endpoint must reject a write (insert) statement (it parses to a
 // WriteCommand, not a QueryNode), respond 400, and leave the target table untouched.
 TEST(QueryHandler, rejectsInsertQueryOnReadOnlyEndpointWithBadRequest) {
-   auto handle = makeActiveDatabaseWithSourceData();
+   const TemporaryDataDirectory data_directory;
+   auto handle = makeActiveDatabaseWithSourceData(data_directory.path());
 
    rhydb_app::test::MockResponse response;
    rhydb_app::test::MockRequest request(response);
@@ -216,7 +398,9 @@ TEST(QueryHandler, rejectsInsertQueryOnReadOnlyEndpointWithBadRequest) {
    request.setURI("/query");
    request.in_stream << "source.filter(country='CH').insertInto(archive)";
 
-   rhydb_app::RhyDBRequestHandlerFactory factory{configWithAdminEndpoint(true), handle};
+   rhydb_app::RhyDBRequestHandlerFactory factory{
+      configWithAdminEndpoint(data_directory.path(), true), handle
+   };
    std::unique_ptr<Poco::Net::HTTPRequestHandler> handler{factory.createRequestHandler(request)};
    handler->handleRequest(request, response);
 

--- a/app/src/admin_query_handler.test.cpp
+++ b/app/src/admin_query_handler.test.cpp
@@ -102,6 +102,14 @@ TEST(AdminQueryHandler, insertsQueryResultAndReportsRowCount) {
    const auto body = nlohmann::json::parse(response.out_stream.str());
    EXPECT_EQ(body.at("insertedRows").get<size_t>(), 2);
 
+   // A successful write reports the data version of the database as it is after the write, so that
+   // a client can tell that the data it queries next is the mutated data.
+   ASSERT_TRUE(response.has("data-version"));
+   EXPECT_THAT(response.get("data-version"), testing::MatchesRegex("[0-9]{10}"));
+   EXPECT_EQ(
+      response.get("data-version"), handle->getActiveDatabase()->getDataVersionTimestamp().value
+   );
+
    // The rows really landed in the target table.
    EXPECT_EQ(
       handle->getActiveDatabase()->tables.at(TableName{"archive"})->row_layout.numRows(), 2U

--- a/app/src/query_handler.cpp
+++ b/app/src/query_handler.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <utility>
+#include <variant>
 
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/Net/HTTPServerRequest.h>
@@ -9,6 +10,7 @@
 #include <Poco/StreamCopier.h>
 #include <spdlog/spdlog.h>
 
+#include <rhydb/query_engine/command/write_command.h>
 #include <rhydb/query_engine/exec_node/arrow_ipc_sink.h>
 #include <rhydb/query_engine/exec_node/ndjson_sink.h>
 #include <rhydb/query_engine/illegal_query_exception.h>
@@ -55,8 +57,21 @@ void QueryHandler::post(
    SPDLOG_INFO("Request Id [{}] - received query: {}", request_id, query_string);
 
    try {
-      auto query_plan = rhydb::query_engine::Planner::planSaneqlQuery(
-         query_string, database->tables, query_options, request_id
+      auto parsed_request =
+         rhydb::query_engine::command::parseRequest(query_string, database->tables);
+
+      // The read query endpoint must not mutate the database. A write statement (e.g. `insertInto`)
+      // parses to a WriteCommand and has to go through the dedicated `POST /admin/query` endpoint.
+      auto* query_node = std::get_if<rhydb::query_engine::operators::QueryNodePtr>(&parsed_request);
+      if (query_node == nullptr) {
+         throw BadRequest(
+            "this query writes to the database; use the 'POST /admin/query' endpoint for write "
+            "statements"
+         );
+      }
+
+      auto query_plan = rhydb::query_engine::Planner::planQuery(
+         std::move(*query_node), database->tables, query_options, request_id
       );
 
       response.set("data-version", database->getDataVersionTimestamp().value);

--- a/app/src/request_handler_factory.cpp
+++ b/app/src/request_handler_factory.cpp
@@ -57,7 +57,9 @@ std::unique_ptr<Poco::Net::HTTPRequestHandler> RhyDBRequestHandlerFactory::route
    }
    // opt-in write-enabled admin endpoint
    if (path == "/admin/query" && runtime_config.api_options.allow_admin_endpoint) {
-      return std::make_unique<AdminQueryHandler>(database_handle, runtime_config.query_options);
+      return std::make_unique<AdminQueryHandler>(
+         database_handle, runtime_config.query_options, admin_write_mutex
+      );
    }
    return std::make_unique<NotFoundHandler>();
 }

--- a/app/src/request_handler_factory.cpp
+++ b/app/src/request_handler_factory.cpp
@@ -44,23 +44,22 @@ std::unique_ptr<Poco::Net::HTTPRequestHandler> RhyDBRequestHandlerFactory::route
    uri.getPathSegments(segments);
 
    if (path == "/health") {
-      return std::make_unique<rhydb_app::HealthHandler>();
+      return std::make_unique<HealthHandler>();
    }
    if (path == "/info") {
-      return std::make_unique<rhydb_app::InfoHandler>(database_handle);
+      return std::make_unique<InfoHandler>(database_handle);
    }
    if (segments.size() == 2 && segments.at(0) == "lineageDefinition") {
-      return std::make_unique<rhydb_app::LineageDefinitionHandler>(database_handle, segments.at(1));
+      return std::make_unique<LineageDefinitionHandler>(database_handle, segments.at(1));
    }
    if (path == "/query") {
-      return std::make_unique<rhydb_app::QueryHandler>(
-         database_handle, runtime_config.query_options
-      );
+      return std::make_unique<QueryHandler>(database_handle, runtime_config.query_options);
    }
-   if (path == "/admin/query") {
-      return std::make_unique<rhydb_app::AdminQueryHandler>(database_handle);
+   // opt-in write-enabled admin endpoint
+   if (path == "/admin/query" && runtime_config.api_options.allow_admin_endpoint) {
+      return std::make_unique<AdminQueryHandler>(database_handle, runtime_config.query_options);
    }
-   return std::make_unique<rhydb_app::NotFoundHandler>();
+   return std::make_unique<NotFoundHandler>();
 }
 
 }  // namespace rhydb_app

--- a/app/src/request_handler_factory.cpp
+++ b/app/src/request_handler_factory.cpp
@@ -7,6 +7,7 @@
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/URI.h>
 
+#include "admin_query_handler.h"
 #include "error_request_handler.h"
 #include "health_handler.h"
 #include "info_handler.h"
@@ -55,6 +56,9 @@ std::unique_ptr<Poco::Net::HTTPRequestHandler> RhyDBRequestHandlerFactory::route
       return std::make_unique<rhydb_app::QueryHandler>(
          database_handle, runtime_config.query_options
       );
+   }
+   if (path == "/admin/query") {
+      return std::make_unique<rhydb_app::AdminQueryHandler>(database_handle);
    }
    return std::make_unique<rhydb_app::NotFoundHandler>();
 }

--- a/app/src/request_handler_factory.cpp
+++ b/app/src/request_handler_factory.cpp
@@ -58,7 +58,10 @@ std::unique_ptr<Poco::Net::HTTPRequestHandler> RhyDBRequestHandlerFactory::route
    // opt-in write-enabled admin endpoint
    if (path == "/admin/query" && runtime_config.api_options.allow_admin_endpoint) {
       return std::make_unique<AdminQueryHandler>(
-         database_handle, runtime_config.query_options, admin_write_mutex
+         database_handle,
+         runtime_config.query_options,
+         runtime_config.data_directory,
+         admin_write_mutex
       );
    }
    return std::make_unique<NotFoundHandler>();

--- a/app/src/request_handler_factory.h
+++ b/app/src/request_handler_factory.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <mutex>
+
 #include <Poco/Net/HTTPRequestHandler.h>
 #include <Poco/Net/HTTPRequestHandlerFactory.h>
 #include <Poco/Net/HTTPServerRequest.h>
@@ -13,9 +16,9 @@
 namespace rhydb_app {
 
 class RhyDBRequestHandlerFactory : public Poco::Net::HTTPRequestHandlerFactory {
-  private:
    const rhydb::config::RuntimeConfig runtime_config;
    std::shared_ptr<ActiveDatabase> database_handle;
+   std::shared_ptr<std::mutex> admin_write_mutex = std::make_shared<std::mutex>();
 
   public:
    RhyDBRequestHandlerFactory(

--- a/app/src/request_handler_factory.test.cpp
+++ b/app/src/request_handler_factory.test.cpp
@@ -15,7 +15,10 @@ using rhydb_app::RhyDBRequestHandlerFactory;
 
 namespace {
 
-std::unique_ptr<RhyDBRequestHandlerFactory> createRequestHandlerWithInitializedDatabase() {
+// `allow_admin_endpoint` switches on the opt-in write endpoint, which is off by default.
+std::unique_ptr<RhyDBRequestHandlerFactory> createRequestHandlerWithInitializedDatabase(
+   bool allow_admin_endpoint = false
+) {
    auto handle = std::make_shared<rhydb_app::ActiveDatabase>();
    auto table_schema = std::make_shared<rhydb::schema::TableSchema>();
    table_schema->primary_key = {.name = "primary_key", .type = rhydb::schema::ColumnType::STRING};
@@ -28,9 +31,10 @@ std::unique_ptr<RhyDBRequestHandlerFactory> createRequestHandlerWithInitializedD
    rhydb::schema::DatabaseSchema schema;
    schema.tables.emplace(rhydb::schema::TableName::getDefault(), table_schema);
    handle->setActiveDatabase(rhydb::Database(schema));
-   auto request_handler = std::make_unique<RhyDBRequestHandlerFactory>(
-      rhydb::config::RuntimeConfig::withDefaults(), handle
-   );
+   auto runtime_config = rhydb::config::RuntimeConfig::withDefaults();
+   runtime_config.api_options.allow_admin_endpoint = allow_admin_endpoint;
+   auto request_handler =
+      std::make_unique<RhyDBRequestHandlerFactory>(std::move(runtime_config), handle);
    return request_handler;
 }
 
@@ -123,14 +127,24 @@ TEST(RhyDBRequestHandlerFactory, routesPostQueryRequest) {
    assertHoldsHandlerType<rhydb_app::QueryHandler>(handler);
 }
 
-TEST(RhyDBRequestHandlerFactory, routesPostAdminQueryRequest) {
+TEST(RhyDBRequestHandlerFactory, routesPostAdminQueryRequestWhenAdminEndpointIsAllowed) {
+   const Poco::URI uri("/admin/query");
+
+   auto under_test = createRequestHandlerWithInitializedDatabase(/*allow_admin_endpoint=*/true);
+
+   auto handler = under_test->routeRequest(uri);
+
+   assertHoldsHandlerType<rhydb_app::AdminQueryHandler>(handler);
+}
+
+TEST(RhyDBRequestHandlerFactory, routesPostAdminQueryRequestToNotFoundHandlerByDefault) {
    const Poco::URI uri("/admin/query");
 
    auto under_test = createRequestHandlerWithInitializedDatabase();
 
    auto handler = under_test->routeRequest(uri);
 
-   assertHoldsHandlerType<rhydb_app::AdminQueryHandler>(handler);
+   assertHoldsHandlerType<rhydb_app::NotFoundHandler>(handler);
 }
 
 TEST(RhyDBRequestHandlerFactory, routesUnknownUrlToNotFoundHandler) {

--- a/app/src/request_handler_factory.test.cpp
+++ b/app/src/request_handler_factory.test.cpp
@@ -2,6 +2,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "admin_query_handler.h"
 #include "health_handler.h"
 #include "info_handler.h"
 #include "lineage_definition_handler.h"
@@ -120,6 +121,16 @@ TEST(RhyDBRequestHandlerFactory, routesPostQueryRequest) {
    auto handler = under_test->routeRequest(uri);
 
    assertHoldsHandlerType<rhydb_app::QueryHandler>(handler);
+}
+
+TEST(RhyDBRequestHandlerFactory, routesPostAdminQueryRequest) {
+   const Poco::URI uri("/admin/query");
+
+   auto under_test = createRequestHandlerWithInitializedDatabase();
+
+   auto handler = under_test->routeRequest(uri);
+
+   assertHoldsHandlerType<rhydb_app::AdminQueryHandler>(handler);
 }
 
 TEST(RhyDBRequestHandlerFactory, routesUnknownUrlToNotFoundHandler) {

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -21,6 +21,7 @@ Configuration is resolved in order of precedence: CLI arguments > environment va
 | `api.maxQueuedHttpConnections` | `256` | Maximum queued connections |
 | `api.threadsForHttpConnections` | `0` | Worker threads (0 = number of CPUs) |
 | `api.estimatedStartupTimeInMinutes` | — | Used in `Retry-After` header during startup |
+| `api.allowAdminEndpoint` | `false` | Whether to serve the write-enabled [`POST /admin/query`](#post-adminquery) endpoint. Opt-in: while it is disabled, the instance is read-only and the path returns 404 |
 | `query.materializationCutoff` | `32767` | Batch size threshold for streaming. (Note: batch size of results is not guaranteed to stay below this number) |
 
 ## Common Response Headers
@@ -203,6 +204,10 @@ This is kept on a separate `/admin` path from `POST /query` because, unlike the 
 endpoint, it mutates the active database. In-place mutation is **not safe to run concurrently** with
 other queries against the same database, so this endpoint is intended for controlled administrative
 use rather than general traffic.
+
+The endpoint is **opt-in**: it is only served when
+[`api.allowAdminEndpoint`](#runtime-configuration) is set to `true`. While it is disabled the path
+does not exist and requests to it get a 404, so an instance that does not enable it stays read-only.
 
 **Request** (a SaneQL write statement as the raw request body):
 ```

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -192,6 +192,52 @@ print(table.to_pandas())
 
 ---
 
+### `POST /admin/query`
+
+Executes a SaneQL **write statement** against the database. Currently the only write statement is
+`<query>.insertInto(<targetTable>)`, which runs the inner query and inserts its result rows into
+`<targetTable>` in place — see [`insertInto`](query_documentation.md#insertintotargettable) for
+semantics and limitations.
+
+This is kept on a separate `/admin` path from `POST /query` because, unlike the read-only query
+endpoint, it mutates the active database. In-place mutation is **not safe to run concurrently** with
+other queries against the same database, so this endpoint is intended for controlled administrative
+use rather than general traffic.
+
+**Request** (a SaneQL write statement as the raw request body):
+```
+source.filter(country='CH').project({primaryKey, country}).insertInto(archive)
+```
+
+**Response** (200, `application/json`): a summary of the effect. For `insertInto`, the number of rows
+inserted:
+```json
+{"insertedRows": 42}
+```
+
+A successful response carries the [`data-version`](#common-response-headers) header reflecting the
+version after the write.
+
+**Errors** (400, `application/json`): returned when the body is not a valid write statement — e.g. a
+plain read query, an unknown target table, or a result that does not produce every column of the
+target table.
+```json
+{
+  "error": "Bad request",
+  "message": "description of what went wrong"
+}
+```
+
+```bash
+curl -X POST \
+  --data "source.filter(country='CH').project({primaryKey, country}).insertInto(archive)" \
+  http://localhost:8081/admin/query
+```
+
+The append times out after 120 seconds.
+
+---
+
 ## Error Responses
 
 All error responses are JSON, regardless of the `Accept` header.

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -195,15 +195,14 @@ print(table.to_pandas())
 
 ### `POST /admin/query`
 
-Executes a SaneQL **write statement** against the database. Currently the only write statement is
-`<query>.insertInto(<targetTable>)`, which runs the inner query and inserts its result rows into
-`<targetTable>` in place — see [`insertInto`](query_documentation.md#insertintotargettable) for
-semantics and limitations.
+Executes a SaneQL **write statement** against the database:
+- `insertInto(query: expression, table: symbol)`. Runs `query` and inserts its result rows into
+`table` — see [`insertInto`](query_documentation.md#`insertInto`) for semantics and
+limitations.
 
-This is kept on a separate `/admin` path from `POST /query` because, unlike the read-only query
-endpoint, it mutates the active database. In-place mutation is **not safe to run concurrently** with
-other queries against the same database, so this endpoint is intended for controlled administrative
-use rather than general traffic.
+The write goes through the [data directory](#runtime-configuration): the most recent state there is
+loaded into a database of its own, the statement is applied to that one, and the result is saved
+back as a new data version.
 
 The endpoint is **opt-in**: it is only served when
 [`api.allowAdminEndpoint`](#runtime-configuration) is set to `true`. While it is disabled the path
@@ -220,18 +219,13 @@ inserted:
 {"insertedRows": 42}
 ```
 
-A successful response carries the [`data-version`](#common-response-headers) header reflecting the
-version after the write.
+A successful response carries the [`data-version`](#common-response-headers) header naming the
+version the write produced, which is served once the directory watcher has picked it up. A failed
+write leaves the data version unchanged.
 
-**Errors** (400, `application/json`): returned when the body is not a valid write statement — e.g. a
-plain read query, an unknown target table, or a result that does not produce every column of the
-target table.
-```json
-{
-  "error": "Bad request",
-  "message": "description of what went wrong"
-}
-```
+**Errors** (400, `application/json`): returned when the body is not a valid write statement.
+A 500 is returned when the write itself could not be carried out, e.g. because the
+data directory holds no state to write to or could not be written.
 
 ```bash
 curl -X POST \

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -197,7 +197,7 @@ print(table.to_pandas())
 
 Executes a SaneQL **write statement** against the database:
 - `insertInto(query: expression, table: symbol)`. Runs `query` and inserts its result rows into
-`table` — see [`insertInto`](query_documentation.md#`insertInto`) for semantics and
+`table` — see [`insertInto`](query_documentation.md) for semantics and
 limitations.
 
 The write goes through the [data directory](#runtime-configuration): the most recent state there is
@@ -207,6 +207,8 @@ back as a new data version.
 The endpoint is **opt-in**: it is only served when
 [`api.allowAdminEndpoint`](#runtime-configuration) is set to `true`. While it is disabled the path
 does not exist and requests to it get a 404, so an instance that does not enable it stays read-only.
+When enabled, it is generally available and no authentication is possible. If used in publicly
+available instances the endpoint should be guarded by other means (e.g. using `nginx` rules).
 
 **Request** (a SaneQL write statement as the raw request body):
 ```

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -494,9 +494,9 @@ so nucleotide and amino acid sequences cannot be distinguished from ordinary str
 
 ## Writing query results to a table
 
-### `insertInto(targetTable)`
+### `insertInto(query: expression, table: symbol)`
 
-Runs the query it is chained onto and inserts the resulting rows into an existing table — a query
+Runs `query` and inserts the resulting rows into `table` — a query
 against table A whose result lands in table B, expressed as a single SaneQL query. It is the only
 SaneQL construct that writes: it mutates the target table rather than returning rows to the caller.
 
@@ -524,8 +524,11 @@ through an insert query. A sequence column is decompressed to a plain string whe
 pipeline, which does not match the structured form the target's sequence column expects, so query
 results containing sequence columns cannot be inserted.
 
-Like other in-place mutations it bumps the data version and is not safe to run concurrently with other
-queries against the same database.
+It bumps the data version of the database it is applied to. The statement itself mutates its target
+table in place, so it is not safe to run next to other queries against the same database; the
+[`POST /admin/query`](api.md#post-adminquery) endpoint - the only way to issue it over the API -
+therefore applies it to a database loaded from the data directory and saves the result back as a new
+data version, which is served once the directory watcher picks it up.
 
 ---
 

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -492,6 +492,43 @@ so nucleotide and amino acid sequences cannot be distinguished from ordinary str
 
 ---
 
+## Writing query results to a table
+
+### `insertInto(targetTable)`
+
+Runs the query it is chained onto and inserts the resulting rows into an existing table — a query
+against table A whose result lands in table B, expressed as a single SaneQL query. It is the only
+SaneQL construct that writes: it mutates the target table rather than returning rows to the caller.
+
+```
+source.filter(country='CH').insertInto(archive)
+source.filter(country='CH').project({primaryKey, country, age}).insertInto(archive)
+source.insertInto('archive')
+```
+
+The target may be written as a bare identifier (`archive`) or a string literal (`'archive'`). It
+must be an existing table in the database; `insertInto` never creates a table.
+
+**Column matching.** The query's output columns are matched to the target table's columns *by name*.
+Every column of the target table must be produced by the query; any extra output columns are ignored.
+Use `project({...})` (or `map({...})`) to shape the result so it lines up with the target's schema.
+A missing column, or a value whose type does not match the target column, is a query error and no
+rows are inserted.
+
+**Placement.** `insertInto` is a *write statement*, not a pipeline operator: it must be the whole
+query (its outermost operation) and cannot be chained further (e.g. `x.insertInto(y).filter(...)` is
+not valid).
+
+**Limitation:** only value columns (`STRING`, `INT32`, `INT64`, `FLOAT`, `DATE32`, `BOOL`) round-trip
+through an insert query. A sequence column is decompressed to a plain string when read into a
+pipeline, which does not match the structured form the target's sequence column expects, so query
+results containing sequence columns cannot be inserted.
+
+Like other in-place mutations it bumps the data version and is not safe to run concurrently with other
+queries against the same database.
+
+---
+
 ## Scalar Functions
 
 Most scalar functions are boolean predicates used inside `.filter(...)`.

--- a/endToEndTests/test/adminQuery.test.js
+++ b/endToEndTests/test/adminQuery.test.js
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test';
+import { expect } from 'chai';
+import { server } from './common.js';
+
+const WRITE_QUERY = 'default.insertInto(default)';
+
+async function countRows() {
+  const response = await server
+    .post('/query')
+    .set('Content-Type', 'text/plain')
+    .send('default.groupBy({count:=count()})');
+
+  expect(response.status).to.equal(200);
+  const rows = response.text
+    .split(/\n/)
+    .filter(line => line !== '')
+    .map(line => JSON.parse(line));
+  return rows[0].count;
+}
+
+describe('Write statements', () => {
+  // The read-only endpoint must refuse a write statement instead of executing it.
+  it('should be rejected by the /query endpoint without touching the data', async () => {
+    const rowsBefore = await countRows();
+
+    await server
+      .post('/query')
+      .set('Content-Type', 'text/plain')
+      .send(WRITE_QUERY)
+      .expect(400)
+      .expect('Content-Type', 'application/json')
+      .expect({
+        error: 'Bad request',
+        message:
+          "this query writes to the database; use the 'POST /admin/query' endpoint for write statements",
+      });
+
+    expect(await countRows()).to.equal(rowsBefore);
+  });
+
+  // The e2e instance runs without a runtime config, so `api.allowAdminEndpoint` keeps its default
+  // value `false` and the write-enabled endpoint is not served at all.
+  it('should not reach /admin/query while api.allowAdminEndpoint is disabled', async () => {
+    const rowsBefore = await countRows();
+
+    await server
+      .post('/admin/query')
+      .set('Content-Type', 'text/plain')
+      .send(WRITE_QUERY)
+      .expect(404)
+      .expect('Content-Type', 'application/json')
+      .expect({ error: 'Not found', message: 'Resource /admin/query does not exist' });
+
+    expect(await countRows()).to.equal(rowsBefore);
+  });
+});

--- a/src/rhydb/append/table_inserter.cpp
+++ b/src/rhydb/append/table_inserter.cpp
@@ -355,19 +355,7 @@ TableInserter::Commit TableInserter::commit() {
    return Commit{};
 }
 
-TableInserter::Commit appendDataToTable(
-   std::shared_ptr<storage::Table> table,
-   NdjsonLineReader& input_data,
-   ClusteredBufferingOptions options
-) {
-   EVOBENCH_SCOPE("TableInserter", "appendDataToTable");
-   TableInserter table_inserter(std::move(table), std::move(options));
-
-   size_t line_count = 0;
-
-   bool first_line = true;
-
-   std::vector<TableInserter::SniffedField> sniffed_field_order;
+void NdjsonInsertStream::insertAll(NdjsonLineReader& input_data) {
    for (auto [json_obj_or_error, raw_line] : input_data) {
       simdjson::ondemand::document_reference ndjson_line;
       if (auto error = json_obj_or_error.get(ndjson_line)) {
@@ -378,18 +366,18 @@ TableInserter::Commit appendDataToTable(
          );
       }
 
-      if (first_line) {
-         auto sniffed_field_order_or_error = table_inserter.sniffFieldOrder(ndjson_line);
+      if (!field_order_sniffed) {
+         auto sniffed_field_order_or_error = table_inserter->sniffFieldOrder(ndjson_line);
          if (!sniffed_field_order_or_error.has_value()) {
             throw AppendException{
                "{} - current line: {}", sniffed_field_order_or_error.error(), raw_line
             };
          }
-         sniffed_field_order = sniffed_field_order_or_error.value();
-         first_line = false;
+         field_order = sniffed_field_order_or_error.value();
+         field_order_sniffed = true;
       }
 
-      auto maybe_error = table_inserter.insert(ndjson_line, sniffed_field_order);
+      auto maybe_error = table_inserter->insert(ndjson_line, field_order);
       if (!maybe_error.has_value()) {
          throw AppendException{"{} - current line: {}", maybe_error.error(), raw_line};
       }
@@ -399,6 +387,18 @@ TableInserter::Commit appendDataToTable(
          SPDLOG_INFO("Processed {} json objects from the input file", line_count);
       }
    }
+}
+
+TableInserter::Commit appendDataToTable(
+   std::shared_ptr<storage::Table> table,
+   NdjsonLineReader& input_data,
+   ClusteredBufferingOptions options
+) {
+   EVOBENCH_SCOPE("TableInserter", "appendDataToTable");
+   TableInserter table_inserter(std::move(table), std::move(options));
+
+   NdjsonInsertStream insert_stream{table_inserter};
+   insert_stream.insertAll(input_data);
 
    return table_inserter.commit();
 }

--- a/src/rhydb/append/table_inserter.h
+++ b/src/rhydb/append/table_inserter.h
@@ -112,6 +112,26 @@ class TableInserter {
    [[nodiscard]] Commit commit();
 };
 
+/// Feeds NDJSON lines into a TableInserter. It keeps the field order sniffed from the very first
+/// line and the running line count across calls, so a stream that arrives in several chunks (e.g.
+/// one query result batch at a time) is inserted exactly as one continuous NDJSON stream would be.
+/// Throws AppendException for a line that cannot be parsed or inserted.
+class NdjsonInsertStream {
+   TableInserter* table_inserter;
+   std::vector<TableInserter::SniffedField> field_order;
+   bool field_order_sniffed = false;
+   size_t line_count = 0;
+
+  public:
+   explicit NdjsonInsertStream(TableInserter& table_inserter)
+       : table_inserter(&table_inserter) {}
+
+   /// Inserts every line that `input_data` yields.
+   void insertAll(NdjsonLineReader& input_data);
+
+   [[nodiscard]] size_t lineCount() const { return line_count; }
+};
+
 TableInserter::Commit appendDataToTable(
    std::shared_ptr<rhydb::storage::Table> table,
    NdjsonLineReader& input_data,

--- a/src/rhydb/common/data_version.cpp
+++ b/src/rhydb/common/data_version.cpp
@@ -63,6 +63,17 @@ DataVersion DataVersion::mineDataVersion() {
    };
 }
 
+DataVersion DataVersion::mineDataVersionAfter(const DataVersion& previous) {
+   auto mined = mineDataVersion();
+   if (previous.timestamp.value.empty() || mined.timestamp > previous.timestamp) {
+      return mined;
+   }
+   const auto next_timestamp = std::stoull(previous.timestamp.value) + 1;
+   return DataVersion{
+      *Timestamp::fromString(std::to_string(next_timestamp)), {CURRENT_SILO_SERIALIZATION_VERSION}
+   };
+}
+
 DataVersion::DataVersion(
    DataVersion::Timestamp timestamp,
    SerializationVersion serialization_version

--- a/src/rhydb/common/data_version.cpp
+++ b/src/rhydb/common/data_version.cpp
@@ -70,7 +70,7 @@ DataVersion DataVersion::mineDataVersionAfter(const DataVersion& previous) {
    }
    const auto next_timestamp = std::stoull(previous.timestamp.value) + 1;
    return DataVersion{
-      *Timestamp::fromString(std::to_string(next_timestamp)), {CURRENT_SILO_SERIALIZATION_VERSION}
+      *Timestamp::fromString(std::to_string(next_timestamp)), {CURRENT_RHYDB_SERIALIZATION_VERSION}
    };
 }
 

--- a/src/rhydb/common/data_version.h
+++ b/src/rhydb/common/data_version.h
@@ -52,6 +52,9 @@ class DataVersion {
 
    static DataVersion mineDataVersion();
 
+   // Generate timestamp that is guaranteed to be greater than previous
+   static DataVersion mineDataVersionAfter(const DataVersion& previous);
+
    static std::optional<DataVersion> fromFile(const std::filesystem::path& file_path);
 
    void saveToFile(const std::filesystem::path& save_file) const;

--- a/src/rhydb/common/data_version.test.cpp
+++ b/src/rhydb/common/data_version.test.cpp
@@ -30,3 +30,15 @@ TEST(DataVersion, shouldConstructWithDefaultVersion) {
       EXPECT_EQ(timestamp->value, "");
    }
 }
+
+// Data versions have a resolution of one second, but each update has to produce a version of its
+// own: it names the directory the state is saved under, and readers use it to tell data apart.
+TEST(DataVersion, shouldMineAVersionThatIsNewerThanThePreviousOne) {
+   auto previous = DataVersion::mineDataVersion();
+   for (size_t update = 0; update < 5; ++update) {
+      const auto next = DataVersion::mineDataVersionAfter(previous);
+      EXPECT_GT(next, previous);
+      EXPECT_EQ(next.getTimestamp().value.size(), 10UL);
+      previous = next;
+   }
+}

--- a/src/rhydb/config/runtime_config.cpp
+++ b/src/rhydb/config/runtime_config.cpp
@@ -111,9 +111,12 @@ ConfigSpecification RuntimeConfig::getConfigSpecification() {
             ConfigAttributeSpecification::createWithDefault(
                apiAllowAdminEndpointOptionKey(),
                ConfigValue::fromBool(false),
-               "Whether to serve the write-enabled 'POST /admin/query' endpoint, which mutates \n"
-               "the active database (e.g. via 'insertInto'). Disabled by default; while it is \n"
-               "disabled the endpoint responds with 404 and the instance stays read-only."
+               "Whether to serve the write-enabled 'POST /admin/query' endpoint, which changes \n"
+               "the data the server serves (e.g. via 'insertInto'). Each write saves a new data \n"
+               "version to the data directory, which must be writable, and is served once it has \n"
+               "been picked up from there. Disabled by default; while it is disabled the endpoint "
+               "\n"
+               "responds with 404 and the instance stays read-only."
             ),
             ConfigAttributeSpecification::createWithDefault(
                queryMaterializationOptionKey(),

--- a/src/rhydb/config/runtime_config.cpp
+++ b/src/rhydb/config/runtime_config.cpp
@@ -42,6 +42,9 @@ ConfigKeyPath apiEstimatedStartupTimeOptionKey() {
 ConfigKeyPath softMemoryLimitOptionKey() {
    return YamlFile::stringToConfigKeyPath("api.softMemoryLimit");
 }
+ConfigKeyPath apiAllowAdminEndpointOptionKey() {
+   return YamlFile::stringToConfigKeyPath("api.allowAdminEndpoint");
+}
 ConfigKeyPath queryMaterializationOptionKey() {
    return YamlFile::stringToConfigKeyPath("query.materializationCutoff");
 }
@@ -106,6 +109,13 @@ ConfigSpecification RuntimeConfig::getConfigSpecification() {
                "Only supported on Linux."
             ),
             ConfigAttributeSpecification::createWithDefault(
+               apiAllowAdminEndpointOptionKey(),
+               ConfigValue::fromBool(false),
+               "Whether to serve the write-enabled 'POST /admin/query' endpoint, which mutates \n"
+               "the active database (e.g. via 'insertInto'). Disabled by default; while it is \n"
+               "disabled the endpoint responds with 404 and the instance stays read-only."
+            ),
+            ConfigAttributeSpecification::createWithDefault(
                queryMaterializationOptionKey(),
                ConfigValue::fromUint32(DEFAULT_ARROW_BATCH_SIZE),
                "If a query results in fewer rows, the query result will be collected \n"
@@ -160,6 +170,9 @@ void RuntimeConfig::overwriteFrom(const VerifiedConfigAttributes& config_source)
    if (auto var = config_source.getUint32(softMemoryLimitOptionKey())) {
       api_options.soft_memory_limit = var.value();
    }
+   if (auto var = config_source.getBool(apiAllowAdminEndpointOptionKey())) {
+      api_options.allow_admin_endpoint = var.value();
+   }
    if (auto var = config_source.getUint32(queryMaterializationOptionKey())) {
       query_options.materialization_cutoff = var.value();
    }
@@ -174,7 +187,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(
    max_connections,
    parallel_threads,
    port,
-   estimated_startup_end
+   estimated_startup_end,
+   allow_admin_endpoint
 )
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(rhydb::config::QueryOptions, materialization_cutoff)

--- a/src/rhydb/config/runtime_config.h
+++ b/src/rhydb/config/runtime_config.h
@@ -17,6 +17,9 @@ class ApiOptions {
    std::optional<std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>>
       estimated_startup_end;
    uint32_t soft_memory_limit;
+   /// Whether the write-enabled `POST /admin/query` endpoint is served. Opt-in, so an instance
+   /// that does not enable it stays strictly read-only.
+   bool allow_admin_endpoint;
 };
 
 class QueryOptions {

--- a/src/rhydb/config/runtime_config.test.cpp
+++ b/src/rhydb/config/runtime_config.test.cpp
@@ -17,4 +17,11 @@ TEST(RuntimeConfig, shouldReadConfig) {
 
    ASSERT_EQ(runtime_config.api_options.port, 1234);
    ASSERT_EQ(runtime_config.data_directory, "test/directory");
+   ASSERT_TRUE(runtime_config.api_options.allow_admin_endpoint);
+}
+
+// The write-enabled admin endpoint must stay off unless it is explicitly switched on, so that an
+// existing read-only instance stays read-only after an upgrade.
+TEST(RuntimeConfig, adminEndpointIsDisabledByDefault) {
+   ASSERT_FALSE(RuntimeConfig::withDefaults().api_options.allow_admin_endpoint);
 }

--- a/src/rhydb/database.cpp
+++ b/src/rhydb/database.cpp
@@ -480,7 +480,8 @@ std::string Database::executeQueryAsArrowIpc(const std::string& query_string) co
 
 nlohmann::json Database::executeWrite(
    const std::string& query_string,
-   const config::QueryOptions& query_options
+   const config::QueryOptions& query_options,
+   std::string_view request_id
 ) {
    const auto request = query_engine::command::parseRequest(query_string, tables);
    const auto* command = std::get_if<query_engine::command::WriteCommandPtr>(&request);
@@ -489,7 +490,7 @@ nlohmann::json Database::executeWrite(
          "expected a write statement, e.g. `<query>.insertInto(<table>)`"
       );
    }
-   return (*command)->execute(*this, query_options);
+   return (*command)->execute(*this, query_options, request_id);
 }
 
 std::string Database::getTablesAsArrowIpc() const {

--- a/src/rhydb/database.cpp
+++ b/src/rhydb/database.cpp
@@ -478,15 +478,18 @@ std::string Database::executeQueryAsArrowIpc(const std::string& query_string) co
    return output_stream.str();
 }
 
-nlohmann::json Database::executeWrite(const std::string& query_string) {
-   auto request = query_engine::command::parseRequest(query_string, tables);
-   auto* command = std::get_if<query_engine::command::WriteCommandPtr>(&request);
+nlohmann::json Database::executeWrite(
+   const std::string& query_string,
+   const config::QueryOptions& query_options
+) {
+   const auto request = query_engine::command::parseRequest(query_string, tables);
+   const auto* command = std::get_if<query_engine::command::WriteCommandPtr>(&request);
    if (command == nullptr) {
       throw query_engine::IllegalQueryException(
          "expected a write statement, e.g. `<query>.insertInto(<targetTable>)`"
       );
    }
-   return (*command)->execute(*this);
+   return (*command)->execute(*this, query_options);
 }
 
 std::string Database::getTablesAsArrowIpc() const {

--- a/src/rhydb/database.cpp
+++ b/src/rhydb/database.cpp
@@ -8,12 +8,14 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <variant>
 
 #include <arrow/api.h>
 #include <arrow/io/memory.h>
 #include <arrow/ipc/writer.h>
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
 
 #include "rhydb/append/table_inserter.h"
 #include "rhydb/common/aa_symbols.h"
@@ -24,6 +26,7 @@
 #include "rhydb/common/version.h"
 #include "rhydb/database_info.h"
 #include "rhydb/persistence/exception.h"
+#include "rhydb/query_engine/command/write_command.h"
 #include "rhydb/query_engine/exec_node/arrow_ipc_sink.h"
 #include "rhydb/query_engine/exec_node/ndjson_sink.h"
 #include "rhydb/query_engine/illegal_query_exception.h"
@@ -473,6 +476,17 @@ std::string Database::executeQueryAsArrowIpc(const std::string& query_string) co
    }
    query_plan.executeAndWrite(output_sink.ValueUnsafe(), DEFAULT_TIMEOUT_SECONDS);
    return output_stream.str();
+}
+
+nlohmann::json Database::executeWrite(const std::string& query_string) {
+   auto request = query_engine::command::parseRequest(query_string, tables);
+   auto* command = std::get_if<query_engine::command::WriteCommandPtr>(&request);
+   if (command == nullptr) {
+      throw query_engine::IllegalQueryException(
+         "expected a write statement, e.g. `<query>.insertInto(<targetTable>)`"
+      );
+   }
+   return (*command)->execute(*this);
 }
 
 std::string Database::getTablesAsArrowIpc() const {

--- a/src/rhydb/database.cpp
+++ b/src/rhydb/database.cpp
@@ -456,7 +456,7 @@ DataVersion::Timestamp Database::getDataVersionTimestamp() const {
 }
 
 void Database::updateDataVersion() {
-   data_version_ = DataVersion::mineDataVersion();
+   data_version_ = DataVersion::mineDataVersionAfter(data_version_);
    SPDLOG_DEBUG("Data version was set to {}", data_version_.toString());
 }
 
@@ -486,7 +486,7 @@ nlohmann::json Database::executeWrite(
    const auto* command = std::get_if<query_engine::command::WriteCommandPtr>(&request);
    if (command == nullptr) {
       throw query_engine::IllegalQueryException(
-         "expected a write statement, e.g. `<query>.insertInto(<targetTable>)`"
+         "expected a write statement, e.g. `<query>.insertInto(<table>)`"
       );
    }
    return (*command)->execute(*this, query_options);

--- a/src/rhydb/database.h
+++ b/src/rhydb/database.h
@@ -2,6 +2,8 @@
 
 #include <filesystem>
 
+#include <nlohmann/json_fwd.hpp>
+
 #include "rhydb/append/table_inserter.h"
 #include "rhydb/common/data_version.h"
 #include "rhydb/common/rhydb_directory.h"
@@ -99,6 +101,13 @@ class Database {
    [[nodiscard]] virtual DataVersion::Timestamp getDataVersionTimestamp() const;
 
    [[nodiscard]] std::string executeQueryAsArrowIpc(const std::string& query_string) const;
+
+   /// Executes a SaneQL write statement (e.g. `<query>.insertInto(<targetTable>)`) against this
+   /// database, mutating it, and returns a JSON summary of the effect (e.g. `{"insertedRows":
+   /// 42}`). Write statements are dispatched through the WriteStatementRegistry, so adding a new
+   /// one does not touch this method. Throws IllegalQueryException if `query_string` is a read
+   /// query rather than a write statement.
+   nlohmann::json executeWrite(const std::string& query_string);
 
    [[nodiscard]] std::string getTablesAsArrowIpc() const;
 

--- a/src/rhydb/database.h
+++ b/src/rhydb/database.h
@@ -7,6 +7,7 @@
 #include "rhydb/append/table_inserter.h"
 #include "rhydb/common/data_version.h"
 #include "rhydb/common/rhydb_directory.h"
+#include "rhydb/config/runtime_config.h"
 #include "rhydb/database_info.h"
 #include "rhydb/query_engine/query_plan.h"
 #include "rhydb/schema/database_schema.h"
@@ -102,12 +103,10 @@ class Database {
 
    [[nodiscard]] std::string executeQueryAsArrowIpc(const std::string& query_string) const;
 
-   /// Executes a SaneQL write statement (e.g. `<query>.insertInto(<targetTable>)`) against this
-   /// database, mutating it, and returns a JSON summary of the effect (e.g. `{"insertedRows":
-   /// 42}`). Write statements are dispatched through the WriteStatementRegistry, so adding a new
-   /// one does not touch this method. Throws IllegalQueryException if `query_string` is a read
-   /// query rather than a write statement.
-   nlohmann::json executeWrite(const std::string& query_string);
+   nlohmann::json executeWrite(
+      const std::string& query_string,
+      const config::QueryOptions& query_options
+   );
 
    [[nodiscard]] std::string getTablesAsArrowIpc() const;
 

--- a/src/rhydb/database.h
+++ b/src/rhydb/database.h
@@ -105,7 +105,8 @@ class Database {
 
    nlohmann::json executeWrite(
       const std::string& query_string,
-      const config::QueryOptions& query_options
+      const config::QueryOptions& query_options,
+      std::string_view request_id
    );
 
    [[nodiscard]] std::string getTablesAsArrowIpc() const;

--- a/src/rhydb/database.test.cpp
+++ b/src/rhydb/database.test.cpp
@@ -437,7 +437,7 @@ TEST(DatabaseInsertQueryTest, insertsAResultThatSpansSeveralBatches) {
 
 // The rows are inserted while the query is still producing, so a query that reads the table it
 // writes into would read columns that the insert mutates underneath it.
-TEST(DatabaseInsertQueryTest, rejectsInsertThatReadsItsTargetTable) {
+TEST(DatabaseInsertQueryTest, rejectsInsertThatReadsItsTable) {
    rhydb::Database database;
    database.createTable(TableName{"source"}, makeValueColumnSchema());
 

--- a/src/rhydb/database.test.cpp
+++ b/src/rhydb/database.test.cpp
@@ -302,6 +302,12 @@ TEST(DatabaseTest, canCreateMultipleTablesAndAddData) {
 namespace {
 using rhydb::schema::TableName;
 
+// The query options the API serves write statements with; the admin endpoint threads the runtime
+// config's options through, so the tests use the same defaults.
+rhydb::config::QueryOptions defaultQueryOptions() {
+   return rhydb::config::RuntimeConfig::withDefaults().query_options;
+}
+
 // Builds a metadata-only table schema (string primary key + a string and an int32 column). Append
 // queries copy query output back through the NDJSON append path, which round-trips value columns
 // cleanly; sequence columns are intentionally left out (a query emits them as decompressed strings,
@@ -350,8 +356,9 @@ TEST(DatabaseInsertQueryTest, copiesFilteredRowsFromOneTableIntoAnother) {
                << R"({"key":"c","country":"CH","age":3})" << "\n";
    database.appendData(TableName{"source"}, source_data);
 
-   const nlohmann::json result =
-      database.executeWrite("source.filter(country='CH').insertInto(archive)");
+   const nlohmann::json result = database.executeWrite(
+      "source.filter(country='CH').insertInto(archive)", defaultQueryOptions()
+   );
 
    EXPECT_EQ(result.at("insertedRows").get<size_t>(), 2);
    EXPECT_EQ(countInTableWhere(database, "archive", "true"), 2);
@@ -383,14 +390,16 @@ TEST(DatabaseInsertQueryTest, reshapesWithProjectAcceptsStringTargetAndAccumulat
    database.appendData(TableName{"source"}, source_data);
 
    // Target named as a string literal; project drops the `age` column the target does not have.
-   const nlohmann::json result =
-      database.executeWrite("source.project({key, country}).insertInto('archive')");
+   const nlohmann::json result = database.executeWrite(
+      "source.project({key, country}).insertInto('archive')", defaultQueryOptions()
+   );
    EXPECT_EQ(result.at("insertedRows").get<size_t>(), 2);
    EXPECT_EQ(countInTableWhere(database, "archive", "true"), 2);
 
    // A second append accumulates on top of the existing rows rather than replacing them.
    const nlohmann::json result_again = database.executeWrite(
-      "source.filter(country='US').project({key, country}).insertInto(archive)"
+      "source.filter(country='US').project({key, country}).insertInto(archive)",
+      defaultQueryOptions()
    );
    EXPECT_EQ(result_again.at("insertedRows").get<size_t>(), 1);
    EXPECT_EQ(countInTableWhere(database, "archive", "true"), 3);
@@ -407,7 +416,7 @@ TEST(DatabaseInsertQueryTest, rejectsInvalidInsertQueries) {
 
    // A plain read query is not a write statement.
    EXPECT_THAT(
-      [&]() { database.executeWrite("source.filter(country='CH')"); },
+      [&]() { database.executeWrite("source.filter(country='CH')", defaultQueryOptions()); },
       ThrowsMessage<rhydb::query_engine::IllegalQueryException>(
          ::testing::HasSubstr("expected a write statement")
       )
@@ -415,7 +424,7 @@ TEST(DatabaseInsertQueryTest, rejectsInvalidInsertQueries) {
 
    // The target table must exist.
    EXPECT_THAT(
-      [&]() { database.executeWrite("source.insertInto(does_not_exist)"); },
+      [&]() { database.executeWrite("source.insertInto(does_not_exist)", defaultQueryOptions()); },
       ThrowsMessage<rhydb::query_engine::IllegalQueryException>(
          ::testing::HasSubstr("target table 'does_not_exist' not found")
       )
@@ -423,12 +432,14 @@ TEST(DatabaseInsertQueryTest, rejectsInvalidInsertQueries) {
 
    // insertInto needs both a source and a target.
    EXPECT_THAT(
-      [&]() { database.executeWrite("insertInto(source)"); },
+      [&]() { database.executeWrite("insertInto(source)", defaultQueryOptions()); },
       ThrowsMessage<rhydb::query_engine::IllegalQueryException>(
          ::testing::HasSubstr("insertInto() requires argument 'target'")
       )
    );
 
    // If the query does not produce every column of the target, the append is rejected.
-   EXPECT_ANY_THROW(database.executeWrite("source.project({key}).insertInto(archive)"));
+   EXPECT_ANY_THROW(
+      database.executeWrite("source.project({key}).insertInto(archive)", defaultQueryOptions())
+   );
 }

--- a/src/rhydb/database.test.cpp
+++ b/src/rhydb/database.test.cpp
@@ -358,7 +358,7 @@ TEST(DatabaseInsertQueryTest, copiesFilteredRowsFromOneTableIntoAnother) {
    database.appendData(TableName{"source"}, source_data);
 
    const nlohmann::json result = database.executeWrite(
-      "source.filter(country='CH').insertInto(archive)", defaultQueryOptions()
+      "source.filter(country='CH').insertInto(archive)", defaultQueryOptions(), "test_request_id"
    );
 
    EXPECT_EQ(result.at("insertedRows").get<size_t>(), 2);
@@ -392,7 +392,9 @@ TEST(DatabaseInsertQueryTest, reshapesWithProjectAcceptsStringTargetAndAccumulat
 
    // Target named as a string literal; project drops the `age` column the target does not have.
    const nlohmann::json result = database.executeWrite(
-      "source.project({key, country}).insertInto('archive')", defaultQueryOptions()
+      "source.project({key, country}).insertInto('archive')",
+      defaultQueryOptions(),
+      "test_request_id"
    );
    EXPECT_EQ(result.at("insertedRows").get<size_t>(), 2);
    EXPECT_EQ(countInTableWhere(database, "archive", "true"), 2);
@@ -400,7 +402,8 @@ TEST(DatabaseInsertQueryTest, reshapesWithProjectAcceptsStringTargetAndAccumulat
    // A second append accumulates on top of the existing rows rather than replacing them.
    const nlohmann::json result_again = database.executeWrite(
       "source.filter(country='US').project({key, country}).insertInto(archive)",
-      defaultQueryOptions()
+      defaultQueryOptions(),
+      "test_request_id"
    );
    EXPECT_EQ(result_again.at("insertedRows").get<size_t>(), 1);
    EXPECT_EQ(countInTableWhere(database, "archive", "true"), 3);
@@ -426,7 +429,9 @@ TEST(DatabaseInsertQueryTest, insertsAResultThatSpansSeveralBatches) {
 
    // A cutoff of 1 makes the table scan emit tiny batches, so the insert sees many of them.
    const nlohmann::json result = database.executeWrite(
-      "source.insertInto(archive)", rhydb::config::QueryOptions{.materialization_cutoff = 1}
+      "source.insertInto(archive)",
+      rhydb::config::QueryOptions{.materialization_cutoff = 1},
+      "test_request_id"
    );
 
    EXPECT_EQ(result.at("insertedRows").get<size_t>(), NUMBER_OF_ROWS);
@@ -446,7 +451,11 @@ TEST(DatabaseInsertQueryTest, rejectsInsertThatReadsItsTable) {
    database.appendData(TableName{"source"}, source_data);
 
    EXPECT_THAT(
-      [&]() { database.executeWrite("source.insertInto(source)", defaultQueryOptions()); },
+      [&]() {
+         database.executeWrite(
+            "source.insertInto(source)", defaultQueryOptions(), "test_request_id"
+         );
+      },
       ThrowsMessage<rhydb::query_engine::IllegalQueryException>(
          ::testing::HasSubstr("cannot write into table 'source' while the query reads from it")
       )
@@ -466,7 +475,11 @@ TEST(DatabaseInsertQueryTest, rejectsInvalidInsertQueries) {
 
    // A plain read query is not a write statement.
    EXPECT_THAT(
-      [&]() { database.executeWrite("source.filter(country='CH')", defaultQueryOptions()); },
+      [&]() {
+         database.executeWrite(
+            "source.filter(country='CH')", defaultQueryOptions(), "test_request_id"
+         );
+      },
       ThrowsMessage<rhydb::query_engine::IllegalQueryException>(
          ::testing::HasSubstr("expected a write statement")
       )
@@ -474,7 +487,11 @@ TEST(DatabaseInsertQueryTest, rejectsInvalidInsertQueries) {
 
    // The target table must exist.
    EXPECT_THAT(
-      [&]() { database.executeWrite("source.insertInto(does_not_exist)", defaultQueryOptions()); },
+      [&]() {
+         database.executeWrite(
+            "source.insertInto(does_not_exist)", defaultQueryOptions(), "test_request_id"
+         );
+      },
       ThrowsMessage<rhydb::query_engine::IllegalQueryException>(
          ::testing::HasSubstr("target table 'does_not_exist' not found")
       )
@@ -482,7 +499,9 @@ TEST(DatabaseInsertQueryTest, rejectsInvalidInsertQueries) {
 
    // insertInto needs both a source and a target.
    EXPECT_THAT(
-      [&]() { database.executeWrite("insertInto(source)", defaultQueryOptions()); },
+      [&]() {
+         database.executeWrite("insertInto(source)", defaultQueryOptions(), "test_request_id");
+      },
       ThrowsMessage<rhydb::query_engine::IllegalQueryException>(
          ::testing::HasSubstr("insertInto() requires argument 'target'")
       )
@@ -507,7 +526,9 @@ TEST(DatabaseInsertQueryTest, insertsNothingWhenAColumnOfTheTargetIsMissing) {
 
    EXPECT_THAT(
       [&]() {
-         database.executeWrite("source.project({key}).insertInto(archive)", defaultQueryOptions());
+         database.executeWrite(
+            "source.project({key}).insertInto(archive)", defaultQueryOptions(), "test_request_id"
+         );
       },
       ThrowsMessage<rhydb::append::AppendException>(
          ::testing::HasSubstr("the column 'age' is not contained in the object")
@@ -534,7 +555,8 @@ TEST(DatabaseInsertQueryTest, insertsNothingWhenAColumnHasTheWrongType) {
       [&]() {
          database.executeWrite(
             "source.project({key, country}).map({age := country}).insertInto(archive)",
-            defaultQueryOptions()
+            defaultQueryOptions(),
+            "test_request_id"
          );
       },
       ThrowsMessage<rhydb::append::AppendException>(::testing::AllOf(

--- a/src/rhydb/database.test.cpp
+++ b/src/rhydb/database.test.cpp
@@ -405,6 +405,55 @@ TEST(DatabaseInsertQueryTest, reshapesWithProjectAcceptsStringTargetAndAccumulat
    EXPECT_EQ(countInTableWhere(database, "archive", "true"), 3);
 }
 
+// The insert streams the query result into the target table batch by batch. With a small
+// materialization cutoff the source query produces several batches, so this covers that the field
+// order sniffed from the first line is reused for the later batches and that every batch lands.
+TEST(DatabaseInsertQueryTest, insertsAResultThatSpansSeveralBatches) {
+   rhydb::Database database;
+   database.createTable(TableName{"source"}, makeValueColumnSchema());
+   database.createTable(TableName{"archive"}, makeValueColumnSchema());
+
+   constexpr size_t NUMBER_OF_ROWS = 25;
+   std::stringstream source_data;
+   for (size_t row = 0; row < NUMBER_OF_ROWS; ++row) {
+      source_data << fmt::format(
+                        R"({{"key":"key{}","country":"CH","age":{}}})", row, static_cast<int>(row)
+                     )
+                  << "\n";
+   }
+   database.appendData(TableName{"source"}, source_data);
+
+   // A cutoff of 1 makes the table scan emit tiny batches, so the insert sees many of them.
+   const nlohmann::json result = database.executeWrite(
+      "source.insertInto(archive)", rhydb::config::QueryOptions{.materialization_cutoff = 1}
+   );
+
+   EXPECT_EQ(result.at("insertedRows").get<size_t>(), NUMBER_OF_ROWS);
+   EXPECT_EQ(countInTableWhere(database, "archive", "true"), NUMBER_OF_ROWS);
+   EXPECT_EQ(countInTableWhere(database, "archive", "country='CH'"), NUMBER_OF_ROWS);
+   EXPECT_EQ(countInTableWhere(database, "archive", "age=24"), 1);
+}
+
+// The rows are inserted while the query is still producing, so a query that reads the table it
+// writes into would read columns that the insert mutates underneath it.
+TEST(DatabaseInsertQueryTest, rejectsInsertThatReadsItsTargetTable) {
+   rhydb::Database database;
+   database.createTable(TableName{"source"}, makeValueColumnSchema());
+
+   std::stringstream source_data;
+   source_data << R"({"key":"a","country":"CH","age":1})" << "\n";
+   database.appendData(TableName{"source"}, source_data);
+
+   EXPECT_THAT(
+      [&]() { database.executeWrite("source.insertInto(source)", defaultQueryOptions()); },
+      ThrowsMessage<rhydb::query_engine::IllegalQueryException>(
+         ::testing::HasSubstr("cannot write into table 'source' while the query reads from it")
+      )
+   );
+   // The rejected write left the table untouched.
+   EXPECT_EQ(countInTableWhere(database, "source", "true"), 1);
+}
+
 TEST(DatabaseInsertQueryTest, rejectsInvalidInsertQueries) {
    rhydb::Database database;
    database.createTable(TableName{"source"}, makeValueColumnSchema());

--- a/src/rhydb/database.test.cpp
+++ b/src/rhydb/database.test.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include "config/source/yaml_file.h"
+#include "rhydb/append/append_exception.h"
 #include "rhydb/common/lineage_tree.h"
 #include "rhydb/common/phylo_tree.h"
 #include "rhydb/config/preprocessing_config.h"
@@ -486,9 +487,61 @@ TEST(DatabaseInsertQueryTest, rejectsInvalidInsertQueries) {
          ::testing::HasSubstr("insertInto() requires argument 'target'")
       )
    );
+}
 
-   // If the query does not produce every column of the target, the append is rejected.
-   EXPECT_ANY_THROW(
-      database.executeWrite("source.project({key}).insertInto(archive)", defaultQueryOptions())
+// A query that does not produce every column of the target is rejected outright: the target keeps
+// exactly the rows it had, no prefix of the result is inserted.
+TEST(DatabaseInsertQueryTest, insertsNothingWhenAColumnOfTheTargetIsMissing) {
+   rhydb::Database database;
+   database.createTable(TableName{"source"}, makeValueColumnSchema());
+   database.createTable(TableName{"archive"}, makeValueColumnSchema());
+
+   std::stringstream source_data;
+   source_data << R"({"key":"a","country":"CH","age":1})" << "\n"
+               << R"({"key":"b","country":"US","age":2})" << "\n";
+   database.appendData(TableName{"source"}, source_data);
+
+   std::stringstream archive_data;
+   archive_data << R"({"key":"existing","country":"DE","age":9})" << "\n";
+   database.appendData(TableName{"archive"}, archive_data);
+
+   EXPECT_THAT(
+      [&]() {
+         database.executeWrite("source.project({key}).insertInto(archive)", defaultQueryOptions());
+      },
+      ThrowsMessage<rhydb::append::AppendException>(
+         ::testing::HasSubstr("the column 'age' is not contained in the object")
+      )
    );
+
+   // The pre-existing row is untouched and nothing of the rejected query landed.
+   EXPECT_EQ(countInTableWhere(database, "archive", "true"), 1);
+   EXPECT_EQ(countInTableWhere(database, "archive", "key='existing'"), 1);
+}
+
+// The same contract for a result column whose type does not match the target column's type.
+TEST(DatabaseInsertQueryTest, insertsNothingWhenAColumnHasTheWrongType) {
+   rhydb::Database database;
+   database.createTable(TableName{"source"}, makeValueColumnSchema());
+   database.createTable(TableName{"archive"}, makeValueColumnSchema());
+
+   std::stringstream source_data;
+   source_data << R"({"key":"a","country":"CH","age":1})" << "\n";
+   database.appendData(TableName{"source"}, source_data);
+
+   // `age` is an INT32 column in the target, the query hands it a string.
+   EXPECT_THAT(
+      [&]() {
+         database.executeWrite(
+            "source.project({key, country}).map({age := country}).insertInto(archive)",
+            defaultQueryOptions()
+         );
+      },
+      ThrowsMessage<rhydb::append::AppendException>(::testing::AllOf(
+         ::testing::HasSubstr("error inserting into column 'age'"),
+         ::testing::HasSubstr("error getting value as int32")
+      ))
+   );
+
+   EXPECT_EQ(countInTableWhere(database, "archive", "true"), 0);
 }

--- a/src/rhydb/database.test.cpp
+++ b/src/rhydb/database.test.cpp
@@ -298,3 +298,137 @@ TEST(DatabaseTest, canCreateMultipleTablesAndAddData) {
       rhydb::test::executeQueryToJsonArray(query_plan_2), nlohmann::json::array({{{"count", 1}}})
    );
 }
+
+namespace {
+using rhydb::schema::TableName;
+
+// Builds a metadata-only table schema (string primary key + a string and an int32 column). Append
+// queries copy query output back through the NDJSON append path, which round-trips value columns
+// cleanly; sequence columns are intentionally left out (a query emits them as decompressed strings,
+// while the append path ingests them as structured objects).
+std::shared_ptr<TableSchema> makeValueColumnSchema() {
+   const ColumnIdentifier key{.name = "key", .type = ColumnType::STRING};
+   const ColumnIdentifier country{.name = "country", .type = ColumnType::STRING};
+   const ColumnIdentifier age{.name = "age", .type = ColumnType::INT32};
+   std::map<ColumnIdentifier, std::shared_ptr<ColumnMetadata>> column_metadata{
+      {key, std::make_shared<StringColumnMetadata>(key.name)},
+      {country, std::make_shared<StringColumnMetadata>(country.name)},
+      {age, std::make_shared<ColumnMetadata>(age.name)},
+   };
+   return std::make_shared<TableSchema>(std::move(column_metadata), key);
+}
+
+// Runs a count aggregation over `table_name` filtered by `filter` and returns the matched row
+// count.
+int64_t countInTableWhere(
+   rhydb::Database& database,
+   const std::string& table_name,
+   const std::string& filter
+) {
+   auto query_plan = rhydb::query_engine::Planner::planSaneqlQuery(
+      fmt::format("{}.filter({}).groupBy({{count:=count()}})", table_name, filter),
+      database.tables,
+      rhydb::config::QueryOptions{},
+      "count_query"
+   );
+   auto result = rhydb::test::executeQueryToJsonArray(query_plan);
+   if (result.empty()) {
+      return 0;
+   }
+   return result.at(0).at("count").get<int64_t>();
+}
+}  // namespace
+
+TEST(DatabaseInsertQueryTest, copiesFilteredRowsFromOneTableIntoAnother) {
+   rhydb::Database database;
+   database.createTable(TableName{"source"}, makeValueColumnSchema());
+   database.createTable(TableName{"archive"}, makeValueColumnSchema());
+
+   std::stringstream source_data;
+   source_data << R"({"key":"a","country":"CH","age":1})" << "\n"
+               << R"({"key":"b","country":"US","age":2})" << "\n"
+               << R"({"key":"c","country":"CH","age":3})" << "\n";
+   database.appendData(TableName{"source"}, source_data);
+
+   const nlohmann::json result =
+      database.executeWrite("source.filter(country='CH').insertInto(archive)");
+
+   EXPECT_EQ(result.at("insertedRows").get<size_t>(), 2);
+   EXPECT_EQ(countInTableWhere(database, "archive", "true"), 2);
+   EXPECT_EQ(countInTableWhere(database, "archive", "country='CH'"), 2);
+   EXPECT_EQ(countInTableWhere(database, "archive", "country='US'"), 0);
+   EXPECT_EQ(countInTableWhere(database, "archive", "age=1"), 1);
+   EXPECT_EQ(countInTableWhere(database, "archive", "age=3"), 1);
+   // The source table is left unchanged.
+   EXPECT_EQ(countInTableWhere(database, "source", "true"), 3);
+}
+
+TEST(DatabaseInsertQueryTest, reshapesWithProjectAcceptsStringTargetAndAccumulates) {
+   rhydb::Database database;
+   database.createTable(TableName{"source"}, makeValueColumnSchema());
+   // Target keeps only a subset of columns; the query must project down to match it.
+   const ColumnIdentifier key{.name = "key", .type = ColumnType::STRING};
+   const ColumnIdentifier country{.name = "country", .type = ColumnType::STRING};
+   std::map<ColumnIdentifier, std::shared_ptr<ColumnMetadata>> archive_metadata{
+      {key, std::make_shared<StringColumnMetadata>(key.name)},
+      {country, std::make_shared<StringColumnMetadata>(country.name)},
+   };
+   database.createTable(
+      TableName{"archive"}, std::make_shared<TableSchema>(std::move(archive_metadata), key)
+   );
+
+   std::stringstream source_data;
+   source_data << R"({"key":"a","country":"CH","age":1})" << "\n"
+               << R"({"key":"b","country":"US","age":2})" << "\n";
+   database.appendData(TableName{"source"}, source_data);
+
+   // Target named as a string literal; project drops the `age` column the target does not have.
+   const nlohmann::json result =
+      database.executeWrite("source.project({key, country}).insertInto('archive')");
+   EXPECT_EQ(result.at("insertedRows").get<size_t>(), 2);
+   EXPECT_EQ(countInTableWhere(database, "archive", "true"), 2);
+
+   // A second append accumulates on top of the existing rows rather than replacing them.
+   const nlohmann::json result_again = database.executeWrite(
+      "source.filter(country='US').project({key, country}).insertInto(archive)"
+   );
+   EXPECT_EQ(result_again.at("insertedRows").get<size_t>(), 1);
+   EXPECT_EQ(countInTableWhere(database, "archive", "true"), 3);
+}
+
+TEST(DatabaseInsertQueryTest, rejectsInvalidInsertQueries) {
+   rhydb::Database database;
+   database.createTable(TableName{"source"}, makeValueColumnSchema());
+   database.createTable(TableName{"archive"}, makeValueColumnSchema());
+
+   std::stringstream source_data;
+   source_data << R"({"key":"a","country":"CH","age":1})" << "\n";
+   database.appendData(TableName{"source"}, source_data);
+
+   // A plain read query is not a write statement.
+   EXPECT_THAT(
+      [&]() { database.executeWrite("source.filter(country='CH')"); },
+      ThrowsMessage<rhydb::query_engine::IllegalQueryException>(
+         ::testing::HasSubstr("expected a write statement")
+      )
+   );
+
+   // The target table must exist.
+   EXPECT_THAT(
+      [&]() { database.executeWrite("source.insertInto(does_not_exist)"); },
+      ThrowsMessage<rhydb::query_engine::IllegalQueryException>(
+         ::testing::HasSubstr("target table 'does_not_exist' not found")
+      )
+   );
+
+   // insertInto needs both a source and a target.
+   EXPECT_THAT(
+      [&]() { database.executeWrite("insertInto(source)"); },
+      ThrowsMessage<rhydb::query_engine::IllegalQueryException>(
+         ::testing::HasSubstr("insertInto() requires argument 'target'")
+      )
+   );
+
+   // If the query does not produce every column of the target, the append is rejected.
+   EXPECT_ANY_THROW(database.executeWrite("source.project({key}).insertInto(archive)"));
+}

--- a/src/rhydb/query_engine/command/insert_command.cpp
+++ b/src/rhydb/query_engine/command/insert_command.cpp
@@ -53,7 +53,6 @@ nlohmann::json InsertCommand::execute(
       target_table_.getName()
    );
 
-
    auto query_plan =
       Planner::planQuery(std::move(source_query_), database.tables, query_options, "insertInto");
 

--- a/src/rhydb/query_engine/command/insert_command.cpp
+++ b/src/rhydb/query_engine/command/insert_command.cpp
@@ -18,14 +18,16 @@ InsertCommand::InsertCommand(operators::QueryNodePtr source_query, schema::Table
     : source_query_(std::move(source_query)),
       target_table_(std::move(target_table)) {}
 
-nlohmann::json InsertCommand::execute(Database& database) {
+nlohmann::json InsertCommand::execute(
+   Database& database,
+   const config::QueryOptions& query_options
+) {
    // Plan and run the source query, streaming its result rows out as NDJSON. Reusing the NDJSON
    // sink and the existing NDJSON append path keeps a single JSON representation shared by both
    // sides, so every column type that a query can emit and the append path can ingest round-trips
    // without a bespoke Arrow-to-column bridge.
-   auto query_plan = Planner::planQuery(
-      std::move(source_query_), database.tables, config::QueryOptions{}, "insertInto"
-   );
+   auto query_plan =
+      Planner::planQuery(std::move(source_query_), database.tables, query_options, "insertInto");
 
    std::stringstream ndjson_buffer;
    exec_node::NdjsonSink output_sink{&ndjson_buffer, query_plan.results_schema};

--- a/src/rhydb/query_engine/command/insert_command.cpp
+++ b/src/rhydb/query_engine/command/insert_command.cpp
@@ -1,0 +1,43 @@
+#include "rhydb/query_engine/command/insert_command.h"
+
+#include <cstddef>
+#include <sstream>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+#include "rhydb/database.h"
+#include "rhydb/query_engine/exec_node/ndjson_sink.h"
+#include "rhydb/query_engine/planner.h"
+#include "rhydb/query_engine/query_plan.h"
+#include "rhydb/storage/table.h"
+
+namespace rhydb::query_engine::command {
+
+InsertCommand::InsertCommand(operators::QueryNodePtr source_query, schema::TableName target_table)
+    : source_query_(std::move(source_query)),
+      target_table_(std::move(target_table)) {}
+
+nlohmann::json InsertCommand::execute(Database& database) {
+   // Plan and run the source query, streaming its result rows out as NDJSON. Reusing the NDJSON
+   // sink and the existing NDJSON append path keeps a single JSON representation shared by both
+   // sides, so every column type that a query can emit and the append path can ingest round-trips
+   // without a bespoke Arrow-to-column bridge.
+   auto query_plan = Planner::planQuery(
+      std::move(source_query_), database.tables, config::QueryOptions{}, "insertInto"
+   );
+
+   std::stringstream ndjson_buffer;
+   exec_node::NdjsonSink output_sink{&ndjson_buffer, query_plan.results_schema};
+   constexpr uint64_t DEFAULT_TIMEOUT_SECONDS = 120;
+   query_plan.executeAndWrite(output_sink, DEFAULT_TIMEOUT_SECONDS);
+
+   auto& target_table = *database.tables.at(target_table_);
+   const size_t rows_before = target_table.row_layout.numRows();
+   database.appendData(target_table_, ndjson_buffer);
+   const size_t rows_after = target_table.row_layout.numRows();
+
+   return {{"insertedRows", rows_after - rows_before}};
+}
+
+}  // namespace rhydb::query_engine::command

--- a/src/rhydb/query_engine/command/insert_command.cpp
+++ b/src/rhydb/query_engine/command/insert_command.cpp
@@ -47,7 +47,7 @@ nlohmann::json InsertCommand::execute(
    // source must not read the table that is being written
    ScannedTableCollector scanned_tables;
    scanned_tables.collectFrom(source_query_);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       !scanned_tables.scanned_tables.contains(target_table_),
       "insertInto() cannot write into table '{}' while the query reads from it",
       target_table_.getName()

--- a/src/rhydb/query_engine/command/insert_command.cpp
+++ b/src/rhydb/query_engine/command/insert_command.cpp
@@ -1,18 +1,39 @@
 #include "rhydb/query_engine/command/insert_command.h"
 
 #include <cstddef>
-#include <sstream>
+#include <set>
 #include <utility>
 
 #include <nlohmann/json.hpp>
 
 #include "rhydb/database.h"
-#include "rhydb/query_engine/exec_node/ndjson_sink.h"
+#include "rhydb/query_engine/command/table_insert_sink.h"
+#include "rhydb/query_engine/illegal_query_exception.h"
+#include "rhydb/query_engine/operators/table_scan_node.h"
+#include "rhydb/query_engine/optimizer/pipeline_pass_base.h"
 #include "rhydb/query_engine/planner.h"
 #include "rhydb/query_engine/query_plan.h"
 #include "rhydb/storage/table.h"
 
 namespace rhydb::query_engine::command {
+
+namespace {
+
+class ScannedTableCollector : public optimizer::PipelinePassBase<ScannedTableCollector> {
+  public:
+   using PipelinePassBase<ScannedTableCollector>::operator();
+
+   std::set<schema::TableName> scanned_tables;
+
+   operators::QueryNodePtr operator()(operators::TableScanNode& node) {
+      scanned_tables.insert(node.table->table_name);
+      return nullptr;
+   }
+
+   void collectFrom(operators::QueryNodePtr& node) { propagateToNode(node); }
+};
+
+}  // namespace
 
 InsertCommand::InsertCommand(operators::QueryNodePtr source_query, schema::TableName target_table)
     : source_query_(std::move(source_query)),
@@ -22,22 +43,29 @@ nlohmann::json InsertCommand::execute(
    Database& database,
    const config::QueryOptions& query_options
 ) {
-   // Plan and run the source query, streaming its result rows out as NDJSON. Reusing the NDJSON
-   // sink and the existing NDJSON append path keeps a single JSON representation shared by both
-   // sides, so every column type that a query can emit and the append path can ingest round-trips
-   // without a bespoke Arrow-to-column bridge.
+   // Inserting streams into the target table while the source query is still producing, so the
+   // source must not read the table that is being written
+   ScannedTableCollector scanned_tables;
+   scanned_tables.collectFrom(source_query_);
+   CHECK_SILO_QUERY(
+      !scanned_tables.scanned_tables.contains(target_table_),
+      "insertInto() cannot write into table '{}' while the query reads from it",
+      target_table_.getName()
+   );
+
+
    auto query_plan =
       Planner::planQuery(std::move(source_query_), database.tables, query_options, "insertInto");
 
-   std::stringstream ndjson_buffer;
-   exec_node::NdjsonSink output_sink{&ndjson_buffer, query_plan.results_schema};
+   auto target_table = database.tables.at(target_table_);
+   const size_t rows_before = target_table->row_layout.numRows();
+
+   TableInsertSink output_sink{target_table, query_plan.results_schema};
    constexpr uint64_t DEFAULT_TIMEOUT_SECONDS = 120;
    query_plan.executeAndWrite(output_sink, DEFAULT_TIMEOUT_SECONDS);
 
-   auto& target_table = *database.tables.at(target_table_);
-   const size_t rows_before = target_table.row_layout.numRows();
-   database.appendData(target_table_, ndjson_buffer);
-   const size_t rows_after = target_table.row_layout.numRows();
+   const size_t rows_after = target_table->row_layout.numRows();
+   database.updateDataVersion();
 
    return {{"insertedRows", rows_after - rows_before}};
 }

--- a/src/rhydb/query_engine/command/insert_command.cpp
+++ b/src/rhydb/query_engine/command/insert_command.cpp
@@ -41,7 +41,8 @@ InsertCommand::InsertCommand(operators::QueryNodePtr source_query, schema::Table
 
 nlohmann::json InsertCommand::execute(
    Database& database,
-   const config::QueryOptions& query_options
+   const config::QueryOptions& query_options,
+   std::string_view request_id
 ) {
    // Inserting streams into the target table while the source query is still producing, so the
    // source must not read the table that is being written
@@ -54,7 +55,7 @@ nlohmann::json InsertCommand::execute(
    );
 
    auto query_plan =
-      Planner::planQuery(std::move(source_query_), database.tables, query_options, "insertInto");
+      Planner::planQuery(std::move(source_query_), database.tables, query_options, request_id);
 
    auto target_table = database.tables.at(target_table_);
    const size_t rows_before = target_table->row_layout.numRows();

--- a/src/rhydb/query_engine/command/insert_command.h
+++ b/src/rhydb/query_engine/command/insert_command.h
@@ -13,7 +13,7 @@ class Database;
 
 namespace rhydb::query_engine::command {
 
-/// `<query>.insertInto(<targetTable>)`: runs the wrapped source query and inserts its result rows
+/// `<query>.insertInto(<table>)`: runs the wrapped source query and inserts its result rows
 /// into the target table. The source query's output columns are matched to the target's columns by
 /// name.
 class InsertCommand : public WriteCommand {

--- a/src/rhydb/query_engine/command/insert_command.h
+++ b/src/rhydb/query_engine/command/insert_command.h
@@ -25,7 +25,8 @@ class InsertCommand : public WriteCommand {
 
    [[nodiscard]] nlohmann::json execute(
       Database& database,
-      const config::QueryOptions& query_options
+      const config::QueryOptions& query_options,
+      std::string_view request_id
    ) override;
 };
 

--- a/src/rhydb/query_engine/command/insert_command.h
+++ b/src/rhydb/query_engine/command/insert_command.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+#include "rhydb/query_engine/command/write_command.h"
+#include "rhydb/query_engine/operators/query_node.h"
+#include "rhydb/schema/database_schema.h"
+
+namespace rhydb {
+class Database;
+}
+
+namespace rhydb::query_engine::command {
+
+/// `<query>.insertInto(<targetTable>)`: runs the wrapped source query and inserts its result rows
+/// into the target table. The source query's output columns are matched to the target's columns by
+/// name.
+class InsertCommand : public WriteCommand {
+   operators::QueryNodePtr source_query_;
+   schema::TableName target_table_;
+
+  public:
+   InsertCommand(operators::QueryNodePtr source_query, schema::TableName target_table);
+
+   [[nodiscard]] nlohmann::json execute(Database& database) override;
+};
+
+}  // namespace rhydb::query_engine::command

--- a/src/rhydb/query_engine/command/insert_command.h
+++ b/src/rhydb/query_engine/command/insert_command.h
@@ -2,6 +2,7 @@
 
 #include <nlohmann/json_fwd.hpp>
 
+#include "rhydb/config/runtime_config.h"
 #include "rhydb/query_engine/command/write_command.h"
 #include "rhydb/query_engine/operators/query_node.h"
 #include "rhydb/schema/database_schema.h"
@@ -22,7 +23,10 @@ class InsertCommand : public WriteCommand {
   public:
    InsertCommand(operators::QueryNodePtr source_query, schema::TableName target_table);
 
-   [[nodiscard]] nlohmann::json execute(Database& database) override;
+   [[nodiscard]] nlohmann::json execute(
+      Database& database,
+      const config::QueryOptions& query_options
+   ) override;
 };
 
 }  // namespace rhydb::query_engine::command

--- a/src/rhydb/query_engine/command/table_insert_sink.cpp
+++ b/src/rhydb/query_engine/command/table_insert_sink.cpp
@@ -1,0 +1,35 @@
+#include "rhydb/query_engine/command/table_insert_sink.h"
+
+#include <string>
+#include <utility>
+
+#include "rhydb/append/ndjson_line_reader.h"
+
+namespace rhydb::query_engine::command {
+
+TableInsertSink::TableInsertSink(
+   std::shared_ptr<storage::Table> target_table,
+   std::shared_ptr<arrow::Schema> results_schema
+)
+    : ndjson_sink(&batch_buffer, std::move(results_schema)),
+      table_inserter(std::move(target_table)),
+      insert_stream(table_inserter) {}
+
+arrow::Status TableInsertSink::writeBatch(const arrow::compute::ExecBatch& batch) {
+   batch_buffer.str(std::string{});
+   batch_buffer.clear();
+
+   ARROW_RETURN_NOT_OK(ndjson_sink.writeBatch(batch));
+
+   append::NdjsonLineReader batch_lines{batch_buffer};
+   insert_stream.insertAll(batch_lines);
+   return arrow::Status::OK();
+}
+
+arrow::Status TableInsertSink::finish() {
+   ARROW_RETURN_NOT_OK(ndjson_sink.finish());
+   [[maybe_unused]] const auto commit = table_inserter.commit();
+   return arrow::Status::OK();
+}
+
+}  // namespace rhydb::query_engine::command

--- a/src/rhydb/query_engine/command/table_insert_sink.h
+++ b/src/rhydb/query_engine/command/table_insert_sink.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <memory>
+#include <sstream>
+
+#include <arrow/type_fwd.h>
+
+#include "rhydb/append/table_inserter.h"
+#include "rhydb/query_engine/exec_node/arrow_batch_sink.h"
+#include "rhydb/query_engine/exec_node/ndjson_sink.h"
+#include "rhydb/storage/table.h"
+
+namespace rhydb::query_engine::command {
+
+/// Query result sink that inserts the rows it receives into a table as they arrive: every batch is
+/// serialized to NDJSON and handed to the append path right away, so only one batch is held in
+/// memory instead of the whole result. Reusing the NDJSON representation keeps a single JSON
+/// representation shared by the query and append sides, so every column type that a query can emit
+/// and the append path can ingest round-trips without a bespoke Arrow-to-column bridge.
+///
+/// The rows become visible in the table when `finish()` commits them, which the query plan calls
+/// once all batches have been written. A batch that cannot be inserted (e.g. a missing target
+/// column) throws an AppendException out of `writeBatch`, leaving the insert uncommitted.
+class TableInsertSink : public exec_node::ArrowBatchSink {
+   std::stringstream batch_buffer;
+   exec_node::NdjsonSink ndjson_sink;
+   append::TableInserter table_inserter;
+   append::NdjsonInsertStream insert_stream;
+
+  public:
+   TableInsertSink(
+      std::shared_ptr<storage::Table> target_table,
+      std::shared_ptr<arrow::Schema> results_schema
+   );
+
+   arrow::Status writeBatch(const arrow::compute::ExecBatch& batch) override;
+
+   arrow::Status finish() override;
+};
+
+}  // namespace rhydb::query_engine::command

--- a/src/rhydb/query_engine/command/write_command.cpp
+++ b/src/rhydb/query_engine/command/write_command.cpp
@@ -30,7 +30,7 @@ WriteCommandPtr buildInsertInto(
                                       ? saneql::ast::extractStringLiteral(target_expr)
                                       : saneql::ast::extractIdentifierName(target_expr);
    auto target_table = schema::TableName(target_name);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       tables.contains(target_table),
       "insertInto() target table '{}' not found in database",
       target_name

--- a/src/rhydb/query_engine/command/write_command.cpp
+++ b/src/rhydb/query_engine/command/write_command.cpp
@@ -1,0 +1,97 @@
+#include "rhydb/query_engine/command/write_command.h"
+
+#include <utility>
+#include <variant>
+
+#include "rhydb/query_engine/command/insert_command.h"
+#include "rhydb/query_engine/illegal_query_exception.h"
+#include "rhydb/query_engine/saneql/ast.h"
+#include "rhydb/query_engine/saneql/ast_to_query.h"
+#include "rhydb/query_engine/saneql/parser.h"
+
+namespace rhydb::query_engine::command {
+
+using saneql::BoundArguments;
+using saneql::ChildConverter;
+using saneql::FunctionSignature;
+using saneql::ParameterDefinition;
+using saneql::Tables;
+
+namespace {
+
+WriteCommandPtr buildInsertInto(
+   const BoundArguments& args,
+   const Tables& tables,
+   const ChildConverter& convert_child
+) {
+   const auto& target_expr = args.at("target");
+   // The target may be a bare identifier (`archive`) or a string literal (`'archive'`).
+   const std::string target_name = saneql::ast::isStringLiteral(target_expr)
+                                      ? saneql::ast::extractStringLiteral(target_expr)
+                                      : saneql::ast::extractIdentifierName(target_expr);
+   auto target_table = schema::TableName(target_name);
+   CHECK_SILO_QUERY(
+      tables.contains(target_table),
+      "insertInto() target table '{}' not found in database",
+      target_name
+   );
+   auto source_query = convert_child(args.at("input"), tables);
+   return std::make_unique<InsertCommand>(std::move(source_query), std::move(target_table));
+}
+
+}  // namespace
+
+WriteStatementRegistry::WriteStatementRegistry() {
+   registerStatement(
+      "insertInto",
+      FunctionSignature{
+         {ParameterDefinition{.name = "input"}, ParameterDefinition{.name = "target"}}
+      },
+      buildInsertInto
+   );
+}
+
+void WriteStatementRegistry::registerStatement(
+   std::string name,
+   FunctionSignature signature,
+   WriteStatementHandler handler
+) {
+   entries_[std::move(name)] =
+      Entry{.signature = std::move(signature), .handler = std::move(handler)};
+}
+
+const WriteStatementRegistry::Entry* WriteStatementRegistry::findStatement(const std::string& name
+) const {
+   auto it = entries_.find(name);
+   if (it == entries_.end()) {
+      return nullptr;
+   }
+   return &it->second;
+}
+
+WriteStatementRegistry& WriteStatementRegistry::instance() {
+   static WriteStatementRegistry registry;
+   return registry;
+}
+
+Request parseRequest(std::string_view query_string, const Tables& tables) {
+   saneql::Parser parser(query_string);
+   auto ast = parser.parse();
+
+   // A write statement is a root function call whose name is registered as a write statement;
+   // anything else is an ordinary read query and goes through the unchanged read conversion path.
+   if (std::holds_alternative<saneql::ast::FunctionCall>(ast->value)) {
+      const auto& call = std::get<saneql::ast::FunctionCall>(ast->value);
+      if (const auto* entry =
+             WriteStatementRegistry::instance().findStatement(call.function_name)) {
+         auto bound = saneql::bindArguments(
+            call.function_name, entry->signature, call.positional_arguments, call.named_arguments
+         );
+         return entry->handler(bound, tables, saneql::convertExpression);
+      }
+   }
+
+   return saneql::convertToQueryTree(*ast, tables);
+}
+
+}  // namespace rhydb::query_engine::command

--- a/src/rhydb/query_engine/command/write_command.h
+++ b/src/rhydb/query_engine/command/write_command.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <variant>
+
+#include <nlohmann/json_fwd.hpp>
+
+#include "rhydb/query_engine/operators/query_node.h"
+#include "rhydb/query_engine/saneql/function_registry.h"
+
+namespace rhydb {
+class Database;
+}
+
+namespace rhydb::query_engine::command {
+
+class WriteCommand {
+  public:
+   virtual ~WriteCommand() = default;
+
+   /// Applies the command to `database`, mutating it, and returns a JSON summary of the effect
+   /// (e.g. `{"insertedRows": 42}`). Consuming: a command is executed at most once.
+   [[nodiscard]] virtual nlohmann::json execute(Database& database) = 0;
+};
+
+using WriteCommandPtr = std::unique_ptr<WriteCommand>;
+
+using Request = std::variant<operators::QueryNodePtr, WriteCommandPtr>;
+
+using WriteStatementHandler = std::function<WriteCommandPtr(
+   const saneql::BoundArguments& args,
+   const saneql::Tables& tables,
+   const saneql::ChildConverter& convert_child
+)>;
+
+class WriteStatementRegistry {
+  public:
+   struct Entry {
+      saneql::FunctionSignature signature;
+      WriteStatementHandler handler;
+   };
+
+   WriteStatementRegistry();
+
+   void registerStatement(
+      std::string name,
+      saneql::FunctionSignature signature,
+      WriteStatementHandler handler
+   );
+
+   [[nodiscard]] const Entry* findStatement(const std::string& name) const;
+
+   [[nodiscard]] static WriteStatementRegistry& instance();
+
+  private:
+   std::map<std::string, Entry> entries_;
+};
+
+/// Parses `query_string` and classifies it: if its root names a registered write statement, returns
+/// the built WriteCommand; otherwise converts it to a read QueryNode tree. Throws
+/// IllegalQueryException / ParseException for malformed input
+Request parseRequest(std::string_view query_string, const saneql::Tables& tables);
+
+}  // namespace rhydb::query_engine::command

--- a/src/rhydb/query_engine/command/write_command.h
+++ b/src/rhydb/query_engine/command/write_command.h
@@ -9,6 +9,7 @@
 
 #include <nlohmann/json_fwd.hpp>
 
+#include "rhydb/config/runtime_config.h"
 #include "rhydb/query_engine/operators/query_node.h"
 #include "rhydb/query_engine/saneql/function_registry.h"
 
@@ -23,8 +24,13 @@ class WriteCommand {
    virtual ~WriteCommand() = default;
 
    /// Applies the command to `database`, mutating it, and returns a JSON summary of the effect
-   /// (e.g. `{"insertedRows": 42}`). Consuming: a command is executed at most once.
-   [[nodiscard]] virtual nlohmann::json execute(Database& database) = 0;
+   /// (e.g. `{"insertedRows": 42}`). Consuming: a command is executed at most once. `query_options`
+   /// are the same options that the read endpoint uses, so a command that plans a query executes it
+   /// with the configured materialization behaviour.
+   [[nodiscard]] virtual nlohmann::json execute(
+      Database& database,
+      const config::QueryOptions& query_options
+   ) = 0;
 };
 
 using WriteCommandPtr = std::unique_ptr<WriteCommand>;

--- a/src/rhydb/query_engine/command/write_command.h
+++ b/src/rhydb/query_engine/command/write_command.h
@@ -29,7 +29,8 @@ class WriteCommand {
    /// with the configured materialization behaviour.
    [[nodiscard]] virtual nlohmann::json execute(
       Database& database,
-      const config::QueryOptions& query_options
+      const config::QueryOptions& query_options,
+      std::string_view request_id
    ) = 0;
 };
 

--- a/testBaseData/test_runtime_config.yaml
+++ b/testBaseData/test_runtime_config.yaml
@@ -1,3 +1,4 @@
 dataDirectory: "test/directory"
 api:
     port: 1234
+    allowAdminEndpoint: true


### PR DESCRIPTION
This adds the functionality to add values to existing tables. This SaneQL interface should also be used by `createTable`, `dropTable`, `delete` and `update` statements in the future