### PR TITLE
feat(query_engine): disallow `column = null` filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,3 +86,13 @@ resolves #1221
 ```
 
 **Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+**Breaking changes:** add a `BREAKING CHANGE:` footer describing the impact and migration. release-please shows the footer text verbatim in the changelog. Since PRs are squash-merged, put the marker in the PR title and the footer at the bottom of the PR description.
+
+```
+feat(query_engine): disallow `... = null` filters
+
+resolves #1503
+
+BREAKING CHANGE: `column = null` filters now error. Use `column.isNull()` instead.
+```

--- a/documentation/python_bindings.md
+++ b/documentation/python_bindings.md
@@ -201,7 +201,7 @@ with Database("path/to/silo-dir") as db:
 
     # Verify via a query
     remaining = len(db.get_filtered_bitmap("default", "age = 4"))
-    cleared = len(db.get_filtered_bitmap("default", "age = null"))
+    cleared = len(db.get_filtered_bitmap("default", "age.isNull()"))
     assert remaining == 0
     assert cleared >= before
 

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -80,7 +80,7 @@ Examples:
 country = 'Germany'
 age > 30
 date <= '2021-12-31'::date
-qc_value <> null
+!qc_value.isNull()
 ```
 
 ### Method Call Syntax

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -70,6 +70,7 @@ default
 Notes:
 - One side must be a column identifier; the other a literal value. For ordering
   operators the column may be on either side (`age > 30` equals `30 < age`).
+- The literal operand must **not** be `null`; use `isNull()` or `isNotNull()` instead.
 - Ordering operators are **not** supported for boolean columns, and comparisons
   **exclude** null values (a null cell never matches an ordering comparison).
 - String ordering is lexicographic and applies to both plain and

--- a/python/tests/test_database.py
+++ b/python/tests/test_database.py
@@ -855,11 +855,11 @@ class TestUpdateColumn:
     def test_update_string_column_clears_rows_to_null(self, main_reference_sequence):
         """The literal 'null' clears the matched rows of a string column."""
         db = self._database_with_string_column(main_reference_sequence)
-        assert self._count(db, "country = null") == 0
+        assert self._count(db, "country.isNull()") == 0
 
         db.update_column("sequences", "country", "null", "primary_key = 'key_29'")
 
-        assert self._count(db, "country = null") == 1
+        assert self._count(db, "country.isNull()") == 1
 
     def test_update_string_column_type_mismatch_raises(self, main_reference_sequence):
         """A non-string literal is rejected for a string column."""
@@ -933,13 +933,13 @@ class TestUpdateColumnOnLoadedDatabase:
     def test_update_column_clears_rows_to_null(self, loaded_database):
         """The literal 'null' clears the matched rows."""
         matching = self._count(loaded_database, "age = 4")
-        nulls_before = self._count(loaded_database, "age = null")
+        nulls_before = self._count(loaded_database, "age.isNull()")
         assert matching > 0
 
         loaded_database.update_column("default", "age", "null", "age = 4")
 
         assert self._count(loaded_database, "age = 4") == 0
-        assert self._count(loaded_database, "age = null") == nulls_before + matching
+        assert self._count(loaded_database, "age.isNull()") == nulls_before + matching
 
     def test_update_does_not_persist_to_disk(self, loaded_database):
         """Updating the in-memory database must not modify the on-disk repo state."""

--- a/src/rhydb/database.test.cpp
+++ b/src/rhydb/database.test.cpp
@@ -164,7 +164,7 @@ TEST(DatabaseTest, updateColumnAssignsScalarValueToMatchingRows) {
    // A SaneQL `null` literal clears the matched rows back to null.
    database->updateColumn(table, "age", "null", "primaryKey = 'key3'");
    ASSERT_EQ(countWhere(*database, "age = 7"), 0);
-   ASSERT_EQ(countWhere(*database, "age = null"), 1);
+   ASSERT_EQ(countWhere(*database, "age.isNull()"), 1);
 
    // Bool values are parsed as the boolean literals 'true'/'false'.
    database->updateColumn(table, "test_boolean_column", "false", "true");
@@ -188,9 +188,9 @@ TEST(DatabaseTest, updateColumnAssignsScalarValueToMatchingRows) {
    // A SaneQL `null` literal clears an indexed string back to null, and a concrete value can be set
    // again afterwards.
    database->updateColumn(table, "division", "null", "primaryKey = 'key1'");
-   ASSERT_EQ(countWhere(*database, "division = null"), 1);
+   ASSERT_EQ(countWhere(*database, "division.isNull()"), 1);
    database->updateColumn(table, "division", "'Basel'", "primaryKey = 'key1'");
-   ASSERT_EQ(countWhere(*database, "division = null"), 0);
+   ASSERT_EQ(countWhere(*database, "division.isNull()"), 0);
    ASSERT_EQ(countWhere(*database, "division = 'Basel'"), 1);
 }
 

--- a/src/rhydb/query_engine/saneql/ast_to_query.cpp
+++ b/src/rhydb/query_engine/saneql/ast_to_query.cpp
@@ -203,10 +203,6 @@ ScalarExpressionPtr convertEqualsToFilter(
    const ast::Expression& value_expr,
    const std::vector<schema::ColumnIdentifier>& schema
 ) {
-   if (isNullLiteral(value_expr)) {
-      return std::make_unique<scalar_expressions::IsNull>(resolveColumn(column_name, schema));
-   }
-
    // Build the value operand first so parse-time value errors (e.g. an invalid date
    // literal or an unsupported value type) are reported before the column is resolved.
    auto value = convertToScalar(value_expr, schema, "the value in an equality");

--- a/src/rhydb/query_engine/scalar_expressions/date_equals.test.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/date_equals.test.cpp
@@ -108,22 +108,22 @@ const QueryTestScenario UNSORTED_DATE_SINGLE_MATCH =
        {{"primaryKey", "row2"}, {"sorted_date", DATE_2021}, {"unsorted_date", DATE_2020}},
     }};
 
-// Matches null1 and null2 (both have sorted_date = null)
-const QueryTestScenario SORTED_DATE_NULL =
-   {.name = "SORTED_DATE_NULL",
-    .query = createDateEqualsNullQuery("sorted_date"),
-    .expected_query_result = {
-       {{"primaryKey", "null1"}, {"sorted_date", nullptr}, {"unsorted_date", nullptr}},
-       {{"primaryKey", "null2"}, {"sorted_date", nullptr}, {"unsorted_date", DATE_2023}},
-    }};
+// `... = null` is rejected; users must use isNull()
+const QueryTestScenario SORTED_DATE_NULL_REJECTED = {
+   .name = "SORTED_DATE_NULL_REJECTED",
+   .query = createDateEqualsNullQuery("sorted_date"),
+   .expected_error_message =
+      "the value in an equality must be a literal value (int, float, string, bool, or date), a "
+      "column reference, or a scalar function call at 1:30"
+};
 
-// Matches only null1 (unsorted_date = null)
-const QueryTestScenario UNSORTED_DATE_NULL =
-   {.name = "UNSORTED_DATE_NULL",
-    .query = createDateEqualsNullQuery("unsorted_date"),
-    .expected_query_result = {
-       {{"primaryKey", "null1"}, {"sorted_date", nullptr}, {"unsorted_date", nullptr}},
-    }};
+const QueryTestScenario UNSORTED_DATE_NULL_REJECTED = {
+   .name = "UNSORTED_DATE_NULL_REJECTED",
+   .query = createDateEqualsNullQuery("unsorted_date"),
+   .expected_error_message =
+      "the value in an equality must be a literal value (int, float, string, bool, or date), a "
+      "column reference, or a scalar function call at 1:32"
+};
 
 const QueryTestScenario DATE_EQUALS_NO_MATCH = {
    .name = "DATE_EQUALS_NO_MATCH",
@@ -168,8 +168,8 @@ QUERY_TEST(
       SORTED_DATE_SINGLE_MATCH,
       UNSORTED_DATE_MULTIPLE_MATCHES,
       UNSORTED_DATE_SINGLE_MATCH,
-      SORTED_DATE_NULL,
-      UNSORTED_DATE_NULL,
+      SORTED_DATE_NULL_REJECTED,
+      UNSORTED_DATE_NULL_REJECTED,
       DATE_EQUALS_NO_MATCH,
       DATE_EQUALS_WRONG_FORMAT,
       DATE_EQUALS_WRONG_VALUE_TYPE,

--- a/src/rhydb/query_engine/scalar_expressions/float_equals.test.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/float_equals.test.cpp
@@ -77,21 +77,20 @@ const QueryTestScenario NEGATED_FLOAT_EQUALS_VALUE_SCENARIO = {
    )
 };
 
-const QueryTestScenario FLOAT_EQUALS_NULL_SCENARIO = {
-   .name = "FLOAT_EQUALS_NULL_SCENARIO",
+const QueryTestScenario FLOAT_EQUALS_NULL_REJECTED_SCENARIO = {
+   .name = "FLOAT_EQUALS_NULL_REJECTED_SCENARIO",
    .query = "default.filter(float_value = null).project({primaryKey, float_value})",
-   .expected_query_result = nlohmann::json({{{"primaryKey", "id_4"}, {"float_value", nullptr}}})
+   .expected_error_message =
+      "the value in an equality must be a literal value (int, float, string, bool, or date), a "
+      "column reference, or a scalar function call at 1:30"
 };
 
-const QueryTestScenario NEGATED_FLOAT_EQUALS_NULL_SCENARIO = {
-   .name = "NEGATED_FLOAT_EQUALS_NULL_SCENARIO",
+const QueryTestScenario NEGATED_FLOAT_EQUALS_NULL_REJECTED_SCENARIO = {
+   .name = "NEGATED_FLOAT_EQUALS_NULL_REJECTED_SCENARIO",
    .query = "default.filter(!(float_value = null)).project({primaryKey, float_value})",
-   .expected_query_result = nlohmann::json(
-      {{{"primaryKey", "id_0"}, {"float_value", 1.23}},
-       {{"primaryKey", "id_1"}, {"float_value", 1.23}},
-       {{"primaryKey", "id_2"}, {"float_value", 0.345}},
-       {{"primaryKey", "id_3"}, {"float_value", 2.345}}}
-   )
+   .expected_error_message =
+      "the value in an equality must be a literal value (int, float, string, bool, or date), a "
+      "column reference, or a scalar function call at 1:32"
 };
 
 const QueryTestScenario FLOAT_EQUALS_WITH_INVALID_VALUE = {
@@ -108,8 +107,8 @@ QUERY_TEST(
    ::testing::Values(
       FLOAT_EQUALS_VALUE_SCENARIO,
       NEGATED_FLOAT_EQUALS_VALUE_SCENARIO,
-      FLOAT_EQUALS_NULL_SCENARIO,
-      NEGATED_FLOAT_EQUALS_NULL_SCENARIO,
+      FLOAT_EQUALS_NULL_REJECTED_SCENARIO,
+      NEGATED_FLOAT_EQUALS_NULL_REJECTED_SCENARIO,
       FLOAT_EQUALS_WITH_INVALID_VALUE
    )
 );

--- a/src/rhydb/query_engine/scalar_expressions/int64_query.test.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/int64_query.test.cpp
@@ -97,10 +97,12 @@ const QueryTestScenario INT64_BETWEEN_SCENARIO = {
       nlohmann::json({row("id_0", VALUE_IN_FILTER), row("id_1", VALUE_IN_FILTER)})
 };
 
-const QueryTestScenario INT64_EQUALS_NULL_SCENARIO = {
-   .name = "INT64_EQUALS_NULL_SCENARIO",
+const QueryTestScenario INT64_EQUALS_NULL_REJECTED_SCENARIO = {
+   .name = "INT64_EQUALS_NULL_REJECTED_SCENARIO",
    .query = "default.filter(int64_value = null)",
-   .expected_query_result = nlohmann::json::array({row("id_4", nullptr)})
+   .expected_error_message =
+      "the value in an equality must be a literal value (int, float, string, bool, or date), a "
+      "column reference, or a scalar function call at 1:30"
 };
 
 const QueryTestScenario INT64_NEGATED_EQUALS_SCENARIO = {
@@ -134,7 +136,7 @@ QUERY_TEST(
       INT64_EQUALS_VALUE_SCENARIO,
       INT64_GREATER_EQUAL_SCENARIO,
       INT64_BETWEEN_SCENARIO,
-      INT64_EQUALS_NULL_SCENARIO,
+      INT64_EQUALS_NULL_REJECTED_SCENARIO,
       INT64_NEGATED_EQUALS_SCENARIO,
       INT64_EQUALS_INT32_RANGE_VALUE_SCENARIO,
       INT64_EQUALS_FUNCTION_CALL_VALUE_SCENARIO

--- a/src/rhydb/query_engine/scalar_expressions/int_equals.test.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/int_equals.test.cpp
@@ -101,43 +101,20 @@ const QueryTestScenario NEGATED_INT_EQUALS_VALUE_SCENARIO = {
    )
 };
 
-const QueryTestScenario INT_EQUALS_NULL_SCENARIO = {
-   .name = "INT_EQUALS_NULL_SCENARIO",
+const QueryTestScenario INT_EQUALS_NULL_REJECTED_SCENARIO = {
+   .name = "INT_EQUALS_NULL_REJECTED_SCENARIO",
    .query = "default.filter(int_value = null)",
-   .expected_query_result = nlohmann::json(
-      {{{"primaryKey", "id_4"},
-        {"int_value", nullptr},
-        {"segment1", nullptr},
-        {"gene1", nullptr},
-        {"unaligned_segment1", nullptr}}}
-   )
+   .expected_error_message =
+      "the value in an equality must be a literal value (int, float, string, bool, or date), a "
+      "column reference, or a scalar function call at 1:28"
 };
 
-const QueryTestScenario NEGATED_INT_EQUALS_NULL_SCENARIO = {
-   .name = "NEGATED_INT_EQUALS_NULL_SCENARIO",
+const QueryTestScenario NEGATED_INT_EQUALS_NULL_REJECTED_SCENARIO = {
+   .name = "NEGATED_INT_EQUALS_NULL_REJECTED_SCENARIO",
    .query = "default.filter(!(int_value = null))",
-   .expected_query_result = nlohmann::json(
-      {{{"primaryKey", "id_0"},
-        {"int_value", VALUE_IN_FILTER},
-        {"segment1", nullptr},
-        {"gene1", nullptr},
-        {"unaligned_segment1", nullptr}},
-       {{"primaryKey", "id_1"},
-        {"int_value", VALUE_IN_FILTER},
-        {"segment1", nullptr},
-        {"gene1", nullptr},
-        {"unaligned_segment1", nullptr}},
-       {{"primaryKey", "id_2"},
-        {"int_value", VALUE_BELOW_FILTER},
-        {"segment1", nullptr},
-        {"gene1", nullptr},
-        {"unaligned_segment1", nullptr}},
-       {{"primaryKey", "id_3"},
-        {"int_value", VALUE_ABOVE_FILTER},
-        {"segment1", nullptr},
-        {"gene1", nullptr},
-        {"unaligned_segment1", nullptr}}}
-   )
+   .expected_error_message =
+      "the value in an equality must be a literal value (int, float, string, bool, or date), a "
+      "column reference, or a scalar function call at 1:30"
 };
 
 const QueryTestScenario INT_EQUALS_WITH_OVERFLOW = {
@@ -166,8 +143,8 @@ QUERY_TEST(
    ::testing::Values(
       INT_EQUALS_VALUE_SCENARIO,
       NEGATED_INT_EQUALS_VALUE_SCENARIO,
-      INT_EQUALS_NULL_SCENARIO,
-      NEGATED_INT_EQUALS_NULL_SCENARIO,
+      INT_EQUALS_NULL_REJECTED_SCENARIO,
+      NEGATED_INT_EQUALS_NULL_REJECTED_SCENARIO,
       INT_EQUALS_WITH_OVERFLOW,
       INT_COMPARISON_WITH_OVERFLOW,
       INT_BETWEEN_WITH_OVERFLOW

--- a/src/rhydb/query_engine/scalar_expressions/int_equals.test.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/int_equals.test.cpp
@@ -117,6 +117,14 @@ const QueryTestScenario NEGATED_INT_EQUALS_NULL_REJECTED_SCENARIO = {
       "column reference, or a scalar function call at 1:30"
 };
 
+const QueryTestScenario INT_NOT_EQUALS_NULL_REJECTED_SCENARIO = {
+   .name = "INT_NOT_EQUALS_NULL_REJECTED_SCENARIO",
+   .query = "default.filter(int_value <> null)",
+   .expected_error_message =
+      "the value in an equality must be a literal value (int, float, string, bool, or date), a "
+      "column reference, or a scalar function call at 1:29"
+};
+
 const QueryTestScenario INT_EQUALS_WITH_OVERFLOW = {
    .name = "INT_EQUALS_WITH_OVERFLOW",
    .query = "default.filter(int_value = 4294967295)",
@@ -145,6 +153,7 @@ QUERY_TEST(
       NEGATED_INT_EQUALS_VALUE_SCENARIO,
       INT_EQUALS_NULL_REJECTED_SCENARIO,
       NEGATED_INT_EQUALS_NULL_REJECTED_SCENARIO,
+      INT_NOT_EQUALS_NULL_REJECTED_SCENARIO,
       INT_EQUALS_WITH_OVERFLOW,
       INT_COMPARISON_WITH_OVERFLOW,
       INT_BETWEEN_WITH_OVERFLOW

--- a/src/rhydb/query_engine/scalar_expressions/is_null.test.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/is_null.test.cpp
@@ -1,3 +1,5 @@
+#include <cstdint>
+
 #include <nlohmann/json.hpp>
 
 #include "rhydb/test/query_fixture.test.h"
@@ -12,6 +14,7 @@ nlohmann::json createData(
    const std::optional<std::string>& string_field,
    const std::optional<std::string>& dictionary_encoded_string_field,
    const std::optional<int>& int_field,
+   const std::optional<int64_t>& int64_field,
    const std::optional<double>& float_field,
    const std::optional<bool>& bool_field,
    const std::optional<std::string>& date_field
@@ -26,6 +29,8 @@ nlohmann::json createData(
          : nlohmann::json(nullptr);
    result["intField"] =
       int_field.has_value() ? nlohmann::json(int_field.value()) : nlohmann::json(nullptr);
+   result["int64Field"] =
+      int64_field.has_value() ? nlohmann::json(int64_field.value()) : nlohmann::json(nullptr);
    result["floatField"] =
       float_field.has_value() ? nlohmann::json(float_field.value()) : nlohmann::json(nullptr);
    result["boolField"] =
@@ -49,6 +54,8 @@ schema:
      generateIndex: true
    - name: "intField"
      type: "int"
+   - name: "int64Field"
+     type: "int64"
    - name: "floatField"
      type: "float"
    - name: "boolField"
@@ -63,15 +70,52 @@ const auto REFERENCE_GENOMES = ReferenceGenomes{{}, {}};
 const QueryTestData TEST_DATA{
    .ndjson_input_data =
       {
-         createData("id_0", "value1", "indexed1", 10, 1.5, true, "2024-01-01"),
-         createData("id_1", std::nullopt, "indexed2", 20, 2.5, false, "2024-01-02"),
-         createData("id_2", "value2", std::nullopt, 30, 3.5, true, "2024-01-03"),
-         createData("id_3", "value3", "indexed3", std::nullopt, 4.5, false, "2024-01-04"),
-         createData("id_4", "value4", "indexed4", 50, std::nullopt, true, "2024-01-05"),
-         createData("id_5", "value5", "indexed5", 60, 6.5, std::nullopt, "2024-01-06"),
-         createData("id_6", "value6", "indexed6", 70, 7.5, false, std::nullopt),
+         createData("id_0", "value1", "indexed1", 10, std::nullopt, 1.5, true, "2024-01-01"),
+         createData(
+            "id_1",
+            std::nullopt,
+            "indexed2",
+            20,
+            5'000'000'001LL,
+            2.5,
+            false,
+            "2024-01-02"
+         ),
+         createData("id_2", "value2", std::nullopt, 30, 5'000'000'002LL, 3.5, true, "2024-01-03"),
+         createData(
+            "id_3",
+            "value3",
+            "indexed3",
+            std::nullopt,
+            5'000'000'003LL,
+            4.5,
+            false,
+            "2024-01-04"
+         ),
+         createData(
+            "id_4",
+            "value4",
+            "indexed4",
+            50,
+            5'000'000'004LL,
+            std::nullopt,
+            true,
+            "2024-01-05"
+         ),
+         createData(
+            "id_5",
+            "value5",
+            "indexed5",
+            60,
+            5'000'000'005LL,
+            6.5,
+            std::nullopt,
+            "2024-01-06"
+         ),
+         createData("id_6", "value6", "indexed6", 70, 5'000'000'006LL, 7.5, false, std::nullopt),
          createData(
             "id_7",
+            std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt,
@@ -103,6 +147,13 @@ const QueryTestScenario IS_NULL_INT_COLUMN = {
    .query = "default.filter(intField.isNull()).project(primaryKey)",
    .expected_query_result =
       nlohmann::json::parse(R"([{"primaryKey":"id_3"},{"primaryKey":"id_7"}])")
+};
+
+const QueryTestScenario IS_NULL_INT64_COLUMN = {
+   .name = "IS_NULL_INT64_COLUMN",
+   .query = "default.filter(int64Field.isNull()).project(primaryKey)",
+   .expected_query_result =
+      nlohmann::json::parse(R"([{"primaryKey":"id_0"},{"primaryKey":"id_7"}])")
 };
 
 const QueryTestScenario IS_NULL_FLOAT_COLUMN = {
@@ -157,6 +208,7 @@ QUERY_TEST(
       IS_NULL_STRING_COLUMN,
       IS_NULL_DICTIONARY_ENCODED_COLUMN,
       IS_NULL_INT_COLUMN,
+      IS_NULL_INT64_COLUMN,
       IS_NULL_FLOAT_COLUMN,
       IS_NULL_BOOL_COLUMN,
       IS_NULL_DATE_COLUMN,

--- a/src/rhydb/query_engine/scalar_expressions/string_equals.test.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/string_equals.test.cpp
@@ -53,26 +53,28 @@ const QueryTestData TEST_DATA{
    .reference_genomes = REFERENCE_GENOMES
 };
 
-const QueryTestScenario STRING_EQUALS_NULL_STRING_COLUMN = {
-   .name = "STRING_EQUALS_NULL_STRING_COLUMN",
+const QueryTestScenario STRING_EQUALS_NULL_REJECTED_STRING_COLUMN = {
+   .name = "STRING_EQUALS_NULL_REJECTED_STRING_COLUMN",
    .query = "default.filter(stringField = null).project(primaryKey)",
-   .expected_query_result =
-      nlohmann::json::parse(R"([{"primaryKey":"id_1"},{"primaryKey":"id_4"}])")
+   .expected_error_message =
+      "the value in an equality must be a literal value (int, float, string, bool, or date), a "
+      "column reference, or a scalar function call at 1:30"
 };
 
-const QueryTestScenario STRING_EQUALS_NULL_DICTIONARY_ENCODED_COLUMN = {
-   .name = "STRING_EQUALS_NULL_DICTIONARY_ENCODED_COLUMN",
+const QueryTestScenario STRING_EQUALS_NULL_REJECTED_DICTIONARY_ENCODED_COLUMN = {
+   .name = "STRING_EQUALS_NULL_REJECTED_DICTIONARY_ENCODED_COLUMN",
    .query = "default.filter(dictionaryEncodedStringField = null).project(primaryKey)",
-   .expected_query_result =
-      nlohmann::json::parse(R"([{"primaryKey":"id_2"},{"primaryKey":"id_4"}])")
+   .expected_error_message =
+      "the value in an equality must be a literal value (int, float, string, bool, or date), a "
+      "column reference, or a scalar function call at 1:47"
 };
 
-const QueryTestScenario STRING_EQUALS_NULL_NEGATED = {
-   .name = "STRING_EQUALS_NULL_NEGATED",
+const QueryTestScenario STRING_EQUALS_NULL_REJECTED_NEGATED = {
+   .name = "STRING_EQUALS_NULL_REJECTED_NEGATED",
    .query = "default.filter(!(stringField = null)).project(primaryKey)",
-   .expected_query_result =
-      nlohmann::json::parse(R"([{"primaryKey":"id_0"},{"primaryKey":"id_2"},{"primaryKey":"id_3"}])"
-      )
+   .expected_error_message =
+      "the value in an equality must be a literal value (int, float, string, bool, or date), a "
+      "column reference, or a scalar function call at 1:32"
 };
 
 const QueryTestScenario STRING_EQUALS_VALUE = {
@@ -99,9 +101,9 @@ QUERY_TEST(
    StringEquals,
    TEST_DATA,
    ::testing::Values(
-      STRING_EQUALS_NULL_STRING_COLUMN,
-      STRING_EQUALS_NULL_DICTIONARY_ENCODED_COLUMN,
-      STRING_EQUALS_NULL_NEGATED,
+      STRING_EQUALS_NULL_REJECTED_STRING_COLUMN,
+      STRING_EQUALS_NULL_REJECTED_DICTIONARY_ENCODED_COLUMN,
+      STRING_EQUALS_NULL_REJECTED_NEGATED,
       STRING_EQUALS_VALUE,
       STRING_EQUALS_INDEXED_VALUE,
       STRING_EQUALS_NO_MATCH


### PR DESCRIPTION
resolves #1503

### Summary

BREAKING CHANGE: `column = null` and `column <> null` filters are no longer supported and now return a query error. Use `column.isNull()` / `column.isNotNull()` instead.

## PR Checklist

- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
