### PR TITLE
chore: fix `HasMutation` display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "silo",
+  "name": "rhydb",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "silo",
+      "name": "rhydb",
       "version": "0.0.1",
       "devDependencies": {
         "@commitlint/cli": "^21.2.2",

--- a/src/rhydb/query_engine/scalar_expressions/has_mutation.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/has_mutation.cpp
@@ -22,7 +22,7 @@ HasMutation<SymbolType>::HasMutation(schema::ColumnIdentifier column, uint32_t p
 
 template <typename SymbolType>
 std::string HasMutation<SymbolType>::toString() const {
-   return column.name + ":" + std::to_string(position_idx);
+   return column.name + ":" + std::to_string(position_idx + 1);
 }
 
 template <typename SymbolType>


### PR DESCRIPTION
### Summary
In mutation filters, the mutation index starts at 1 for users, but RhyDB internally uses a 0-based index -> in that display, we need to convert. The other mutation filters already do that.

(and drive-by fix: update the package.lock to include the new package name)
