### PR TITLE
feat: rename env variables and CLI arguments (SILO -> RhyDb)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,9 @@ EXPOSE 8081
 
 ENTRYPOINT ["./rhydb"]
 
-ENV SILO_PREPROCESSING_CONFIG="/app/preprocessing_config.yaml"
-ENV SILO_DEFAULT_PREPROCESSING_CONFIG="/app/default_preprocessing_config.yaml"
-ENV SILO_DEFAULT_RUNTIME_CONFIG="/app/default_runtime_config.yaml"
+ENV RHYDB_PREPROCESSING_CONFIG="/app/preprocessing_config.yaml"
+ENV RHYDB_DEFAULT_PREPROCESSING_CONFIG="/app/default_preprocessing_config.yaml"
+ENV RHYDB_DEFAULT_RUNTIME_CONFIG="/app/default_runtime_config.yaml"
 
 LABEL org.opencontainers.image.source="https://github.com/GenSpectrum/LAPIS-SILO"
 LABEL org.opencontainers.image.description="High-performance analytical database for sequence alignment data"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 High-performance analytical database for sequence alignment data
 
-RhyDB was formerly named SILO. The rename is still in progress: environment variables still use the `SILO_` prefix, and
-the repository is still `GenSpectrum/LAPIS-SILO`. Documentation refers to those by their actual names.
+RhyDB was formerly named SILO. The rename is still in progress: the repository is still `GenSpectrum/LAPIS-SILO`.
+Documentation refers to those by their actual names.
 
 For information on how to build, test, and contribute to RhyDB, see [Contributing](documentation/developer/contributing.md).
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ snake_case (`database_config.yaml`, `preprocessing_config.yaml`, `runtime_config
 overridden using the options `--database-config=X`, `--preprocessing-config=X`, and `--runtime-config=X`.
 
 Preprocessing and Runtime configurations contain default values for all fields and are thus only optional. Their
-parameters can also be provided as command-line arguments in snake_case and as environment variables prefixed with SILO_
-in capital SNAKE_CASE. (e.g. SILO_INPUT_DIRECTORY).
+parameters can also be provided as command-line arguments in snake_case and as environment variables prefixed with RHYDB_
+in capital SNAKE_CASE. (e.g. RHYDB_INPUT_DIRECTORY).
 
 The precendence is `CLI argument > Environment Variable > Configuration File > Default Value`
 

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -114,7 +114,7 @@ int mainWhichMayThrowExceptions(int argc, char** argv) {
    SPDLOG_INFO("Starting SILO (version {})", rhydb::RELEASE_VERSION);
 
    std::vector<std::string> env_allow_list;
-   env_allow_list.emplace_back("SILO_PANIC");
+   env_allow_list.emplace_back("RHYDB_PANIC");
    for (auto& field :
         rhydb::config::PreprocessingConfig::getConfigSpecification().attribute_specifications) {
       env_allow_list.emplace_back(

--- a/benchmarking/Makefile_preprocessing
+++ b/benchmarking/Makefile_preprocessing
@@ -1,9 +1,9 @@
 all: $(PREPROCESSING_STAMP)
 
-SILO_PREPROCESSING_CONFIG=$(DATASET_DIR)/preprocessing_config.yaml
-export SILO_PREPROCESSING_CONFIG
-SILO_INPUT_DIRECTORY=$(DATASET_DIR)
-export SILO_INPUT_DIRECTORY
+RHYDB_PREPROCESSING_CONFIG=$(DATASET_DIR)/preprocessing_config.yaml
+export RHYDB_PREPROCESSING_CONFIG
+RHYDB_INPUT_DIRECTORY=$(DATASET_DIR)
+export RHYDB_INPUT_DIRECTORY
 
 
 # ---- Get dependencies --------------------------------------------------------

--- a/buildScripts/bump_serialization_version.sh
+++ b/buildScripts/bump_serialization_version.sh
@@ -26,9 +26,9 @@ find "$SERIALIZED_STATE_DIR" -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} +
 echo "Building rhydb_test..."
 make -C "$REPO_ROOT" build/Debug/rhydb_test
 
-# 4. Run the save/reload test with SILO_KEEP_SERIALIZED_STATE to preserve the new state
+# 4. Run the save/reload test with RHYDB_KEEP_SERIALIZED_STATE to preserve the new state
 echo "Generating new serialized state..."
-SILO_KEEP_SERIALIZED_STATE=1 "$REPO_ROOT/build/Debug/rhydb_test" \
+RHYDB_KEEP_SERIALIZED_STATE=1 "$REPO_ROOT/build/Debug/rhydb_test" \
     --gtest_filter="DatabaseTest.shouldSaveAndReloadDatabaseWithoutErrors"
 
 # 5. Verify a new directory was created

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -12,7 +12,7 @@ rhydb api \
 
 ### Runtime Configuration
 
-Configuration is resolved in order of precedence: CLI arguments > environment variables (prefixed `SILO_`) > config file > defaults.
+Configuration is resolved in order of precedence: CLI arguments > environment variables (prefixed `RHYDB_`) > config file > defaults.
 
 | Key | Default | Description |
 |-----|---------|-------------|

--- a/documentation/developer/config.md
+++ b/documentation/developer/config.md
@@ -64,15 +64,17 @@ There are some complications:
   if given, user-provided config file (taken from (defaults,) env vars
   and command line options).
 
-* Allowing multiple modes (with `silo` currently `api` and
+* Allowing multiple modes (with `rhydb` currently `api` and
   `preprocessing`), while also allowing configuration via environment
   variables, requires that environment variables meant for the other
   mode should not lead to errors. Environment variables are often set
   before deciding in which mode the program should run, or hang
   around, or in the case of the Docker image the configuration files
-  are always specified via env vars, for both modes. However, while
+  are always specified via env vars, for both modes. However,
   totally unknown environment variables that start with the
-  application prefix (`SILO_`) should be reported as usage errors.
+  application prefix (`RHYDB_`) should be reported as usage errors.
+  Variables that still use the deprecated `SILO_` prefix are warned
+  about and ignored, to ease migration.
 
 The logic for handling the precedence and these complications is in
 the templated [`getConfig`](../src/config/config_interface.h)

--- a/documentation/developer/config.md
+++ b/documentation/developer/config.md
@@ -64,7 +64,7 @@ There are some complications:
   if given, user-provided config file (taken from (defaults,) env vars
   and command line options).
 
-* Allowing multiple modes (with `rhydb` currently `api` and
+* Allowing multiple modes (with `rhydb` e.g. `api` and
   `preprocessing`), while also allowing configuration via environment
   variables, requires that environment variables meant for the other
   mode should not lead to errors. Environment variables are often set

--- a/documentation/incremental_preprocessing.md
+++ b/documentation/incremental_preprocessing.md
@@ -1,10 +1,10 @@
 # Incremental Preprocessing with `rhydb append`
 
-The `rhydb append` command adds new records to an existing RhyDB database without requiring a full preprocessing run. It reads data in NDJSON format, appends it to a previously built database state, and writes the resulting updated state to the silo-directory.
+The `rhydb append` command adds new records to an existing RhyDB database without requiring a full preprocessing run. It reads data in NDJSON format, appends it to a previously built database state, and writes the resulting updated state to the data directory.
 
 ## Overview
 
-A typical RhyDB workflow begins with `rhydb preprocessing`, which builds a database from scratch. As new data becomes available, `rhydb append` can be used to incorporate it incrementally. The command loads an existing database state, parses the new records from an NDJSON source, validates and inserts them, and then persists the updated database as a new versioned state in the silo-directory.
+A typical RhyDB workflow begins with `rhydb preprocessing`, which builds a database from scratch. As new data becomes available, `rhydb append` can be used to incorporate it incrementally. The command loads an existing database state, parses the new records from an NDJSON source, validates and inserts them, and then persists the updated database as a new versioned state in the data directory.
 
 The append operation is atomic in the sense that the new state is only written after all records have been successfully inserted and validated. If any record fails validation (for example, due to a schema mismatch or a duplicate primary key), the operation aborts and the existing state remains untouched.
 
@@ -18,17 +18,17 @@ rhydb append [options...]
 
 All options can also be provided via environment variables or a YAML configuration file. Options override environment variables, which override YAML file entries.
 
-**`--silo-directory <path>`** (default: `.`)
-The path to a silo-directory. This directory is used both as the source of existing database states (unless `--silo-data-source` is specified) and as the destination for the newly produced state.
-Environment variable: `SILO_SILO_DIRECTORY`. YAML key: `siloDirectory`.
+**`--data-directory <path>`** (default: `.`)
+The path to a data directory. This directory is used both as the source of existing database states (unless `--data-source` is specified) and as the destination for the newly produced state.
+Environment variable: `RHYDB_DATA_DIRECTORY`. YAML key: `dataDirectory`.
 
 **`--append-file <path>`** (optional)
 The path to an NDJSON file containing the records to append. Compressed files (`.zst` and `.xz`) are detected and decompressed transparently. If this option is omitted, data is read from stdin instead.
-Environment variable: `SILO_APPEND_FILE`. YAML key: `appendFile`.
+Environment variable: `RHYDB_APPEND_FILE`. YAML key: `appendFile`.
 
-**`--silo-data-source <path>`** (optional)
-A directory containing a valid RhyDB database state to use as the base for appending. If omitted, `rhydb append` automatically selects the most recent compatible state from the silo-directory. An error is raised if no valid state can be found.
-Environment variable: `SILO_SILO_DATA_SOURCE`. YAML key: `siloDataSource`.
+**`--data-source <path>`** (optional)
+A directory containing a valid RhyDB database state to use as the base for appending. If omitted, `rhydb append` automatically selects the most recent compatible state from the data directory. An error is raised if no valid state can be found.
+Environment variable: `RHYDB_DATA_SOURCE`. YAML key: `dataSource`.
 
 ## Input Format
 
@@ -42,7 +42,7 @@ See `input_format.md` for further details.
 
 When `rhydb append` is invoked, the following steps are performed:
 
-1. The silo-directory is opened, and the base database state is determined -- either from the explicitly provided `--silo-data-source` or by scanning the silo-directory for the most recent compatible state.
+1. The data directory is opened, and the base database state is determined -- either from the explicitly provided `--data-source` or by scanning the data directory for the most recent compatible state.
 
 2. The existing database is loaded from disk into memory.
 
@@ -52,7 +52,7 @@ When `rhydb append` is invoked, the following steps are performed:
 
 5. Each subsequent line is parsed and its values are inserted into the database. Progress is logged every 10,000 records.
 
-6. A new data version is assigned, and the updated database state is saved as a new timestamped subdirectory within the silo-directory.
+6. A new data version is assigned, and the updated database state is saved as a new timestamped subdirectory within the data directory.
 
 ## Examples
 
@@ -62,20 +62,20 @@ Append data from a file to the database in the current directory:
 rhydb append --append-file new_sequences.ndjson
 ```
 
-Append compressed data to a specific silo-directory:
+Append compressed data to a specific data directory:
 
 ```
-rhydb append --silo-directory /data/silo --append-file new_sequences.ndjson.zst
+rhydb append --data-directory /data/silo --append-file new_sequences.ndjson.zst
 ```
 
 Pipe data from another process into append:
 
 ```
-generate_data | rhydb append --silo-directory /data/silo
+generate_data | rhydb append --data-directory /data/silo
 ```
 
 Append to a specific base state rather than the most recent one:
 
 ```
-rhydb append --silo-directory /data/silo --silo-data-source /data/silo/20240101T120000
+rhydb append --data-directory /data/silo --data-source /data/silo/20240101T120000
 ```

--- a/documentation/python_bindings.md
+++ b/documentation/python_bindings.md
@@ -25,8 +25,8 @@ The bindings depend on `pyarrow` and `pyroaring`, which are installed automatica
 ```python
 from rhydb import Database
 
-# Load a preprocessed database state from a silo-directory
-db = Database("path/to/silo-directory")
+# Load a preprocessed database state from a data directory
+db = Database("path/to/data-directory")
 
 # Run a SaneQL query; results come back as a pyarrow.Table
 table = db.query("default.filter(region = 'Europe').project({primaryKey, age})")
@@ -45,7 +45,7 @@ db.update_column("default", "age", "0", filter_expression="age = 4")
 **`Database(file_name=None)`**
 Creates an empty database, or loads an existing one when `file_name` is given.
 
-`file_name` is a **silo-directory**: the directory that holds one or more versioned database states (see [Data Directories](data_directories.md)). The most recent compatible state is loaded automatically.
+`file_name` is a **data directory**: the directory that holds one or more versioned database states (see [Data Directories](data_directories.md)). The most recent compatible state is loaded automatically.
 
 ```python
 empty = Database()                       # in-memory, no tables

--- a/src/config/config_key_path.h
+++ b/src/config/config_key_path.h
@@ -41,7 +41,7 @@ class ConfigKeyPath {
 /// refers to a path segment or sub-path segment (i.e. to decide
 /// whether the input value meant to refer to api.port or apiPort), so
 /// we have only 1 level of strings. This is the case for CLI
-/// arguments (--api-port) and Environment Variables (SILO_API_PORT)
+/// arguments (--api-port) and Environment Variables (RHYDB_API_PORT)
 class AmbiguousConfigKeyPath {
    std::vector<std::string> path;
 

--- a/src/config/source/environment_variables.cpp
+++ b/src/config/source/environment_variables.cpp
@@ -8,6 +8,7 @@
 #include <boost/algorithm/string/split.hpp>
 
 constexpr std::string_view ENV_VAR_PREFIX = "RHYDB_";
+constexpr std::string_view DEPRECATED_ENV_VAR_PREFIX = "SILO_";
 
 namespace {
 
@@ -34,6 +35,14 @@ EnvironmentVariables EnvironmentVariables::newWithAllowListAndEnv(
             if (key.starts_with(ENV_VAR_PREFIX)) {
                const std::string val{env + i + 1};
                key_value_pairs.emplace_back(key, val);
+            } else if (key.starts_with(DEPRECATED_ENV_VAR_PREFIX)) {
+               SPDLOG_WARN(
+                  "Ignoring environment variable '{}': the '{}' prefix is deprecated and no longer "
+                  "read. Environment variables now use the '{}' prefix.",
+                  key,
+                  DEPRECATED_ENV_VAR_PREFIX,
+                  ENV_VAR_PREFIX
+               );
             }
             break;
          }

--- a/src/config/source/environment_variables.cpp
+++ b/src/config/source/environment_variables.cpp
@@ -7,7 +7,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>
 
-constexpr std::string_view ENV_VAR_PREFIX = "SILO_";
+constexpr std::string_view ENV_VAR_PREFIX = "RHYDB_";
 
 namespace {
 

--- a/src/config/source/environment_variables.cpp
+++ b/src/config/source/environment_variables.cpp
@@ -73,7 +73,7 @@ AmbiguousConfigKeyPath EnvironmentVariables::stringToConfigKeyPath(
    const std::string& key_path_string
 ) {
    if (!key_path_string.starts_with(ENV_VAR_PREFIX)) {
-      throw rhydb::config::ConfigException(fmt::format(
+      throw ConfigException(fmt::format(
          "the provided option '{}' is not a valid environment variable option. It should be "
          "prefixed with '{}'",
          key_path_string,
@@ -94,7 +94,7 @@ AmbiguousConfigKeyPath EnvironmentVariables::stringToConfigKeyPath(
 
    auto result = AmbiguousConfigKeyPath::tryFrom(std::move(delimited_lowercase_strings));
    if (result == std::nullopt) {
-      throw rhydb::config::ConfigException(fmt::format(
+      throw ConfigException(fmt::format(
          "the provided option '{}' is not a valid environment variable option", key_path_string
       ));
    }
@@ -130,7 +130,7 @@ AmbiguousConfigKeyPath EnvironmentVariables::stringToConfigKeyPath(
    if (!invalid_config_keys.empty()) {
       const std::string_view keys_or_options =
          (invalid_config_keys.size() >= 2) ? "variables" : "variable";
-      throw rhydb::config::ConfigException(fmt::format(
+      throw ConfigException(fmt::format(
          "in {}: unknown {} {} for '{}'",
          debugContext(),
          keys_or_options,

--- a/src/config/source/environment_variables.test.cpp
+++ b/src/config/source/environment_variables.test.cpp
@@ -64,14 +64,6 @@ TEST(EnvironmentVariables, doesNotErrorWhenThePrefixIsNotRHYDB_) {
    ASSERT_NO_THROW((void)env_vars.verify({}));
 }
 
-TEST(EnvironmentVariables, ignoresDeprecatedSiloPrefixWithoutError) {
-   const std::vector<std::string> allow_list;
-   const char* env_var = "SILO_API_PORT=1234";
-   const std::vector<const char*> var_vector = {env_var, nullptr};
-   auto env_vars = EnvironmentVariables::newWithAllowListAndEnv(allow_list, var_vector.data());
-   ASSERT_NO_THROW((void)env_vars.verify({.program_name = "some_binary_name"}));
-}
-
 TEST(EnvironmentVariables, errorsOnWrongType) {
    const std::vector<std::string> allow_list{"RHYDB_FOO"};
    const char* env_var = "RHYDB_FOO=bar";

--- a/src/config/source/environment_variables.test.cpp
+++ b/src/config/source/environment_variables.test.cpp
@@ -56,9 +56,9 @@ TEST(EnvironmentVariables, errorsIfSiloDebugIsProvidedButNotAllowed) {
    );
 }
 
-TEST(EnvironmentVariables, doesNotErrorWhenThePrefixIsNotSILO_) {
+TEST(EnvironmentVariables, doesNotErrorWhenThePrefixIsNotRHYDB_) {
    const std::vector<std::string> allow_list;
-   const char* env_var = "SILODEBUG=1";
+   const char* env_var = "RHYDBDEBUG=1";
    const std::vector<const char*> var_vector = {env_var, nullptr};
    auto env_vars = EnvironmentVariables::newWithAllowListAndEnv(allow_list, var_vector.data());
    ASSERT_NO_THROW((void)env_vars.verify({}));

--- a/src/config/source/environment_variables.test.cpp
+++ b/src/config/source/environment_variables.test.cpp
@@ -8,35 +8,36 @@ using rhydb::config::EnvironmentVariables;
 
 TEST(EnvironmentVariables, correctPrefixedUppercase) {
    ASSERT_EQ(
-      EnvironmentVariables::configKeyPathToString(ConfigKeyPath::tryFrom({{"a"}}).value()), "SILO_A"
+      EnvironmentVariables::configKeyPathToString(ConfigKeyPath::tryFrom({{"a"}}).value()),
+      "RHYDB_A"
    );
    ASSERT_EQ(
       EnvironmentVariables::configKeyPathToString(ConfigKeyPath::tryFrom({{"abc"}}).value()),
-      "SILO_ABC"
+      "RHYDB_ABC"
    );
    ASSERT_EQ(
       EnvironmentVariables::configKeyPathToString(
          ConfigKeyPath::tryFrom({{"some", "snake", "case"}}).value()
       ),
-      "SILO_SOME_SNAKE_CASE"
+      "RHYDB_SOME_SNAKE_CASE"
    );
    ASSERT_EQ(
       EnvironmentVariables::configKeyPathToString(
          ConfigKeyPath::tryFrom({{"some"}, {"subsectioned", "sequence"}}).value()
       ),
-      "SILO_SOME_SUBSECTIONED_SEQUENCE"
+      "RHYDB_SOME_SUBSECTIONED_SEQUENCE"
    );
    ASSERT_EQ(
       EnvironmentVariables::configKeyPathToString(
          ConfigKeyPath::tryFrom({{"some"}, {"more"}, {"sections"}}).value()
       ),
-      "SILO_SOME_MORE_SECTIONS"
+      "RHYDB_SOME_MORE_SECTIONS"
    );
 }
 
 TEST(EnvironmentVariables, successfullyIgnoreTheAllowList) {
-   const std::vector<std::string> allow_list = {"SILO_DEBUG"};
-   const char* env_var = "SILO_DEBUG=1";
+   const std::vector<std::string> allow_list = {"RHYDB_DEBUG"};
+   const char* env_var = "RHYDB_DEBUG=1";
    const std::vector<const char*> var_vector = {env_var, nullptr};
    auto env_vars = EnvironmentVariables::newWithAllowListAndEnv(allow_list, var_vector.data());
    ASSERT_NO_THROW((void)env_vars.verify({}));
@@ -44,13 +45,13 @@ TEST(EnvironmentVariables, successfullyIgnoreTheAllowList) {
 
 TEST(EnvironmentVariables, errorsIfSiloDebugIsProvidedButNotAllowed) {
    const std::vector<std::string> allow_list;
-   const char* env_var = "SILO_DEBUG=1";
+   const char* env_var = "RHYDB_DEBUG=1";
    const std::vector<const char*> var_vector = {env_var, nullptr};
    auto env_vars = EnvironmentVariables::newWithAllowListAndEnv(allow_list, var_vector.data());
    EXPECT_THAT(
       [&]() { (void)env_vars.verify({.program_name = "some_binary_name"}); },
       ThrowsMessage<rhydb::config::ConfigException>(::testing::HasSubstr(
-         "in environment variables: unknown variable SILO_DEBUG for 'some_binary_name'"
+         "in environment variables: unknown variable RHYDB_DEBUG for 'some_binary_name'"
       ))
    );
 }
@@ -64,8 +65,8 @@ TEST(EnvironmentVariables, doesNotErrorWhenThePrefixIsNotSILO_) {
 }
 
 TEST(EnvironmentVariables, errorsOnWrongType) {
-   const std::vector<std::string> allow_list{"SILO_FOO"};
-   const char* env_var = "SILO_FOO=bar";
+   const std::vector<std::string> allow_list{"RHYDB_FOO"};
+   const char* env_var = "RHYDB_FOO=bar";
    const std::vector<const char*> var_vector = {env_var, nullptr};
    auto env_vars = EnvironmentVariables::newWithAllowListAndEnv(allow_list, var_vector.data());
    EXPECT_THAT(
@@ -86,9 +87,9 @@ TEST(EnvironmentVariables, errorsOnWrongType) {
 }
 
 TEST(EnvironmentVariables, parsesVariables) {
-   const std::vector<std::string> allow_list{"SILO_FOO", "SILO_FOO_INT"};
-   const char* env_var1 = "SILO_FOO=bar";
-   const char* env_var2 = "SILO_FOO_INT=1";
+   const std::vector<std::string> allow_list{"RHYDB_FOO", "RHYDB_FOO_INT"};
+   const char* env_var1 = "RHYDB_FOO=bar";
+   const char* env_var2 = "RHYDB_FOO_INT=1";
    const std::vector<const char*> var_vector = {env_var1, env_var2, nullptr};
    auto env_vars = EnvironmentVariables::newWithAllowListAndEnv(allow_list, var_vector.data());
    ASSERT_NO_THROW((void)env_vars.verify(rhydb::config::ConfigSpecification{
@@ -108,8 +109,8 @@ TEST(EnvironmentVariables, parsesVariables) {
 }
 
 TEST(EnvironmentVariables, parsesVariablesWithDoubleEquals) {
-   const std::vector<std::string> allow_list{"SILO_FOO"};
-   const char* env_var1 = "SILO_FOO=bar=baz";
+   const std::vector<std::string> allow_list{"RHYDB_FOO"};
+   const char* env_var1 = "RHYDB_FOO=bar=baz";
    const std::vector<const char*> var_vector = {env_var1, nullptr};
    auto env_vars = EnvironmentVariables::newWithAllowListAndEnv(allow_list, var_vector.data());
    ASSERT_EQ(

--- a/src/config/source/environment_variables.test.cpp
+++ b/src/config/source/environment_variables.test.cpp
@@ -43,7 +43,7 @@ TEST(EnvironmentVariables, successfullyIgnoreTheAllowList) {
    ASSERT_NO_THROW((void)env_vars.verify({}));
 }
 
-TEST(EnvironmentVariables, errorsIfSiloDebugIsProvidedButNotAllowed) {
+TEST(EnvironmentVariables, errorsIfRhydbDebugIsProvidedButNotAllowed) {
    const std::vector<std::string> allow_list;
    const char* env_var = "RHYDB_DEBUG=1";
    const std::vector<const char*> var_vector = {env_var, nullptr};

--- a/src/config/source/environment_variables.test.cpp
+++ b/src/config/source/environment_variables.test.cpp
@@ -64,6 +64,14 @@ TEST(EnvironmentVariables, doesNotErrorWhenThePrefixIsNotRHYDB_) {
    ASSERT_NO_THROW((void)env_vars.verify({}));
 }
 
+TEST(EnvironmentVariables, ignoresDeprecatedSiloPrefixWithoutError) {
+   const std::vector<std::string> allow_list;
+   const char* env_var = "SILO_API_PORT=1234";
+   const std::vector<const char*> var_vector = {env_var, nullptr};
+   auto env_vars = EnvironmentVariables::newWithAllowListAndEnv(allow_list, var_vector.data());
+   ASSERT_NO_THROW((void)env_vars.verify({.program_name = "some_binary_name"}));
+}
+
 TEST(EnvironmentVariables, errorsOnWrongType) {
    const std::vector<std::string> allow_list{"RHYDB_FOO"};
    const char* env_var = "RHYDB_FOO=bar";

--- a/src/rhydb/append/append.cpp
+++ b/src/rhydb/append/append.cpp
@@ -43,10 +43,10 @@ rhydb::RhyDBDataSource getMostRecentOrSpecifiedDatabaseState(
 namespace rhydb::append {
 
 int runAppend(const rhydb::config::AppendConfig& append_config) {
-   const rhydb::RhyDBDirectory silo_directory{append_config.data_directory};
+   const rhydb::RhyDBDirectory data_directory{append_config.data_directory};
 
    const auto database_state_directory =
-      getMostRecentOrSpecifiedDatabaseState(silo_directory, append_config.data_source);
+      getMostRecentOrSpecifiedDatabaseState(data_directory, append_config.data_source);
 
    SPDLOG_INFO("append - Loading database from {}", database_state_directory.path);
    Database database = Database::loadDatabaseState(database_state_directory);

--- a/src/rhydb/append/append.cpp
+++ b/src/rhydb/append/append.cpp
@@ -43,10 +43,10 @@ rhydb::RhyDBDataSource getMostRecentOrSpecifiedDatabaseState(
 namespace rhydb::append {
 
 int runAppend(const rhydb::config::AppendConfig& append_config) {
-   const rhydb::RhyDBDirectory silo_directory{append_config.silo_directory};
+   const rhydb::RhyDBDirectory silo_directory{append_config.data_directory};
 
    const auto database_state_directory =
-      getMostRecentOrSpecifiedDatabaseState(silo_directory, append_config.silo_data_source);
+      getMostRecentOrSpecifiedDatabaseState(silo_directory, append_config.data_source);
 
    SPDLOG_INFO("append - Loading database from {}", database_state_directory.path);
    Database database = Database::loadDatabaseState(database_state_directory);
@@ -55,8 +55,8 @@ int runAppend(const rhydb::config::AppendConfig& append_config) {
    auto input = InputStreamWrapper::openFileOrStdIn(append_config.append_file);
    database.appendData(schema::TableName::getDefault(), input.getInputStream());
 
-   SPDLOG_INFO("append - saving database to directory '{}'", append_config.silo_directory);
-   database.saveDatabaseState(append_config.silo_directory);
+   SPDLOG_INFO("append - saving database to directory '{}'", append_config.data_directory);
+   database.saveDatabaseState(append_config.data_directory);
 
    SPDLOG_INFO(
       "append - finished appending data, resulting database info: {}", database.getDatabaseInfo()

--- a/src/rhydb/common/panic.cpp
+++ b/src/rhydb/common/panic.cpp
@@ -16,7 +16,7 @@ namespace {
    const char* file,
    int line
 ) {
-   const char* env = getenv("SILO_PANIC");
+   const char* env = getenv("RHYDB_PANIC");
    bool do_abort;
    if (env) {
       do_abort = strcmp(env, "abort") == 0;

--- a/src/rhydb/common/panic.h
+++ b/src/rhydb/common/panic.h
@@ -21,7 +21,7 @@ namespace rhydb::common {
 /// connections. OTOH, to make debugging via gdb or core dumps
 /// possible even when the code that captures exceptions can't be
 /// disabled, `panic` can be instructed at runtime to call `abort`
-/// instead by setting the `SILO_PANIC` environment variable to the
+/// instead by setting the `RHYDB_PANIC` environment variable to the
 /// string `abort` (with any other value, or when unset, panic
 /// silently throws the mentioned exception instead).
 [[noreturn]] void panic(const std::string& msg, const char* file, int line);

--- a/src/rhydb/common/panic.h
+++ b/src/rhydb/common/panic.h
@@ -63,23 +63,21 @@ namespace rhydb::common {
 
 [[noreturn]] void assertFailure(const char* msg, const char* file, int line);
 
-#define SILO_INTERNAL_ASSERT_OP_(prefix_str, e1, op, e2)                                 \
-   do {                                                                                  \
-      auto silo_internal_assert_op_v1 = (e1);                                           \
-      auto silo_internal_assert_op_v2 = (e2);                                           \
-      if (!(silo_internal_assert_op_v1 op silo_internal_assert_op_v2)) {               \
-         rhydb::common::assertOpFailure(                                                 \
-            prefix_str,                                                                  \
-            #e1,                                                                         \
-            #op,                                                                         \
-            #e2,                                                                         \
-            fmt::format(                                                                 \
-               "{} " #op " {}", silo_internal_assert_op_v1, silo_internal_assert_op_v2 \
-            ),                                                                           \
-            __FILE__,                                                                    \
-            __LINE__                                                                     \
-         );                                                                              \
-      }                                                                                  \
+#define SILO_INTERNAL_ASSERT_OP_(prefix_str, e1, op, e2)                                          \
+   do {                                                                                           \
+      auto silo_internal_assert_op_v1 = (e1);                                                     \
+      auto silo_internal_assert_op_v2 = (e2);                                                     \
+      if (!(silo_internal_assert_op_v1 op silo_internal_assert_op_v2)) {                          \
+         rhydb::common::assertOpFailure(                                                          \
+            prefix_str,                                                                           \
+            #e1,                                                                                  \
+            #op,                                                                                  \
+            #e2,                                                                                  \
+            fmt::format("{} " #op " {}", silo_internal_assert_op_v1, silo_internal_assert_op_v2), \
+            __FILE__,                                                                             \
+            __LINE__                                                                              \
+         );                                                                                       \
+      }                                                                                           \
    } while (0)
 
 #define SILO_ASSERT_OP_(partial_prefix, e1, op, e2) \

--- a/src/rhydb/common/panic.h
+++ b/src/rhydb/common/panic.h
@@ -65,16 +65,16 @@ namespace rhydb::common {
 
 #define SILO_INTERNAL_ASSERT_OP_(prefix_str, e1, op, e2)                                 \
    do {                                                                                  \
-      auto silo_internal_assert_op__v1 = (e1);                                           \
-      auto silo_internal_assert_op__v2 = (e2);                                           \
-      if (!(silo_internal_assert_op__v1 op silo_internal_assert_op__v2)) {               \
+      auto silo_internal_assert_op_v1 = (e1);                                           \
+      auto silo_internal_assert_op_v2 = (e2);                                           \
+      if (!(silo_internal_assert_op_v1 op silo_internal_assert_op_v2)) {               \
          rhydb::common::assertOpFailure(                                                 \
             prefix_str,                                                                  \
             #e1,                                                                         \
             #op,                                                                         \
             #e2,                                                                         \
             fmt::format(                                                                 \
-               "{} " #op " {}", silo_internal_assert_op__v1, silo_internal_assert_op__v2 \
+               "{} " #op " {}", silo_internal_assert_op_v1, silo_internal_assert_op_v2 \
             ),                                                                           \
             __FILE__,                                                                    \
             __LINE__                                                                     \

--- a/src/rhydb/common/panic.test.cpp
+++ b/src/rhydb/common/panic.test.cpp
@@ -45,19 +45,19 @@ void nullCapableSetenv(const char* name, const char* value, int overwrite) {
 TEST(panic, assertEqPanicModes) {
    SILO_ASSERT_EQ(1 + 1, 2);
 
-   const char* old_env = getenv("SILO_PANIC");
-   setenv("SILO_PANIC", "", 1);
+   const char* old_env = getenv("RHYDB_PANIC");
+   setenv("RHYDB_PANIC", "", 1);
    try {
       SILO_ASSERT_EQ(1 + 1, 3);
    } catch (const std::exception& ex) {
       assertMsg(ex.what(), "ASSERT_EQ failure: 1 + 1 == 3: 2 == 3");
    };
 
-   setenv("SILO_PANIC", "abort", 1);
+   setenv("RHYDB_PANIC", "abort", 1);
    ASSERT_DEATH(SILO_ASSERT_EQ(1 + 1, 3), "ASSERT_EQ failure: 1 \\+ 1 == 3: 2 == 3");
 
    // revert it back
-   nullCapableSetenv("SILO_PANIC", old_env, 1);
+   nullCapableSetenv("RHYDB_PANIC", old_env, 1);
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming,readability-function-cognitive-complexity)
@@ -71,14 +71,14 @@ TEST(panic, debugAssertBehavesAsPerCompilationMode) {
 
 #if SILO_DEBUG_ASSERTIONS
 
-   const char* old_env = getenv("SILO_PANIC");
-   setenv("SILO_PANIC", "", 1);
+   const char* old_env = getenv("RHYDB_PANIC");
+   setenv("RHYDB_PANIC", "", 1);
    try {
       SILO_DEBUG_ASSERT(1 + 1 == 3);
    } catch (const std::exception& ex) {
       assertMsg(ex.what(), "DEBUG_ASSERT failure: 1 + 1 == 3");
    };
-   nullCapableSetenv("SILO_PANIC", old_env, 1);
+   nullCapableSetenv("RHYDB_PANIC", old_env, 1);
 
 #else
    // check that SILO_DEBUG_ASSERT is disabled
@@ -95,14 +95,14 @@ TEST(panic, debugAssertGeWorks) {
 
 #if SILO_DEBUG_ASSERTIONS
 
-   const char* old_env = getenv("SILO_PANIC");
-   setenv("SILO_PANIC", "", 1);
+   const char* old_env = getenv("RHYDB_PANIC");
+   setenv("RHYDB_PANIC", "", 1);
    try {
       SILO_DEBUG_ASSERT_GE(1 + 5, 7);
    } catch (const std::exception& ex) {
       assertMsg(ex.what(), "DEBUG_ASSERT_GE failure: 1 + 5 >= 7: 6 >= 7");
    };
-   nullCapableSetenv("SILO_PANIC", old_env, 1);
+   nullCapableSetenv("RHYDB_PANIC", old_env, 1);
 
 #else
    // check that SILO_DEBUG_ASSERT is disabled

--- a/src/rhydb/config/append_config.cpp
+++ b/src/rhydb/config/append_config.cpp
@@ -10,14 +10,14 @@ namespace {
 ConfigKeyPath appendConfigOptionKey() {
    return YamlFile::stringToConfigKeyPath("appendConfig");
 }
-ConfigKeyPath siloDirectoryOptionKey() {
-   return YamlFile::stringToConfigKeyPath("siloDirectory");
+ConfigKeyPath dataDirectoryOptionKey() {
+   return YamlFile::stringToConfigKeyPath("dataDirectory");
 }
 ConfigKeyPath appendFileOptionKey() {
    return YamlFile::stringToConfigKeyPath("appendFile");
 }
-ConfigKeyPath siloDataSourceOptionKey() {
-   return YamlFile::stringToConfigKeyPath("siloDataSource");
+ConfigKeyPath dataSourceOptionKey() {
+   return YamlFile::stringToConfigKeyPath("dataSource");
 }
 }  // namespace
 
@@ -36,11 +36,11 @@ ConfigSpecification AppendConfig::getConfigSpecification() {
       .program_name = "rhydb append",
       .attribute_specifications{
          ConfigAttributeSpecification::createWithDefault(
-            siloDirectoryOptionKey(),
+            dataDirectoryOptionKey(),
             ConfigValue::fromPath("."),
-            "The path to a silo-directory, a directory that contains silo outputs. This may be "
+            "The path to a data directory that contains rhydb outputs. This may be "
             "used for input (see `rhydb api --help`) and will be used for the output of the new "
-            "silo state"
+            "state"
          ),
          ConfigAttributeSpecification::createWithoutDefault(
             appendFileOptionKey(),
@@ -49,24 +49,24 @@ ConfigSpecification AppendConfig::getConfigSpecification() {
             "the database. If no file is given, the data is expected on stdin instead."
          ),
          ConfigAttributeSpecification::createWithoutDefault(
-            siloDataSourceOptionKey(),
+            dataSourceOptionKey(),
             ConfigValueType::PATH,
-            "A directory that contains a valid silo state. If this is not given, the most recent "
-            "database state from the silo-directory is taken instead."
+            "A directory that contains a valid rhydb state. If this is not given, the most recent "
+            "database state from the data directory is taken instead."
          )
       }
    };
 }
 
 void AppendConfig::overwriteFrom(const VerifiedConfigAttributes& config_source) {
-   if (auto var = config_source.getPath(siloDirectoryOptionKey())) {
-      silo_directory = var.value();
+   if (auto var = config_source.getPath(dataDirectoryOptionKey())) {
+      data_directory = var.value();
    }
    if (auto var = config_source.getPath(appendFileOptionKey())) {
       append_file = var.value();
    }
-   if (auto var = config_source.getPath(siloDataSourceOptionKey())) {
-      silo_data_source = var.value();
+   if (auto var = config_source.getPath(dataSourceOptionKey())) {
+      data_source = var.value();
    }
 }
 

--- a/src/rhydb/config/append_config.h
+++ b/src/rhydb/config/append_config.h
@@ -17,9 +17,9 @@ class AppendConfig {
    AppendConfig() = default;
 
   public:
-   std::filesystem::path silo_directory;
+   std::filesystem::path data_directory;
    std::optional<std::filesystem::path> append_file;
-   std::optional<std::filesystem::path> silo_data_source;
+   std::optional<std::filesystem::path> data_source;
 
    /// Create AppendConfig with all default values from the specification
    static AppendConfig withDefaults();
@@ -35,7 +35,7 @@ class AppendConfig {
       const VerifiedConfigAttributes& env_source
    );
 
-   NLOHMANN_DEFINE_TYPE_INTRUSIVE(AppendConfig, silo_directory, append_file, silo_data_source)
+   NLOHMANN_DEFINE_TYPE_INTRUSIVE(AppendConfig, data_directory, append_file, data_source)
 };
 
 }  // namespace rhydb::config

--- a/src/rhydb/database.test.cpp
+++ b/src/rhydb/database.test.cpp
@@ -90,8 +90,8 @@ TEST(DatabaseTest, shouldSaveAndReloadDatabaseWithoutErrors) {
    EXPECT_GT(database_info.horizontal_bitmaps_size, 0);
 
    // When bumping the serialization version, run `make bump-serialization-version` which sets
-   // SILO_KEEP_SERIALIZED_STATE=1 to preserve the produced directory for committing to Git.
-   if (std::getenv("SILO_KEEP_SERIALIZED_STATE") == nullptr) {
+   // RHYDB_KEEP_SERIALIZED_STATE=1 to preserve the produced directory for committing to Git.
+   if (std::getenv("RHYDB_KEEP_SERIALIZED_STATE") == nullptr) {
       std::filesystem::remove_all(data_source.path);
    }
 }


### PR DESCRIPTION
resolves #1470

### Summary

Renames RhyDB's option interface away from the old `SILO` naming: environment variables now use the `RHYDB_` prefix instead of `SILO_`, and the `rhydb append` directory options are renamed.

- **Env var prefix `SILO_` → `RHYDB_`** — applies to all config env vars, plus the standalone `RHYDB_PANIC` and `RHYDB_KEEP_SERIALIZED_STATE` vars.
- **`rhydb append` options** — `--silo-directory` → `--data-directory` (`RHYDB_DATA_DIRECTORY`, YAML `dataDirectory`) and `--silo-data-source` → `--data-source` (`RHYDB_DATA_SOURCE`, YAML `dataSource`), aligning with `rhydb api` which already uses `dataDirectory`.
- **Deprecation warning** — any env var still using the `SILO_` prefix is logged at WARN and ignored, so old configs at least log something rather than silently falling back to defaults.

No backward-compatible aliases: old `SILO_*` vars and `--silo-*` flags stop being recognized.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.

BREAKING CHANGE: environment variables now use the `RHYDB_` prefix instead of `SILO_`, and the `rhydb append` options `--silo-directory`/`--silo-data-source` are renamed to `--data-directory`/`--data-source` (YAML keys `dataDirectory`/`dataSource`). Update env vars, CLI flags, YAML config keys, and Docker/compose setups accordingly.