### PR TITLE
chore: rename `CHECK_SILO_QUERY` -> `CHECK_RHYDB_QUERY`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Use `using my::Type` (only in `.cpp` files) deliberately for all `rhydb::...` ty
 - `std::expected<T, Error>` for recoverable errors.
 - `SILO_ASSERT()` for debug assertions.
 - Arrow functions: use `ARROW_ASSIGN_OR_RAISE` / `ARROW_RETURN_NOT_OK` macros.
-- `CHECK_SILO_QUERY(condition, fmt, args...)` for query validation errors shown to users.
+- `CHECK_RHYDB_QUERY(condition, fmt, args...)` for query validation errors shown to users.
 - Exceptions only for preprocessing/initialization.
 
 ### Logging

--- a/src/rhydb/query_engine/illegal_query_exception.h
+++ b/src/rhydb/query_engine/illegal_query_exception.h
@@ -5,7 +5,7 @@
 
 #include <fmt/format.h>
 
-#define CHECK_RHYDB_QUERY(condition, ...)                                \
+#define CHECK_RHYDB_QUERY(condition, ...)                               \
    do {                                                                 \
       const bool condition_bool = condition;                            \
       if (!(condition_bool)) {                                          \

--- a/src/rhydb/query_engine/illegal_query_exception.h
+++ b/src/rhydb/query_engine/illegal_query_exception.h
@@ -5,7 +5,7 @@
 
 #include <fmt/format.h>
 
-#define CHECK_SILO_QUERY(condition, ...)                                \
+#define CHECK_RHYDB_QUERY(condition, ...)                                \
    do {                                                                 \
       const bool condition_bool = condition;                            \
       if (!(condition_bool)) {                                          \

--- a/src/rhydb/query_engine/operators/aggregate_node.cpp
+++ b/src/rhydb/query_engine/operators/aggregate_node.cpp
@@ -42,7 +42,7 @@ arrow::acero::AggregateNodeOptions buildAggregateOptions(
       switch (agg.function) {
          case AggregateFunction::COUNT: {
             // TODO(#1231) implement path including source column
-            CHECK_SILO_QUERY(
+            CHECK_RHYDB_QUERY(
                !agg.source_column.has_value(), "count(<column_ref>) not yet implemented"
             );
             options = std::make_shared<arrow::compute::CountOptions>(

--- a/src/rhydb/query_engine/operators/most_recent_common_ancestor_node.cpp
+++ b/src/rhydb/query_engine/operators/most_recent_common_ancestor_node.cpp
@@ -93,12 +93,12 @@ arrow::Result<arrow::acero::ExecNode*> MostRecentCommonAncestorNode::addToExecPl
 ) const {
    auto bitmap_filter = computeFilter(filter, *table);
 
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table->schema->getColumn(column_name).has_value(),
       "Column '{}' not found in table schema",
       column_name
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table->schema->getColumn(column_name).value().type == schema::ColumnType::STRING,
       "MostRecentCommonAncestor action cannot be called on column '{}' as it is not a column "
       "of type STRING",
@@ -106,7 +106,7 @@ arrow::Result<arrow::acero::ExecNode*> MostRecentCommonAncestorNode::addToExecPl
    );
    const auto& optional_table_metadata =
       table->schema->getColumnMetadata<storage::column::StringColumn>(column_name);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       optional_table_metadata.has_value() &&
          optional_table_metadata.value()->phylo_tree.has_value(),
       "MostRecentCommonAncestor action cannot be called on Column '{}' as it does not have a "

--- a/src/rhydb/query_engine/operators/phylo_subtree_node.cpp
+++ b/src/rhydb/query_engine/operators/phylo_subtree_node.cpp
@@ -93,19 +93,19 @@ arrow::Result<arrow::acero::ExecNode*> PhyloSubtreeNode::addToExecPlan(
 ) const {
    auto bitmap_filter = computeFilter(filter, *table);
 
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table->schema->getColumn(column_name).has_value(),
       "Column '{}' not found in table schema",
       column_name
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table->schema->getColumn(column_name).value().type == schema::ColumnType::STRING,
       "PhyloSubtree action cannot be called on column '{}' as it is not a column of type STRING",
       column_name
    );
    const auto& optional_table_metadata =
       table->schema->getColumnMetadata<storage::column::StringColumn>(column_name);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       optional_table_metadata.has_value() &&
          optional_table_metadata.value()->phylo_tree.has_value(),
       "PhyloSubtree action cannot be called on Column '{}' as it does not have a "

--- a/src/rhydb/query_engine/optimizer/filter_pushdown_pass.cpp
+++ b/src/rhydb/query_engine/optimizer/filter_pushdown_pass.cpp
@@ -159,7 +159,7 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::SchemaNode& no
    // schema() reports a child's output schema; it is a result-producing source with no
    // place to push a predicate into. A filter() applied to its output therefore cannot be
    // realized -> reject the query.
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       current_filters.empty(),
       "filter() cannot be applied to the output of schema(); schema() is a source operator "
       "and its result cannot be filtered. Apply filter() before schema() instead."
@@ -182,7 +182,7 @@ operators::QueryNodePtr FilterPushdownPass::operator()(operators::JoinNode& node
    // outer join changes the result (null-extended rows would no longer be filtered out), as
    // does pushing a predicate that references no column at all. Rather than push unsafely,
    // reject any filter above join() and point the user at the inputs.
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       current_filters.empty(),
       "filter() cannot be applied to the output of join(); a filter above a join cannot be "
       "pushed into a join input safely. Apply the filter to one of the join inputs instead."

--- a/src/rhydb/query_engine/optimizer/node_resolution_pass.cpp
+++ b/src/rhydb/query_engine/optimizer/node_resolution_pass.cpp
@@ -33,12 +33,12 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
    operators::UnresolvedMutationsNode<SymbolType>& node
 ) {
    auto scan = getTableScanOrNone(*node.child);
-   CHECK_SILO_QUERY(scan.has_value(), "mutations() must be applied to a table scan");
+   CHECK_RHYDB_QUERY(scan.has_value(), "mutations() must be applied to a table scan");
 
    std::vector<schema::ColumnIdentifier> bound_sequence_columns;
    for (const auto& sequence_name : node.sequence_names) {
       auto column_identifier = (*scan)->table->schema->getColumn(sequence_name);
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          column_identifier.has_value() && column_identifier.value().type == SymbolType::COLUMN_TYPE,
          "The database does not contain the {} sequence '{}'",
          SymbolType::SYMBOL_NAME,
@@ -67,7 +67,7 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
    } else {
       for (const auto& field_str : node.fields) {
          auto it = std::ranges::find(operators::MutationsNode<SymbolType>::VALID_FIELDS, field_str);
-         CHECK_SILO_QUERY(
+         CHECK_RHYDB_QUERY(
             it != operators::MutationsNode<SymbolType>::VALID_FIELDS.end(),
             "The attribute 'fields' contains an invalid field '{}'. Valid fields are "
             "mutationFrom, mutationTo, position, sequenceName, proportion, coverage, count.",
@@ -92,12 +92,12 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
    operators::UnresolvedInsertionsNode<SymbolType>& node
 ) {
    auto scan = getTableScanOrNone(*node.child);
-   CHECK_SILO_QUERY(scan.has_value(), "insertions() must be applied to a table scan");
+   CHECK_RHYDB_QUERY(scan.has_value(), "insertions() must be applied to a table scan");
 
    std::vector<schema::ColumnIdentifier> bound_sequence_columns;
    for (const auto& sequence_name : node.sequence_names) {
       auto column_identifier = (*scan)->table->schema->getColumn(sequence_name);
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          column_identifier.has_value() && column_identifier.value().type == SymbolType::COLUMN_TYPE,
          "The database does not contain the {} sequence '{}'",
          SymbolType::SYMBOL_NAME,
@@ -138,7 +138,7 @@ operators::QueryNodePtr NodeResolutionPass::operator()(operators::AggregateNode&
 operators::QueryNodePtr NodeResolutionPass::operator()(operators::UnresolvedPhyloSubtreeNode& node
 ) {
    auto scan = getTableScanOrNone(*node.child);
-   CHECK_SILO_QUERY(scan.has_value(), "phyloSubtree() must be applied to a table scan");
+   CHECK_RHYDB_QUERY(scan.has_value(), "phyloSubtree() must be applied to a table scan");
 
    return std::make_unique<operators::PhyloSubtreeNode>(
       std::move((*scan)->table),
@@ -154,7 +154,7 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
    operators::UnresolvedMostRecentCommonAncestorNode& node
 ) {
    auto scan = getTableScanOrNone(*node.child);
-   CHECK_SILO_QUERY(scan.has_value(), "mostRecentCommonAncestor() must be applied to a table scan");
+   CHECK_RHYDB_QUERY(scan.has_value(), "mostRecentCommonAncestor() must be applied to a table scan");
    return std::make_unique<operators::MostRecentCommonAncestorNode>(
       std::move((*scan)->table),
       std::move((*scan)->filter),

--- a/src/rhydb/query_engine/optimizer/node_resolution_pass.cpp
+++ b/src/rhydb/query_engine/optimizer/node_resolution_pass.cpp
@@ -154,7 +154,9 @@ operators::QueryNodePtr NodeResolutionPass::operator()(
    operators::UnresolvedMostRecentCommonAncestorNode& node
 ) {
    auto scan = getTableScanOrNone(*node.child);
-   CHECK_RHYDB_QUERY(scan.has_value(), "mostRecentCommonAncestor() must be applied to a table scan");
+   CHECK_RHYDB_QUERY(
+      scan.has_value(), "mostRecentCommonAncestor() must be applied to a table scan"
+   );
    return std::make_unique<operators::MostRecentCommonAncestorNode>(
       std::move((*scan)->table),
       std::move((*scan)->filter),

--- a/src/rhydb/query_engine/query_parse_sequence_name.h
+++ b/src/rhydb/query_engine/query_parse_sequence_name.h
@@ -8,7 +8,7 @@ namespace rhydb {
 
 template <typename SymbolType>
 std::string validateSequenceName(std::string sequence_name, const schema::TableSchema& schema) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       schema.getColumn(sequence_name).has_value() &&
          schema.getColumn(sequence_name).value().type == SymbolType::COLUMN_TYPE,
       "Database does not contain the {} Sequence with name: '{}'",

--- a/src/rhydb/query_engine/saneql/ast.cpp
+++ b/src/rhydb/query_engine/saneql/ast.cpp
@@ -113,7 +113,7 @@ ExpressionPtr makeExpr(ExpressionVariant value, SourceLocation location) {
 }
 
 std::string extractIdentifierName(const Expression& expression) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<Identifier>(expression.value),
       "expected identifier at {}:{}",
       expression.location.line,
@@ -123,7 +123,7 @@ std::string extractIdentifierName(const Expression& expression) {
 }
 
 std::string extractStringLiteral(const Expression& expression) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<StringLiteral>(expression.value),
       "expected string literal at {}:{}",
       expression.location.line,
@@ -133,19 +133,19 @@ std::string extractStringLiteral(const Expression& expression) {
 }
 
 uint32_t extractUint32Literal(const Expression& expression) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<IntLiteral>(expression.value),
       "expected integer literal at {}:{}",
       expression.location.line,
       expression.location.column
    );
    int64_t parsed_value = std::get<IntLiteral>(expression.value).value;
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       parsed_value >= std::numeric_limits<uint32_t>::min(),
       "Cannot cast {} to uint32. Value out of range",
       parsed_value
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       parsed_value <= std::numeric_limits<uint32_t>::max(),
       "Cannot cast {} to uint32. Value out of range",
       parsed_value
@@ -154,19 +154,19 @@ uint32_t extractUint32Literal(const Expression& expression) {
 }
 
 int32_t extractInt32Literal(const Expression& expression) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<IntLiteral>(expression.value),
       "expected integer literal at {}:{}",
       expression.location.line,
       expression.location.column
    );
    int64_t parsed_value = std::get<IntLiteral>(expression.value).value;
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       parsed_value >= std::numeric_limits<int32_t>::min(),
       "Cannot cast {} to int32. Value out of range",
       parsed_value
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       parsed_value <= std::numeric_limits<int32_t>::max(),
       "Cannot cast {} to int32. Value out of range",
       parsed_value
@@ -175,7 +175,7 @@ int32_t extractInt32Literal(const Expression& expression) {
 }
 
 int64_t extractInt64Literal(const Expression& expression) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<IntLiteral>(expression.value),
       "expected integer literal at {}:{}",
       expression.location.line,
@@ -197,7 +197,7 @@ double extractNumericAsFloatLiteral(const Expression& expression) {
 }
 
 bool extractBoolLiteral(const Expression& expression) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<BoolLiteral>(expression.value),
       "expected boolean literal at {}:{}",
       expression.location.line,
@@ -207,14 +207,14 @@ bool extractBoolLiteral(const Expression& expression) {
 }
 
 common::Date32 extractDateValue(const Expression& expression) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<TypeCast>(expression.value),
       "expected date type cast at {}:{}",
       expression.location.line,
       expression.location.column
    );
    const auto& cast = std::get<TypeCast>(expression.value);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       cast.target_type == "date",
       "expected cast to 'date', got '{}' at {}:{}",
       cast.target_type,
@@ -223,7 +223,7 @@ common::Date32 extractDateValue(const Expression& expression) {
    );
    auto date_string = extractStringLiteral(*cast.operand);
    auto result = common::stringToDate32(date_string);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       result.has_value(),
       "invalid date '{}' at {}:{}: {}",
       date_string,
@@ -242,7 +242,7 @@ std::optional<common::Date32> extractOptionalDateValue(const Expression& express
 }
 
 std::vector<std::string> extractSetOfIdentifiers(const Expression& expression) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<SetLiteral>(expression.value),
       "expected set literal at {}:{}",
       expression.location.line,
@@ -258,7 +258,7 @@ std::vector<std::string> extractSetOfIdentifiers(const Expression& expression) {
 }
 
 const SetLiteral& extractSetLiteral(const Expression& expression) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<SetLiteral>(expression.value),
       "expected set literal at {}:{}",
       expression.location.line,

--- a/src/rhydb/query_engine/saneql/ast_to_query.cpp
+++ b/src/rhydb/query_engine/saneql/ast_to_query.cpp
@@ -982,7 +982,9 @@ operators::QueryNodePtr buildScanNode(
    const auto& name = std::get<ast::Identifier>(ast.value).name;
    auto table_name = schema::TableName(name);
    auto iter = tables.find(table_name);
-   CHECK_RHYDB_QUERY(iter != tables.end(), "table '{}' not found in database", table_name.getName());
+   CHECK_RHYDB_QUERY(
+      iter != tables.end(), "table '{}' not found in database", table_name.getName()
+   );
    const auto table_schema = iter->second->schema;
    std::vector<schema::ColumnIdentifier> fields = iter->second->schema->getColumnIdentifiers();
    auto table_scan = std::make_unique<operators::TableScanNode>(

--- a/src/rhydb/query_engine/saneql/ast_to_query.cpp
+++ b/src/rhydb/query_engine/saneql/ast_to_query.cpp
@@ -83,7 +83,7 @@ schema::ColumnIdentifier resolveColumn(
 ) {
    const auto found =
       std::ranges::find_if(schema, [&](const auto& col) { return col.name == column_name; });
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       found != schema.end(), "The database does not contain the column '{}'", column_name
    );
    return *found;
@@ -100,7 +100,7 @@ std::unique_ptr<scalar_expressions::ScalarExpression> convertScalarFunctionCall(
    std::string_view error_context
 ) {
    const auto* entry = ScalarFunctionRegistry::instance().findFunction(call.function_name);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       entry != nullptr,
       "{} references unknown scalar function '{}' at {}:{}",
       error_context,
@@ -117,7 +117,7 @@ std::unique_ptr<scalar_expressions::ScalarExpression> convertScalarFunctionCall(
    for (const auto& referenced : expression->freeIUs()) {
       const bool exists =
          std::ranges::any_of(schema, [&](const auto& col) { return col.name == referenced.name; });
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          exists,
          "{} references unknown column '{}' at {}:{}",
          error_context,
@@ -146,7 +146,7 @@ std::unique_ptr<scalar_expressions::ScalarExpression> convertToScalar(
    if (std::holds_alternative<ast::Identifier>(value)) {
       const auto& name = std::get<ast::Identifier>(value).name;
       auto found = std::ranges::find_if(schema, [&](const auto& col) { return col.name == name; });
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          found != schema.end(),
          "{} references unknown column '{}' at {}:{}",
          error_context,
@@ -310,7 +310,7 @@ ScalarExpressionPtr handleIn(
 ) {
    auto column_name = extractIdentifierName(args.at("column"));
    const auto& set_expr = args.at("values");
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<ast::SetLiteral>(set_expr.value),
       "in() expects a set literal argument at {}:{}",
       set_expr.location.line,
@@ -402,7 +402,7 @@ ScalarExpressionPtr handleLike(
    auto column_name = extractIdentifierName(args.at("column"));
    auto pattern = extractStringLiteral(args.at("pattern"));
    auto regex = std::make_unique<re2::RE2>(pattern);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       regex->ok(),
       "Invalid Regular Expression. The parsing of the regular expression failed with the "
       "error '{}'. See https://github.com/google/re2/wiki/Syntax for a Syntax specification.",
@@ -419,10 +419,10 @@ ScalarExpressionPtr handleSymbolEquals(
    const std::vector<schema::ColumnIdentifier>& schema
 ) {
    const uint32_t position = extractUint32Literal(args.at("position"));
-   CHECK_SILO_QUERY(position > 0, "The field 'position' is 1-indexed. Value of 0 not allowed.");
+   CHECK_RHYDB_QUERY(position > 0, "The field 'position' is 1-indexed. Value of 0 not allowed.");
    const uint32_t position_idx = position - 1;
    auto symbol_str = extractStringLiteral(args.at("symbol"));
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       symbol_str.size() == 1, "{}() symbol must be a single character", args.functionName()
    );
    auto sequence_name = extractStringLiteral(args.at("sequenceName"));
@@ -434,7 +434,7 @@ ScalarExpressionPtr handleSymbolEquals(
       );
    }
    auto symbol = SymbolType::charToSymbol(symbol_char);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       symbol.has_value(), "{}() invalid symbol '{}'", args.functionName(), symbol_char
    );
    return std::make_unique<scalar_expressions::SymbolEquals<SymbolType>>(
@@ -448,7 +448,7 @@ ScalarExpressionPtr handleHasMutation(
    const std::vector<schema::ColumnIdentifier>& schema
 ) {
    const uint32_t position = extractUint32Literal(args.at("position"));
-   CHECK_SILO_QUERY(position > 0, "The field 'position' is 1-indexed. Value of 0 not allowed.");
+   CHECK_RHYDB_QUERY(position > 0, "The field 'position' is 1-indexed. Value of 0 not allowed.");
    auto sequence_name = extractStringLiteral(args.at("sequenceName"));
    auto column = resolveColumn(sequence_name, schema);
    return std::make_unique<scalar_expressions::HasMutation<SymbolType>>(
@@ -463,7 +463,7 @@ ScalarExpressionPtr handleInsertionContains(
 ) {
    auto position = extractUint32Literal(args.at("position"));
    auto value = extractStringLiteral(args.at("value"));
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       !value.empty(),
       "The field 'value' in an InsertionContains expression must not be an empty string"
    );
@@ -480,7 +480,7 @@ ScalarExpressionPtr handleAt(
 ) {
    auto input_column = extractIdentifierName(args.at("input"));
    const uint32_t position = extractUint32Literal(args.at("position"));
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       position > 0, "at(): the field 'position' is 1-indexed. Value of 0 not allowed."
    );
    // Resolve the referenced column against the available schema so the At carries the
@@ -488,7 +488,7 @@ ScalarExpressionPtr handleAt(
    // placeholder type; the caller reports the (contextual) unknown-column error.
    const auto found =
       std::ranges::find_if(schema, [&](const auto& col) { return col.name == input_column; });
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       found != schema.end(), "at(): the field {} is not found in the current context", input_column
    );
    return std::make_unique<scalar_expressions::At>(
@@ -503,12 +503,12 @@ ScalarExpressionPtr handleIsoWeek(
    auto input_column = extractIdentifierName(args.at("input"));
    const auto found =
       std::ranges::find_if(schema, [&](const auto& col) { return col.name == input_column; });
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       found != schema.end(),
       "isoWeek(): the field {} is not found in the current context",
       input_column
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       found->type == schema::ColumnType::DATE32,
       "isoWeek(): the field {} must be a date column",
       input_column
@@ -566,7 +566,7 @@ scalar_expressions::MutationProfile<SymbolType>::Mutation parseMutationRecord(
    for (const auto& field : record.fields) {
       if (field.name == "position") {
          const uint32_t pos_val = extractUint32Literal(*field.value);
-         CHECK_SILO_QUERY(
+         CHECK_RHYDB_QUERY(
             pos_val > 0,
             "The 'position' field in a {} MutationProfile mutation is 1-indexed; "
             "value 0 is not allowed",
@@ -580,23 +580,23 @@ scalar_expressions::MutationProfile<SymbolType>::Mutation parseMutationRecord(
       }
    }
 
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       found_position,
       "Each mutation in a {} MutationProfile expression must have a 'position' field",
       SymbolType::SYMBOL_NAME
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       found_symbol,
       "Each mutation in a {} MutationProfile expression must have a 'symbol' field",
       SymbolType::SYMBOL_NAME
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       symbol_str.size() == 1,
       "The 'symbol' field in a {} MutationProfile mutation must be a single character",
       SymbolType::SYMBOL_NAME
    );
    const auto sym = SymbolType::charToSymbol(symbol_str[0]);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       sym.has_value(),
       "Invalid {} symbol '{}' in MutationProfile",
       SymbolType::SYMBOL_NAME,
@@ -613,7 +613,7 @@ std::vector<typename scalar_expressions::MutationProfile<SymbolType>::Mutation> 
    using MP = scalar_expressions::MutationProfile<SymbolType>;
    std::vector<typename MP::Mutation> parsed_mutations;
    for (const auto& elem : mutations_set.elements) {
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          std::holds_alternative<ast::RecordLiteral>(elem->value),
          "Each element of 'mutations' in a {} MutationProfile expression must be a record "
          "literal with 'position' and 'symbol' fields",
@@ -641,7 +641,7 @@ ScalarExpressionPtr handleMutationProfile(
    const int input_count = static_cast<int>(query_seq_expr != nullptr) +
                            static_cast<int>(sequence_id_expr != nullptr) +
                            static_cast<int>(mutations_expr != nullptr);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       input_count == 1,
       "Exactly one of 'querySequence', 'sequenceId', or 'mutations' must be provided in a {} "
       "MutationProfile expression, but {} were provided",
@@ -662,7 +662,7 @@ ScalarExpressionPtr handleMutationProfile(
       );
    }
 
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<ast::SetLiteral>(mutations_expr->value),
       "The 'mutations' argument of a {} MutationProfile expression must be a set literal",
       SymbolType::SYMBOL_NAME
@@ -694,7 +694,7 @@ std::unique_ptr<scalar_expressions::ScalarExpression> convertToFilter(
             return std::make_unique<scalar_expressions::BoolLiteral>(node.value);
          } else if constexpr (std::is_same_v<T, ast::FunctionCall>) {
             const auto* entry = ScalarFunctionRegistry::instance().findFunction(node.function_name);
-            CHECK_SILO_QUERY(entry != nullptr, "unknown scalar function '{}'", node.function_name);
+            CHECK_RHYDB_QUERY(entry != nullptr, "unknown scalar function '{}'", node.function_name);
             auto bound = bindArguments(
                node.function_name, entry->signature, node.positional_arguments, node.named_arguments
             );
@@ -702,7 +702,7 @@ std::unique_ptr<scalar_expressions::ScalarExpression> convertToFilter(
             // The registry also holds value-producing scalar functions (e.g. `at`),
             // which are not filter predicates. Reject them here rather than letting a
             // non-boolean expression reach compile().
-            CHECK_SILO_QUERY(
+            CHECK_RHYDB_QUERY(
                expression->type() == schema::ColumnType::BOOL,
                "scalar function '{}' produces a {} value and cannot be used as a filter "
                "predicate at {}:{}",
@@ -748,7 +748,7 @@ operators::AggregateDefinition parseAggregateDefinition(
    const ast::RecordField& field,
    const std::vector<schema::ColumnIdentifier>& schema
 ) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<ast::FunctionCall>(field.value->value),
       "aggregate definition '{}' must be a function call (e.g. count(), sum(col))",
       field.name
@@ -761,7 +761,7 @@ operators::AggregateDefinition parseAggregateDefinition(
       auto found = std::ranges::find_if(schema, [&](const auto& col) {
          return col.name == source_column_name;
       });
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          found != schema.end(),
          "source column {} is not present in the input's output schema",
          source_column_name
@@ -782,7 +782,7 @@ std::vector<schema::ColumnIdentifier> parseGroupByFields(
       auto group_by_name = extractIdentifierName(*elem);
       auto found =
          std::ranges::find_if(schema, [&](const auto& col) { return col.name == group_by_name; });
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          found != schema.end(),
          "groupBy field '{}' is not present in the input's output schema",
          group_by_name
@@ -800,7 +800,7 @@ GroupByArgs parseGroupBySpecs(
 
    // Parse aggregates (required) — a RecordLiteral like {count:=count()}
    const auto& agg_expr = args.at("aggregates");
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<ast::RecordLiteral>(agg_expr.value),
       "groupBy aggregates must be a record literal like {{count:=count()}}"
    );
@@ -845,7 +845,7 @@ OrderByField parseOrderByField(
          std::ranges::find_if(child_schema.begin(), child_schema.end(), [&](const auto& col) {
             return col.name == identifier_name;
          });
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          found != child_schema.end(),
          "OrderByField {} is not contained in the result of this operation. "
          "Allowed values are {}.",
@@ -856,14 +856,14 @@ OrderByField parseOrderByField(
    }
    if (std::holds_alternative<ast::FunctionCall>(expression.value)) {
       const auto& call = std::get<ast::FunctionCall>(expression.value);
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          call.function_name == "asc" || call.function_name == "desc",
          "orderBy field must be an identifier or asc()/desc() call, got '{}' at {}:{}",
          call.function_name,
          expression.location.line,
          expression.location.column
       );
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          call.positional_arguments.size() == 1 && call.named_arguments.empty(),
          "{}() expects exactly one argument",
          call.function_name
@@ -873,7 +873,7 @@ OrderByField parseOrderByField(
          std::ranges::find_if(child_schema.begin(), child_schema.end(), [&](const auto& col) {
             return col.name == identifier_name;
          });
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          found != child_schema.end(),
          "OrderByField {} is not contained in the result of this operation. "
          "Allowed values are {}.",
@@ -982,7 +982,7 @@ operators::QueryNodePtr buildScanNode(
    const auto& name = std::get<ast::Identifier>(ast.value).name;
    auto table_name = schema::TableName(name);
    auto iter = tables.find(table_name);
-   CHECK_SILO_QUERY(iter != tables.end(), "table '{}' not found in database", table_name.getName());
+   CHECK_RHYDB_QUERY(iter != tables.end(), "table '{}' not found in database", table_name.getName());
    const auto table_schema = iter->second->schema;
    std::vector<schema::ColumnIdentifier> fields = iter->second->schema->getColumnIdentifiers();
    auto table_scan = std::make_unique<operators::TableScanNode>(
@@ -1045,7 +1045,7 @@ operators::QueryNodePtr handleProject(
    for (const auto& name : field_names) {
       auto found =
          std::ranges::find_if(child_schema, [&](const auto& col) { return col.name == name; });
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          found != child_schema.end(),
          "project field '{}' is not present in the input's output schema",
          name
@@ -1083,12 +1083,12 @@ operators::QueryNodePtr handleMap(
    const ChildConverter& convert_child
 ) {
    const auto& expressions_argument = args.at("expressions");
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<ast::RecordLiteral>(expressions_argument.value),
       "map() expects a record of assignments like {x := 3, y := age}"
    );
    const auto& record = std::get<ast::RecordLiteral>(expressions_argument.value);
-   CHECK_SILO_QUERY(!record.fields.empty(), "map() requires at least one assignment");
+   CHECK_RHYDB_QUERY(!record.fields.empty(), "map() requires at least one assignment");
 
    auto child = convert_child(args.at("input"), tables);
    const auto child_schema = child->getOutputSchema();
@@ -1097,7 +1097,7 @@ operators::QueryNodePtr handleMap(
    std::vector<operators::MapNode::Assignment> assignments;
    assignments.reserve(record.fields.size());
    for (const auto& field : record.fields) {
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          seen_output_names.insert(field.name).second,
          "map() assigns the output column '{}' more than once",
          field.name
@@ -1125,7 +1125,7 @@ operators::QueryNodePtr handleMutations(
       sequence_names = extractSetOfIdentifiers(*seq_expr);
    }
    auto min_proportion = extractNumericAsFloatLiteral(args.at("minProportion"));
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       min_proportion >= 0 && min_proportion <= 1,
       "Invalid proportion: minProportion must be in interval [0.0, 1.0]"
    );
@@ -1196,7 +1196,7 @@ operators::QueryNodePtr handleLimit(
 ) {
    auto child = convert_child(args.at("input"), tables);
    const uint32_t limit_val = extractUint32Literal(args.at("count"));
-   CHECK_SILO_QUERY(limit_val > 0, "limit must be a positive number");
+   CHECK_RHYDB_QUERY(limit_val > 0, "limit must be a positive number");
    auto offset = args.getOptionalUint32("offset");
    return std::make_unique<operators::FetchNode>(std::move(child), limit_val, offset);
 }
@@ -1295,7 +1295,7 @@ ResolvedJoinColumn resolveJoinColumn(
    const std::vector<schema::ColumnIdentifier>& left_schema,
    const std::vector<schema::ColumnIdentifier>& right_schema
 ) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<ast::Identifier>(expression.value),
       "join() on-expression must compare column identifiers, got '{}' at {}:{}",
       expression.toString(),
@@ -1305,13 +1305,13 @@ ResolvedJoinColumn resolveJoinColumn(
    const auto name = extractIdentifierName(expression);
    auto in_left = findColumnByName(left_schema, name);
    auto in_right = findColumnByName(right_schema, name);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       !(in_left.has_value() && in_right.has_value()),
       "join() on-expression references column '{}', which exists in both inputs and is therefore "
       "ambiguous. Rename one side (e.g. via map()) before joining.",
       name
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       in_left.has_value() || in_right.has_value(),
       "join() on-expression references unknown column '{}'",
       name
@@ -1329,7 +1329,7 @@ void collectJoinKeys(
    const std::vector<schema::ColumnIdentifier>& right_schema,
    JoinKeys& keys
 ) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<ast::BinaryExpr>(on_expression.value),
       "join() on-expression must be an equality between a left and a right column, or a "
       "conjunction (&&) of such equalities, at {}:{}",
@@ -1342,7 +1342,7 @@ void collectJoinKeys(
       collectJoinKeys(*binary.right, left_schema, right_schema, keys);
       return;
    }
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       binary.op == BinaryOp::EQUALS,
       "join() on-expression only supports equality (=) comparisons, optionally combined with "
       "'&&', at {}:{}",
@@ -1351,7 +1351,7 @@ void collectJoinKeys(
    );
    auto first = resolveJoinColumn(*binary.left, left_schema, right_schema);
    auto second = resolveJoinColumn(*binary.right, left_schema, right_schema);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       first.side != second.side,
       "join() on-expression equality must reference one column from each input, but both '{}' and "
       "'{}' resolve to the same input at {}",
@@ -1359,7 +1359,7 @@ void collectJoinKeys(
       binary.right->toString(),
       on_expression.location.toString()
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       first.column.type == second.column.type,
       "join() on-expression equality must reference equal column types from each input, but "
       "'{}' and '{}' have mismatching types {} and {} at {}",
@@ -1437,7 +1437,7 @@ operators::QueryNodePtr handleJoin(
          overlapping_names.push_back(left_column.name);
       }
    }
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       overlapping_names.empty(),
       "join() requires the two inputs to have disjoint column names, but the column(s) [{}] are "
       "present in both. Rename one side (e.g. via map()) before joining.",
@@ -1446,7 +1446,7 @@ operators::QueryNodePtr handleJoin(
 
    JoinKeys keys;
    collectJoinKeys(args.at("on"), left_schema, right_schema, keys);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       !keys.left.empty(),
       "join() on-expression must contain at least one equality between a left and a right column"
    );
@@ -1469,7 +1469,7 @@ operators::QueryNodePtr handleUnionAll(
 
    auto left_schema = left->getOutputSchema();
    auto right_schema = right->getOutputSchema();
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       left_schema == right_schema,
       "unionAll requires both inputs to have the same schema "
       "(same column names, types, and order). "
@@ -1492,7 +1492,7 @@ operators::QueryNodePtr convertExpression(
       return buildScanNode(ast, tables);
    }
 
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       std::holds_alternative<ast::FunctionCall>(ast.value),
       "expected table reference or function call at {}:{}",
       ast.location.line,
@@ -1501,7 +1501,7 @@ operators::QueryNodePtr convertExpression(
    const auto& call = std::get<ast::FunctionCall>(ast.value);
 
    const auto* entry = FunctionRegistry::instance().findFunction(call.function_name);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       entry != nullptr,
       "unknown function '{}' at {}:{}",
       call.function_name,

--- a/src/rhydb/query_engine/saneql/function_registry.cpp
+++ b/src/rhydb/query_engine/saneql/function_registry.cpp
@@ -17,7 +17,7 @@ BoundArguments::BoundArguments(
 
 const ast::Expression& BoundArguments::at(const std::string& name) const {
    auto it = bound_.find(name);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       it != bound_.end(), "{}(): required argument '{}' is missing", function_name_, name
    );
    return *it->second;
@@ -75,7 +75,7 @@ BoundArguments bindArguments(
          }
          ++next_param;
       }
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          target != nullptr, "{}() received too many positional arguments", function_name
       );
       bound[target->name] = pos_arg.value.get();
@@ -89,13 +89,13 @@ BoundArguments bindArguments(
 
    // Bind named arguments
    for (const auto& named_arg : named) {
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          valid_names.contains(named_arg.name),
          "{}() received unknown argument '{}'",
          function_name,
          named_arg.name
       );
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          !bound.contains(named_arg.name),
          "{}() received duplicate argument '{}'",
          function_name,
@@ -106,7 +106,7 @@ BoundArguments bindArguments(
 
    // Check that all required parameters are bound
    for (const auto& param : signature.parameters) {
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          !param.required || bound.contains(param.name),
          "{}() requires argument '{}'",
          function_name,

--- a/src/rhydb/query_engine/scalar_expressions/comparison.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/comparison.cpp
@@ -124,7 +124,7 @@ std::unique_ptr<Operator> compileTypedComparison(
    std::string_view type_name,
    typename ColumnType::value_type value
 ) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       column_map.contains(column_name), "The column '{}' is not of type {}", column_name, type_name
    );
    return std::make_unique<Selection>(
@@ -185,7 +185,7 @@ std::unique_ptr<Operator> compileStringComparison(
       );
    }
 
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.columns.dictionary_encoded_columns.contains(column_name),
       "The column '{}' is not of type string",
       column_name
@@ -230,12 +230,12 @@ std::unique_ptr<Operator> compileBoolComparison(
 ) {
    // The column type is checked first so that comparing a non-bool column against a
    // bool literal reports the type mismatch rather than claiming the column is boolean.
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.columns.bool_columns.contains(column_name),
       "The column '{}' is not of type bool",
       column_name
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       comparator == Comparator::EQUALS || comparator == Comparator::NOT_EQUALS,
       "The comparison operators <,>,<=,>= are not supported for boolean column '{}'",
       column_name
@@ -265,12 +265,12 @@ std::unique_ptr<Operator> compileIntComparison(
          table, table.columns.int64_columns, column_name, comparator, "int64", value
       );
    }
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.columns.int32_columns.contains(column_name),
       "The column '{}' is not of type int",
       column_name
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       value >= std::numeric_limits<int32_t>::min() && value <= std::numeric_limits<int32_t>::max(),
       "Cannot cast {} to int32. Value out of range",
       value
@@ -324,12 +324,12 @@ std::unique_ptr<ScalarExpression> Comparison::rewrite(
    if (split.has_value()) {
       if (const auto* string_value = dynCast<StringLiteral>(split->value)) {
          const auto& column_name = split->column->column.name;
-         CHECK_SILO_QUERY(
+         CHECK_RHYDB_QUERY(
             table.schema->getColumn(column_name).has_value(),
             "The database does not contain the column '{}'",
             column_name
          );
-         CHECK_SILO_QUERY(
+         CHECK_RHYDB_QUERY(
             table.columns.string_columns.contains(column_name) ||
                table.columns.dictionary_encoded_columns.contains(column_name),
             "The column '{}' is not of type string",
@@ -348,7 +348,7 @@ std::unique_ptr<ScalarExpression> Comparison::rewrite(
 
 std::unique_ptr<Operator> Comparison::compile(const Table& table) const {
    auto split = splitColumnAndValue(left.get(), right.get());
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       split.has_value(),
       "A Comparison expression can only be compiled to a filter when exactly one side is a column "
       "reference and the other a literal value"
@@ -358,7 +358,7 @@ std::unique_ptr<Operator> Comparison::compile(const Table& table) const {
    const Comparator effective_comparator =
       split->column_on_right ? flipComparator(comparator) : comparator;
 
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.schema->getColumn(column_name).has_value(),
       "The database does not contain the column '{}'",
       column_name

--- a/src/rhydb/query_engine/scalar_expressions/date_between.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/date_between.cpp
@@ -59,12 +59,12 @@ using filter::operators::RangeSelection;
 using filter::operators::Selection;
 
 std::unique_ptr<Operator> DateBetween::compile(const storage::Table& table) const {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.schema->getColumn(column.name).has_value(),
       "The database does not contain the column '{}'",
       column.name
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.columns.date32_columns.contains(column.name),
       "The column '{}' is not of type date",
       column.name

--- a/src/rhydb/query_engine/scalar_expressions/float_between.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/float_between.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<ScalarExpression> FloatBetween::rewrite(
 
 std::unique_ptr<filter::operators::Operator> FloatBetween::compile(const storage::Table& table
 ) const {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.columns.float_columns.contains(column.name),
       "The database does not contain the float column '{}'",
       column.name

--- a/src/rhydb/query_engine/scalar_expressions/has_mutation.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/has_mutation.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<ScalarExpression> HasMutation<SymbolType>::rewrite(
 
    auto column_metadata =
       table.schema->getColumnMetadata<typename SymbolType::Column>(valid_sequence_name).value();
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       position_idx < column_metadata->reference_sequence.size(),
       "Has{}Mutation position is out of bounds {} > {}",
       SymbolType::SYMBOL_NAME,

--- a/src/rhydb/query_engine/scalar_expressions/insertion_contains.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/insertion_contains.cpp
@@ -58,7 +58,7 @@ std::unique_ptr<filter::operators::Operator> InsertionContains<SymbolType>::comp
    const storage::column::SequenceColumn<SymbolType>& sequence_store =
       sequence_stores.at(valid_sequence_name);
    const size_t reference_sequence_size = sequence_store.metadata->reference_sequence.size();
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       position_idx <= reference_sequence_size,
       "the requested insertion position ({}) is larger than the length of the reference sequence "
       "({}) for sequence '{}'",

--- a/src/rhydb/query_engine/scalar_expressions/int_between.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/int_between.cpp
@@ -28,7 +28,7 @@ namespace {
 /// literal.
 void checkBoundFitsInt32(std::optional<int64_t> bound) {
    if (bound.has_value()) {
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          bound.value() >= std::numeric_limits<int32_t>::min() &&
             bound.value() <= std::numeric_limits<int32_t>::max(),
          "Cannot cast {} to int32. Value out of range",
@@ -108,12 +108,12 @@ std::unique_ptr<filter::operators::Operator> IntBetween::compileFor(
 
 std::unique_ptr<filter::operators::Operator> IntBetween::compile(const storage::Table& table
 ) const {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.schema->getColumn(column.name).has_value(),
       "The database does not contain the column '{}'",
       column.name
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.columns.int32_columns.contains(column.name) ||
          table.columns.int64_columns.contains(column.name),
       "The column '{}' is not of type int32 or int64",

--- a/src/rhydb/query_engine/scalar_expressions/is_null.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/is_null.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<ScalarExpression> IsNull::rewrite(
 
 std::unique_ptr<filter::operators::Operator> IsNull::compile(const storage::Table& table) const {
    const auto& maybe_target_column = table.schema->getColumn(column.name);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       maybe_target_column.has_value(),
       "The column '{}' is not contained in the database",
       column.name

--- a/src/rhydb/query_engine/scalar_expressions/lineage_filter.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/lineage_filter.cpp
@@ -50,7 +50,7 @@ std::optional<const roaring::Roaring*> LineageFilter::getBitmapForValue(
 
    const auto value_id_opt = lineage_column.getValueId(lineage.value());
 
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       value_id_opt.has_value(),
       "The lineage '{}' is not a valid lineage for column '{}'.",
       lineage.value(),
@@ -76,12 +76,12 @@ std::unique_ptr<ScalarExpression> LineageFilter::rewrite(
 
 std::unique_ptr<filter::operators::Operator> LineageFilter::compile(const storage::Table& table
 ) const {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.schema->getColumn(column.name).has_value(),
       "The database does not contain the column '{}'",
       column.name
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.columns.dictionary_encoded_columns.contains(column.name) &&
          table.columns.dictionary_encoded_columns.at(column.name).getLineageIndex().has_value(),
       "The database does not contain a lineage index for the column '{}'",

--- a/src/rhydb/query_engine/scalar_expressions/mutation_profile.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/mutation_profile.cpp
@@ -65,7 +65,7 @@ std::vector<typename SymbolType::Symbol> MutationProfile<SymbolType>::buildProfi
 ) const {
    const auto& query_sequence = std::get<QuerySequenceInput>(input).sequence;
    const size_t ref_len = sequence_column.metadata->reference_sequence.size();
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       query_sequence.size() == ref_len,
       "querySequence length {} does not match the reference sequence length {} for {} "
       "MutationProfile",
@@ -78,7 +78,7 @@ std::vector<typename SymbolType::Symbol> MutationProfile<SymbolType>::buildProfi
    profile.reserve(ref_len);
    for (char character : query_sequence) {
       const auto symbol = SymbolType::charToSymbol(character);
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          symbol.has_value(),
          "Invalid {} symbol '{}' in querySequence for MutationProfile",
          SymbolType::SYMBOL_NAME,
@@ -159,7 +159,7 @@ std::vector<typename SymbolType::Symbol> MutationProfile<SymbolType>::buildProfi
       return reconstructSequenceAtRow<SymbolType>(seq_col, found_row_id.value());
    }
 
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       false,
       "No sequence found with primary key '{}' in {} MutationProfile",
       seq_id,
@@ -182,7 +182,7 @@ std::vector<typename SymbolType::Symbol> MutationProfile<SymbolType>::buildProfi
    );
 
    for (const auto& mutation : mutation_list) {
-      CHECK_SILO_QUERY(
+      CHECK_RHYDB_QUERY(
          mutation.position_idx < ref_len,
          "{} MutationProfile mutation position {} is out of bounds (reference length {})",
          SymbolType::SYMBOL_NAME,

--- a/src/rhydb/query_engine/scalar_expressions/phylo_child_filter.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/phylo_child_filter.cpp
@@ -31,14 +31,14 @@ std::unique_ptr<filter::operators::Operator> createMatchingBitmap(
    const std::string& internal_node,
    storage::column::RowLayout row_layout
 ) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       string_column.metadata->phylo_tree.has_value(),
       "Phylotree filter cannot be called on Column '{}' as it does not have a phylogenetic tree "
       "associated with it",
       string_column.metadata->column_name
    );
    auto internal_tree_node = string_column.metadata->phylo_tree->getTreeNodeId(internal_node);
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       internal_tree_node.has_value(),
       "The node '{}' does not exist in the phylogenetic tree of column '{}'",
       internal_node,
@@ -64,12 +64,12 @@ std::unique_ptr<ScalarExpression> PhyloChildFilter::rewrite(
 
 std::unique_ptr<filter::operators::Operator> PhyloChildFilter::compile(const storage::Table& table
 ) const {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.schema->getColumn(column.name).has_value(),
       "The database does not contain the column '{}'",
       column.name
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.columns.string_columns.contains(column.name),
       "The column '{}' is not of type string",
       column.name

--- a/src/rhydb/query_engine/scalar_expressions/string_in_set.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/string_in_set.cpp
@@ -41,12 +41,12 @@ std::unique_ptr<ScalarExpression> StringInSet::rewrite(
    const storage::Table& table,
    AmbiguityMode /*mode*/
 ) const {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.schema->getColumn(column.name).has_value(),
       "The database does not contain the column '{}'",
       column.name
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.columns.string_columns.contains(column.name) ||
          table.columns.dictionary_encoded_columns.contains(column.name),
       "The column '{}' is not of type string",

--- a/src/rhydb/query_engine/scalar_expressions/string_search.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/string_search.cpp
@@ -62,12 +62,12 @@ std::unique_ptr<ScalarExpression> StringSearch::rewrite(
 
 std::unique_ptr<filter::operators::Operator> StringSearch::compile(const storage::Table& table
 ) const {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.schema->getColumn(column.name).has_value(),
       "The database does not contain the column '{}'",
       column.name
    );
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       table.columns.string_columns.contains(column.name) ||
          table.columns.dictionary_encoded_columns.contains(column.name),
       "The column '{}' is not of type string",

--- a/src/rhydb/query_engine/scalar_expressions/symbol_equals.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/symbol_equals.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<ScalarExpression> SymbolEquals<SymbolType>::rewrite(
    const auto& sequence_column =
       table.columns.getColumns<typename SymbolType::Column>().at(valid_sequence_name);
 
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       position_idx < sequence_column.metadata->reference_sequence.size(),
       "{} position is out of bounds {} > {}",
       getFilterName(),

--- a/src/rhydb/query_engine/scalar_expressions/symbol_in_set.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/symbol_in_set.cpp
@@ -234,7 +234,7 @@ std::unique_ptr<filter::operators::Operator> compileSymbolInSet(
    const std::vector<typename SymbolType::Symbol>& symbols,
    const storage::column::RowLayout& row_layout
 ) {
-   CHECK_SILO_QUERY(
+   CHECK_RHYDB_QUERY(
       position_idx < sequence_column.metadata->reference_sequence.size(),
       "SymbolInSet<{}> position is out of bounds {} > {}",
       SymbolType::SYMBOL_NAME,


### PR DESCRIPTION


### Summary
Part of #1489: renaming one of the macros.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [x] The implemented feature is covered by an appropriate test.
