### PR TITLE
test(query_engine): add unit tests for mutations and insertions operator

### DIFF
--- a/src/rhydb/database.cpp
+++ b/src/rhydb/database.cpp
@@ -244,7 +244,7 @@ std::string Database::getAminoAcidReferenceSequence(
       table_schema->getColumnMetadata<storage::column::SequenceColumn<AminoAcid>>(sequence_name);
    if (maybe_sequence_column_metadata == std::nullopt) {
       SPDLOG_ERROR(
-         "The database table {} does not contain the nucleotide sequence column {}",
+         "The database table {} does not contain the amino acid sequence column {}",
          table_name,
          sequence_name
       );

--- a/src/rhydb/query_engine/operators/insertions_node.test.cpp
+++ b/src/rhydb/query_engine/operators/insertions_node.test.cpp
@@ -66,6 +66,16 @@ const QueryTestScenario INSERTIONS_SEQUENCE_NAMES_SELECTS = {
    ])")
 };
 
+const QueryTestScenario INSERTIONS_WITH_INPUT_FILTER = {
+   .name = "INSERTIONS_WITH_INPUT_FILTER",
+   .query =
+      "default.filter(primaryKey = 's1' || primaryKey = 's2')"
+      ".insertions().orderBy({sequenceName, position})",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"position":2,"insertedSymbols":"TT","sequenceName":"segment1","count":2}
+   ])")
+};
+
 const QueryTestScenario INSERTIONS_ON_NON_SCAN = {
    .name = "INSERTIONS_ON_NON_SCAN",
    .query = "default.project({primaryKey}).insertions()",
@@ -119,6 +129,7 @@ QUERY_TEST(
    ::testing::Values(
       INSERTIONS_ALL_FIELDS,
       INSERTIONS_SEQUENCE_NAMES_SELECTS,
+      INSERTIONS_WITH_INPUT_FILTER,
       INSERTIONS_ON_NON_SCAN,
       INSERTIONS_UNKNOWN_SEQUENCE_NAME,
       INSERTIONS_WRONG_TYPE_SEQUENCE_NAME

--- a/src/rhydb/query_engine/operators/insertions_node.test.cpp
+++ b/src/rhydb/query_engine/operators/insertions_node.test.cpp
@@ -1,0 +1,136 @@
+#include <nlohmann/json.hpp>
+
+#include "rhydb/test/query_fixture.test.h"
+
+namespace {
+using rhydb::ReferenceGenomes;
+using rhydb::test::QueryTestData;
+using rhydb::test::QueryTestScenario;
+
+nlohmann::json createData(
+   const std::string& primary_key,
+   const nlohmann::json::array_t& segment1_insertions,
+   const nlohmann::json::array_t& segment2_insertions,
+   const nlohmann::json::array_t& gene1_insertions
+) {
+   return {
+      {"primaryKey", primary_key},
+      {"segment1", {{"sequence", "AAAA"}, {"insertions", segment1_insertions}}},
+      {"segment2", {{"sequence", "GG"}, {"insertions", segment2_insertions}}},
+      {"gene1", {{"sequence", "MK"}, {"insertions", gene1_insertions}}}
+   };
+}
+
+const auto DATABASE_CONFIG = R"(
+schema:
+  instanceName: "test"
+  metadata:
+    - name: "primaryKey"
+      type: "string"
+  primaryKey: "primaryKey"
+)";
+
+const auto REFERENCE_GENOMES =
+   ReferenceGenomes{{{"segment1", "AAAA"}, {"segment2", "GG"}}, {{"gene1", "MK"}}};
+
+const QueryTestData TEST_DATA{
+   .ndjson_input_data =
+      {createData("s1", {"2:TT"}, {}, {}),
+       createData("s2", {"2:TT"}, {}, {}),
+       createData("s3", {"3:G"}, {"1:CC"}, {}),
+       createData("s4", {}, {"1:CC"}, {"1:W"}),
+       createData("s5", {"2:TT"}, {}, {"1:W"})},
+   .database_config = DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES,
+   .without_unaligned_sequences = true
+};
+
+// ---- nucleotide insertions() ----
+
+const QueryTestScenario INSERTIONS_ALL_FIELDS = {
+   .name = "INSERTIONS_ALL_FIELDS",
+   .query = "default.insertions().orderBy({sequenceName, position})",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"position":2,"insertedSymbols":"TT","sequenceName":"segment1","count":3},
+      {"position":3,"insertedSymbols":"G","sequenceName":"segment1","count":1},
+      {"position":1,"insertedSymbols":"CC","sequenceName":"segment2","count":2}
+   ])")
+};
+
+const QueryTestScenario INSERTIONS_SEQUENCE_NAMES_SELECTS = {
+   .name = "INSERTIONS_SEQUENCE_NAMES_SELECTS",
+   .query = "default.insertions(sequenceNames:={segment1}).orderBy({position})",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"position":2,"insertedSymbols":"TT","sequenceName":"segment1","count":3},
+      {"position":3,"insertedSymbols":"G","sequenceName":"segment1","count":1}
+   ])")
+};
+
+const QueryTestScenario INSERTIONS_ON_NON_SCAN = {
+   .name = "INSERTIONS_ON_NON_SCAN",
+   .query = "default.project({primaryKey}).insertions()",
+   .expected_error_message = "insertions() must be applied to a table scan"
+};
+
+const QueryTestScenario INSERTIONS_UNKNOWN_SEQUENCE_NAME = {
+   .name = "INSERTIONS_UNKNOWN_SEQUENCE_NAME",
+   .query = "default.insertions(sequenceNames:={unknownSegment})",
+   .expected_error_message =
+      "The database does not contain the Nucleotide sequence 'unknownSegment'"
+};
+
+// gene1 exists but is an amino acid sequence
+const QueryTestScenario INSERTIONS_WRONG_TYPE_SEQUENCE_NAME = {
+   .name = "INSERTIONS_WRONG_TYPE_SEQUENCE_NAME",
+   .query = "default.insertions(sequenceNames:={gene1})",
+   .expected_error_message = "The database does not contain the Nucleotide sequence 'gene1'"
+};
+
+// ---- amino acid aminoAcidInsertions() ----
+
+const QueryTestScenario AA_INSERTIONS_ALL_FIELDS = {
+   .name = "AA_INSERTIONS_ALL_FIELDS",
+   .query = "default.aminoAcidInsertions()",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"position":1,"insertedSymbols":"W","sequenceName":"gene1","count":2}
+   ])")
+};
+
+const QueryTestScenario AA_INSERTIONS_SEQUENCE_NAMES_SELECTS = {
+   .name = "AA_INSERTIONS_SEQUENCE_NAMES_SELECTS",
+   .query = "default.aminoAcidInsertions(sequenceNames:={gene1})",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"position":1,"insertedSymbols":"W","sequenceName":"gene1","count":2}
+   ])")
+};
+
+// segment1 is a nucleotide sequence
+const QueryTestScenario AA_INSERTIONS_WRONG_TYPE_SEQUENCE_NAME = {
+   .name = "AA_INSERTIONS_WRONG_TYPE_SEQUENCE_NAME",
+   .query = "default.aminoAcidInsertions(sequenceNames:={segment1})",
+   .expected_error_message = "The database does not contain the AminoAcid sequence 'segment1'"
+};
+
+}  // namespace
+
+QUERY_TEST(
+   InsertionsNode,
+   TEST_DATA,
+   ::testing::Values(
+      INSERTIONS_ALL_FIELDS,
+      INSERTIONS_SEQUENCE_NAMES_SELECTS,
+      INSERTIONS_ON_NON_SCAN,
+      INSERTIONS_UNKNOWN_SEQUENCE_NAME,
+      INSERTIONS_WRONG_TYPE_SEQUENCE_NAME
+   )
+);
+
+QUERY_TEST(
+   InsertionsNodeAminoAcid,
+   TEST_DATA,
+   ::testing::Values(
+      AA_INSERTIONS_ALL_FIELDS,
+      AA_INSERTIONS_SEQUENCE_NAMES_SELECTS,
+      AA_INSERTIONS_WRONG_TYPE_SEQUENCE_NAME
+   )
+);

--- a/src/rhydb/query_engine/operators/mutations_node.test.cpp
+++ b/src/rhydb/query_engine/operators/mutations_node.test.cpp
@@ -1,0 +1,138 @@
+#include <nlohmann/json.hpp>
+
+#include "rhydb/test/query_fixture.test.h"
+
+namespace {
+using rhydb::ReferenceGenomes;
+using rhydb::test::QueryTestData;
+using rhydb::test::QueryTestScenario;
+
+nlohmann::json createData(
+   const std::string& primary_key,
+   const std::string& nucleotide_sequence,
+   const std::string& amino_acid_sequence
+) {
+   return {
+      {"primaryKey", primary_key},
+      {"segment1", {{"sequence", nucleotide_sequence}, {"insertions", nlohmann::json::array()}}},
+      {"gene1", {{"sequence", amino_acid_sequence}, {"insertions", nlohmann::json::array()}}}
+   };
+}
+
+const auto DATABASE_CONFIG = R"(
+schema:
+  instanceName: "test"
+  metadata:
+    - name: "primaryKey"
+      type: "string"
+  primaryKey: "primaryKey"
+)";
+
+// segment1 reference is "AT"; s1 carries a single substitution A->C at position 1, s2 matches the
+// reference. gene1 is the reference "M*" for both rows and therefore contributes no (amino acid)
+// mutations. So the nucleotide `mutations()` operator produces exactly one row:
+//   {mutationFrom:A, mutationTo:C, sequenceName:segment1, position:1, proportion:0.5, coverage:2,
+//    count:1}
+const auto REFERENCE_GENOMES = ReferenceGenomes{{{"segment1", "AT"}}, {{"gene1", "M*"}}};
+
+const QueryTestData TEST_DATA{
+   .ndjson_input_data =
+      {
+         createData("s1", "CT", "M*"),
+         createData("s2", "AT", "M*")
+      },
+   .database_config = DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES,
+   .without_unaligned_sequences = true
+};
+
+const QueryTestScenario MUTATIONS_ALL_FIELDS = {
+   .name = "MUTATIONS_ALL_FIELDS",
+   .query = "default.mutations(minProportion:=0.0)",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"mutationFrom":"A","mutationTo":"C","sequenceName":"segment1","position":1,
+       "proportion":0.5,"coverage":2,"count":1}
+   ])"),
+};
+
+const QueryTestScenario MUTATIONS_MIN_PROPORTION_EXCLUDES_BELOW_THRESHOLD = {
+   .name = "MUTATIONS_MIN_PROPORTION_EXCLUDES_BELOW_THRESHOLD",
+   .query = "default.mutations(minProportion:=0.6)",
+   .expected_query_result = nlohmann::json::array(),
+};
+
+const QueryTestScenario MUTATIONS_FIELDS_NARROWED = {
+   .name = "MUTATIONS_FIELDS_NARROWED",
+   .query = "default.mutations(minProportion:=0.0, fields:={position, count})",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"position":1,"count":1}
+   ])"),
+};
+
+const QueryTestScenario MUTATIONS_SEQUENCE_NAMES_SELECTS = {
+   .name = "MUTATIONS_SEQUENCE_NAMES_SELECTS",
+   .query = "default.mutations(minProportion:=0.0, sequenceNames:={segment1})",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"mutationFrom":"A","mutationTo":"C","sequenceName":"segment1","position":1,
+       "proportion":0.5,"coverage":2,"count":1}
+   ])"),
+};
+
+const QueryTestScenario MUTATIONS_INVALID_MIN_PROPORTION = {
+   .name = "MUTATIONS_INVALID_MIN_PROPORTION",
+   .query = "default.mutations(minProportion:=1.5)",
+   .expected_error_message = "Invalid proportion: minProportion must be in interval [0.0, 1.0]"
+};
+
+const QueryTestScenario MUTATIONS_MISSING_MIN_PROPORTION = {
+   .name = "MUTATIONS_MISSING_MIN_PROPORTION",
+   .query = "default.mutations()",
+   .expected_error_message = "mutations() requires argument 'minProportion'"
+};
+
+const QueryTestScenario MUTATIONS_ON_NON_SCAN = {
+   .name = "MUTATIONS_ON_NON_SCAN",
+   .query = "default.project({primaryKey}).mutations(minProportion:=0.1)",
+   .expected_error_message = "mutations() must be applied to a table scan"
+};
+
+const QueryTestScenario MUTATIONS_UNKNOWN_SEQUENCE_NAME = {
+   .name = "MUTATIONS_UNKNOWN_SEQUENCE_NAME",
+   .query = "default.mutations(minProportion:=0.1, sequenceNames:={unknownSegment})",
+   .expected_error_message =
+      "The database does not contain the Nucleotide sequence 'unknownSegment'"
+};
+
+// gene1 exists but is an amino acid sequence
+const QueryTestScenario MUTATIONS_WRONG_TYPE_SEQUENCE_NAME = {
+   .name = "MUTATIONS_WRONG_TYPE_SEQUENCE_NAME",
+   .query = "default.mutations(minProportion:=0.1, sequenceNames:={gene1})",
+   .expected_error_message = "The database does not contain the Nucleotide sequence 'gene1'"
+};
+
+const QueryTestScenario MUTATIONS_INVALID_FIELD = {
+   .name = "MUTATIONS_INVALID_FIELD",
+   .query = "default.mutations(minProportion:=0.1, fields:={notAField})",
+   .expected_error_message =
+      "The attribute 'fields' contains an invalid field 'notAField'. Valid fields are "
+      "mutationFrom, mutationTo, position, sequenceName, proportion, coverage, count."
+};
+
+}  // namespace
+
+QUERY_TEST(
+   MutationsNode,
+   TEST_DATA,
+   ::testing::Values(
+      MUTATIONS_ALL_FIELDS,
+      MUTATIONS_MIN_PROPORTION_EXCLUDES_BELOW_THRESHOLD,
+      MUTATIONS_FIELDS_NARROWED,
+      MUTATIONS_SEQUENCE_NAMES_SELECTS,
+      MUTATIONS_INVALID_MIN_PROPORTION,
+      MUTATIONS_MISSING_MIN_PROPORTION,
+      MUTATIONS_ON_NON_SCAN,
+      MUTATIONS_UNKNOWN_SEQUENCE_NAME,
+      MUTATIONS_WRONG_TYPE_SEQUENCE_NAME,
+      MUTATIONS_INVALID_FIELD
+   )
+);

--- a/src/rhydb/query_engine/operators/mutations_node.test.cpp
+++ b/src/rhydb/query_engine/operators/mutations_node.test.cpp
@@ -90,6 +90,19 @@ const QueryTestScenario MUTATIONS_SEQUENCE_NAMES_SELECTS = {
    ])")
 };
 
+const QueryTestScenario MUTATIONS_WITH_INPUT_FILTER = {
+   .name = "MUTATIONS_WITH_INPUT_FILTER",
+   .query =
+      "default.filter(primaryKey = 's2' || primaryKey = 's3')"
+      ".mutations(minProportion:=0.0).orderBy({sequenceName, position, mutationTo})",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"mutationFrom":"A","mutationTo":"C","sequenceName":"segment1","position":1,
+       "proportion":1.0,"coverage":2,"count":2},
+      {"mutationFrom":"G","mutationTo":"T","sequenceName":"segment2","position":1,
+       "proportion":0.5,"coverage":2,"count":1}
+   ])")
+};
+
 const QueryTestScenario MUTATIONS_FIELDS_NARROWED = {
    .name = "MUTATIONS_FIELDS_NARROWED",
    .query =
@@ -182,6 +195,7 @@ QUERY_TEST(
       MUTATIONS_MIN_PROPORTION_KEEPS_SUBSET,
       MUTATIONS_MIN_PROPORTION_EXCLUDES_ALL,
       MUTATIONS_SEQUENCE_NAMES_SELECTS,
+      MUTATIONS_WITH_INPUT_FILTER,
       MUTATIONS_FIELDS_NARROWED,
       MUTATIONS_INVALID_MIN_PROPORTION,
       MUTATIONS_MISSING_MIN_PROPORTION,

--- a/src/rhydb/query_engine/operators/mutations_node.test.cpp
+++ b/src/rhydb/query_engine/operators/mutations_node.test.cpp
@@ -9,13 +9,15 @@ using rhydb::test::QueryTestScenario;
 
 nlohmann::json createData(
    const std::string& primary_key,
-   const std::string& nucleotide_sequence,
-   const std::string& amino_acid_sequence
+   const std::string& segment1,
+   const std::string& segment2,
+   const std::string& gene1
 ) {
    return {
       {"primaryKey", primary_key},
-      {"segment1", {{"sequence", nucleotide_sequence}, {"insertions", nlohmann::json::array()}}},
-      {"gene1", {{"sequence", amino_acid_sequence}, {"insertions", nlohmann::json::array()}}}
+      {"segment1", {{"sequence", segment1}, {"insertions", nlohmann::json::array()}}},
+      {"segment2", {{"sequence", segment2}, {"insertions", nlohmann::json::array()}}},
+      {"gene1", {{"sequence", gene1}, {"insertions", nlohmann::json::array()}}}
    };
 }
 
@@ -28,54 +30,73 @@ schema:
   primaryKey: "primaryKey"
 )";
 
-// segment1 reference is "AT"; s1 carries a single substitution A->C at position 1, s2 matches the
-// reference. gene1 is the reference "M*" for both rows and therefore contributes no (amino acid)
-// mutations. So the nucleotide `mutations()` operator produces exactly one row:
-//   {mutationFrom:A, mutationTo:C, sequenceName:segment1, position:1, proportion:0.5, coverage:2,
-//    count:1}
-const auto REFERENCE_GENOMES = ReferenceGenomes{{{"segment1", "AT"}}, {{"gene1", "M*"}}};
+const auto REFERENCE_GENOMES =
+   ReferenceGenomes{{{"segment1", "ATGC"}, {"segment2", "GG"}}, {{"gene1", "MK"}}};
 
 const QueryTestData TEST_DATA{
    .ndjson_input_data =
       {
-         createData("s1", "CT", "M*"),
-         createData("s2", "AT", "M*")
+         createData("s1", "ATGC", "GG", "MK"),  // all references
+         createData("s2", "CTGC", "GG", "TK"),  // segment1 A->C, gene1 M->T
+         createData("s3", "CTGC", "TG", "TK"),  // segment1 A->C, segment2 G->T, gene1 M->T
+         createData("s4", "GTGC", "GG", "MK"),  // segment1 A->G
+         createData("s5", "NTGC", "GG", "MK")   // segment1 position 1 is N (uncovered)
       },
    .database_config = DATABASE_CONFIG,
    .reference_genomes = REFERENCE_GENOMES,
    .without_unaligned_sequences = true
 };
 
+// ---- nucleotide mutations() ----
+
 const QueryTestScenario MUTATIONS_ALL_FIELDS = {
    .name = "MUTATIONS_ALL_FIELDS",
-   .query = "default.mutations(minProportion:=0.0)",
+   .query = "default.mutations(minProportion:=0.0).orderBy({sequenceName, position, mutationTo})",
    .expected_query_result = nlohmann::json::parse(R"([
       {"mutationFrom":"A","mutationTo":"C","sequenceName":"segment1","position":1,
-       "proportion":0.5,"coverage":2,"count":1}
+       "proportion":0.5,"coverage":4,"count":2},
+      {"mutationFrom":"A","mutationTo":"G","sequenceName":"segment1","position":1,
+       "proportion":0.25,"coverage":4,"count":1},
+      {"mutationFrom":"G","mutationTo":"T","sequenceName":"segment2","position":1,
+       "proportion":0.2,"coverage":5,"count":1}
    ])"),
 };
 
-const QueryTestScenario MUTATIONS_MIN_PROPORTION_EXCLUDES_BELOW_THRESHOLD = {
-   .name = "MUTATIONS_MIN_PROPORTION_EXCLUDES_BELOW_THRESHOLD",
+const QueryTestScenario MUTATIONS_MIN_PROPORTION_KEEPS_SUBSET = {
+   .name = "MUTATIONS_MIN_PROPORTION_KEEPS_SUBSET",
+   .query = "default.mutations(minProportion:=0.3)",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"mutationFrom":"A","mutationTo":"C","sequenceName":"segment1","position":1,
+       "proportion":0.5,"coverage":4,"count":2}
+   ])"),
+};
+
+const QueryTestScenario MUTATIONS_MIN_PROPORTION_EXCLUDES_ALL = {
+   .name = "MUTATIONS_MIN_PROPORTION_EXCLUDES_ALL",
    .query = "default.mutations(minProportion:=0.6)",
    .expected_query_result = nlohmann::json::array(),
 };
 
-const QueryTestScenario MUTATIONS_FIELDS_NARROWED = {
-   .name = "MUTATIONS_FIELDS_NARROWED",
-   .query = "default.mutations(minProportion:=0.0, fields:={position, count})",
-   .expected_query_result = nlohmann::json::parse(R"([
-      {"position":1,"count":1}
-   ])"),
-};
-
 const QueryTestScenario MUTATIONS_SEQUENCE_NAMES_SELECTS = {
    .name = "MUTATIONS_SEQUENCE_NAMES_SELECTS",
-   .query = "default.mutations(minProportion:=0.0, sequenceNames:={segment1})",
+   .query =
+      "default.mutations(minProportion:=0.0, sequenceNames:={segment1})"
+      ".orderBy({position, mutationTo})",
    .expected_query_result = nlohmann::json::parse(R"([
       {"mutationFrom":"A","mutationTo":"C","sequenceName":"segment1","position":1,
-       "proportion":0.5,"coverage":2,"count":1}
-   ])"),
+       "proportion":0.5,"coverage":4,"count":2},
+      {"mutationFrom":"A","mutationTo":"G","sequenceName":"segment1","position":1,
+       "proportion":0.25,"coverage":4,"count":1}
+   ])")
+};
+
+const QueryTestScenario MUTATIONS_FIELDS_NARROWED = {
+   .name = "MUTATIONS_FIELDS_NARROWED",
+   .query =
+      "default.mutations(minProportion:=0.0, sequenceNames:={segment2}, fields:={position, count})",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"position":1,"count":1}
+   ])")
 };
 
 const QueryTestScenario MUTATIONS_INVALID_MIN_PROPORTION = {
@@ -118,6 +139,39 @@ const QueryTestScenario MUTATIONS_INVALID_FIELD = {
       "mutationFrom, mutationTo, position, sequenceName, proportion, coverage, count."
 };
 
+// ---- amino acid aminoAcidMutations() ----
+
+const QueryTestScenario AA_MUTATIONS_ALL_FIELDS = {
+   .name = "AA_MUTATIONS_ALL_FIELDS",
+   .query = "default.aminoAcidMutations(minProportion:=0.0)",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"mutationFrom":"M","mutationTo":"T","sequenceName":"gene1","position":1,
+       "proportion":0.4,"coverage":5,"count":2}
+   ])")
+};
+
+const QueryTestScenario AA_MUTATIONS_MIN_PROPORTION_EXCLUDES = {
+   .name = "AA_MUTATIONS_MIN_PROPORTION_EXCLUDES",
+   .query = "default.aminoAcidMutations(minProportion:=0.5)",
+   .expected_query_result = nlohmann::json::array()
+};
+
+const QueryTestScenario AA_MUTATIONS_SEQUENCE_NAMES_SELECTS = {
+   .name = "AA_MUTATIONS_SEQUENCE_NAMES_SELECTS",
+   .query = "default.aminoAcidMutations(minProportion:=0.0, sequenceNames:={gene1})",
+   .expected_query_result = nlohmann::json::parse(R"([
+      {"mutationFrom":"M","mutationTo":"T","sequenceName":"gene1","position":1,
+       "proportion":0.4,"coverage":5,"count":2}
+   ])")
+};
+
+// segment1 is a nucleotide sequence
+const QueryTestScenario AA_MUTATIONS_WRONG_TYPE_SEQUENCE_NAME = {
+   .name = "AA_MUTATIONS_WRONG_TYPE_SEQUENCE_NAME",
+   .query = "default.aminoAcidMutations(minProportion:=0.1, sequenceNames:={segment1})",
+   .expected_error_message = "The database does not contain the AminoAcid sequence 'segment1'"
+};
+
 }  // namespace
 
 QUERY_TEST(
@@ -125,14 +179,26 @@ QUERY_TEST(
    TEST_DATA,
    ::testing::Values(
       MUTATIONS_ALL_FIELDS,
-      MUTATIONS_MIN_PROPORTION_EXCLUDES_BELOW_THRESHOLD,
-      MUTATIONS_FIELDS_NARROWED,
+      MUTATIONS_MIN_PROPORTION_KEEPS_SUBSET,
+      MUTATIONS_MIN_PROPORTION_EXCLUDES_ALL,
       MUTATIONS_SEQUENCE_NAMES_SELECTS,
+      MUTATIONS_FIELDS_NARROWED,
       MUTATIONS_INVALID_MIN_PROPORTION,
       MUTATIONS_MISSING_MIN_PROPORTION,
       MUTATIONS_ON_NON_SCAN,
       MUTATIONS_UNKNOWN_SEQUENCE_NAME,
       MUTATIONS_WRONG_TYPE_SEQUENCE_NAME,
       MUTATIONS_INVALID_FIELD
+   )
+);
+
+QUERY_TEST(
+   MutationsNodeAminoAcid,
+   TEST_DATA,
+   ::testing::Values(
+      AA_MUTATIONS_ALL_FIELDS,
+      AA_MUTATIONS_MIN_PROPORTION_EXCLUDES,
+      AA_MUTATIONS_SEQUENCE_NAMES_SELECTS,
+      AA_MUTATIONS_WRONG_TYPE_SEQUENCE_NAME
    )
 );


### PR DESCRIPTION
### Summary
While implementing #1372, I noticed that we don't seem to have unit tests for the insertions and mutations operator.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
- [x] The implemented feature is covered by an appropriate test.
