### PR TITLE
feat(query_engine): allow a boolean field ref as filter

### DIFF
--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -111,6 +111,8 @@ Keeps only rows where the boolean predicate is true. Passes all input columns th
 default.filter(country = 'USA' && age > 30)
 ```
 
+A boolean column can be used directly as a predicate: `default.filter(isHuman)` is equivalent to `default.filter(isHuman = true)`, and `default.filter(!isHuman)` negates it (a set complement that also keeps rows where `isHuman` is null, matching `!(isHuman = true)`). Only boolean columns may be used this way; a bare reference to a non-boolean column is rejected.
+
 ### `groupBy(aggregates [, columns])`
 
 Aggregates rows, producing counts or other aggregate values. `aggregates` is a record literal; `columns` is an optional set of column names to group by.

--- a/src/rhydb/query_engine/saneql/ast_to_query.cpp
+++ b/src/rhydb/query_engine/saneql/ast_to_query.cpp
@@ -674,6 +674,57 @@ ScalarExpressionPtr handleMutationProfile(
    );
 }
 
+ScalarExpressionPtr convertIdentifierToFilter(
+   const ast::Identifier& node,
+   const ast::Expression& ast,
+   const std::vector<schema::ColumnIdentifier>& schema
+) {
+   auto found =
+      std::ranges::find_if(schema, [&](const auto& col) { return col.name == node.name; });
+   CHECK_RHYDB_QUERY(
+      found != schema.end(),
+      "filter references unknown column '{}' at {}:{}",
+      node.name,
+      ast.location.line,
+      ast.location.column
+   );
+   CHECK_RHYDB_QUERY(
+      found->type == schema::ColumnType::BOOL,
+      "column '{}' has type {} and cannot be used directly as a filter predicate; only boolean "
+      "columns can. Use a comparison such as `{} = ...` instead, at {}:{}",
+      node.name,
+      schema::columnTypeToString(found->type),
+      node.name,
+      ast.location.line,
+      ast.location.column
+   );
+   return std::make_unique<scalar_expressions::FieldRef>(*found);
+}
+
+ScalarExpressionPtr convertFunctionCallToFilter(
+   const ast::FunctionCall& node,
+   const ast::Expression& ast,
+   const std::vector<schema::ColumnIdentifier>& schema
+) {
+   const auto* entry = ScalarFunctionRegistry::instance().findFunction(node.function_name);
+   CHECK_RHYDB_QUERY(entry != nullptr, "unknown scalar function '{}'", node.function_name);
+   auto bound = bindArguments(
+      node.function_name, entry->signature, node.positional_arguments, node.named_arguments
+   );
+   auto expression = entry->handler(bound, schema);
+   // The registry also holds value-producing scalar functions (e.g. `at`), which are not filter
+   // predicates. Reject them here rather than letting a non-boolean expression reach compile().
+   CHECK_RHYDB_QUERY(
+      expression->type() == schema::ColumnType::BOOL,
+      "scalar function '{}' produces a {} value and cannot be used as a filter predicate at {}:{}",
+      node.function_name,
+      schema::columnTypeToString(expression->type()),
+      ast.location.line,
+      ast.location.column
+   );
+   return expression;
+}
+
 }  // namespace
 
 std::unique_ptr<scalar_expressions::ScalarExpression> convertToFilter(
@@ -692,26 +743,10 @@ std::unique_ptr<scalar_expressions::ScalarExpression> convertToFilter(
             );
          } else if constexpr (std::is_same_v<T, ast::BoolLiteral>) {
             return std::make_unique<scalar_expressions::BoolLiteral>(node.value);
+         } else if constexpr (std::is_same_v<T, ast::Identifier>) {
+            return convertIdentifierToFilter(node, ast, schema);
          } else if constexpr (std::is_same_v<T, ast::FunctionCall>) {
-            const auto* entry = ScalarFunctionRegistry::instance().findFunction(node.function_name);
-            CHECK_RHYDB_QUERY(entry != nullptr, "unknown scalar function '{}'", node.function_name);
-            auto bound = bindArguments(
-               node.function_name, entry->signature, node.positional_arguments, node.named_arguments
-            );
-            auto expression = entry->handler(bound, schema);
-            // The registry also holds value-producing scalar functions (e.g. `at`),
-            // which are not filter predicates. Reject them here rather than letting a
-            // non-boolean expression reach compile().
-            CHECK_RHYDB_QUERY(
-               expression->type() == schema::ColumnType::BOOL,
-               "scalar function '{}' produces a {} value and cannot be used as a filter "
-               "predicate at {}:{}",
-               node.function_name,
-               schema::columnTypeToString(expression->type()),
-               ast.location.line,
-               ast.location.column
-            );
-            return expression;
+            return convertFunctionCallToFilter(node, ast, schema);
          } else {
             throw IllegalQueryException(
                "unsupported expression type in filter context at {}:{}",

--- a/src/rhydb/query_engine/saneql/ast_to_query.cpp
+++ b/src/rhydb/query_engine/saneql/ast_to_query.cpp
@@ -688,16 +688,6 @@ ScalarExpressionPtr convertIdentifierToFilter(
       ast.location.line,
       ast.location.column
    );
-   CHECK_RHYDB_QUERY(
-      found->type == schema::ColumnType::BOOL,
-      "column '{}' has type {} and cannot be used directly as a filter predicate; only boolean "
-      "columns can. Use a comparison such as `{} = ...` instead, at {}:{}",
-      node.name,
-      schema::columnTypeToString(found->type),
-      node.name,
-      ast.location.line,
-      ast.location.column
-   );
    return std::make_unique<scalar_expressions::FieldRef>(*found);
 }
 

--- a/src/rhydb/query_engine/saneql/ast_to_query.test.cpp
+++ b/src/rhydb/query_engine/saneql/ast_to_query.test.cpp
@@ -229,6 +229,34 @@ TEST(AstToQueryConvertToFilter, unsupportedExpressionTypeThrows) {
    );
 }
 
+TEST(AstToQueryConvertToFilter, booleanColumnReferenceBuildsFieldRef) {
+   const std::vector<rhydb::schema::ColumnIdentifier> schema{
+      {.name = "isHuman", .type = rhydb::schema::ColumnType::BOOL}
+   };
+   EXPECT_EQ(parseFilter("isHuman", schema)->toString(), "isHuman");
+}
+
+TEST(AstToQueryConvertToFilter, nonBooleanColumnReferenceThrows) {
+   const std::vector<rhydb::schema::ColumnIdentifier> schema{
+      {.name = "age", .type = rhydb::schema::ColumnType::INT32}
+   };
+   EXPECT_THAT(
+      [&]() { (void)parseFilter("age", schema); },
+      ThrowsMessage<IllegalQueryException>(
+         ::testing::HasSubstr("cannot be used directly as a filter predicate")
+      )
+   );
+}
+
+TEST(AstToQueryConvertToFilter, unknownColumnReferenceThrows) {
+   EXPECT_THAT(
+      []() { (void)parseFilter("missing"); },
+      ThrowsMessage<IllegalQueryException>(
+         ::testing::HasSubstr("filter references unknown column 'missing'")
+      )
+   );
+}
+
 // --- integer comparisons ---
 
 TEST(AstToQueryIntComparison, lessThanBuildsComparison) {

--- a/src/rhydb/query_engine/saneql/ast_to_query.test.cpp
+++ b/src/rhydb/query_engine/saneql/ast_to_query.test.cpp
@@ -236,18 +236,6 @@ TEST(AstToQueryConvertToFilter, booleanColumnReferenceBuildsFieldRef) {
    EXPECT_EQ(parseFilter("isHuman", schema)->toString(), "isHuman");
 }
 
-TEST(AstToQueryConvertToFilter, nonBooleanColumnReferenceThrows) {
-   const std::vector<rhydb::schema::ColumnIdentifier> schema{
-      {.name = "age", .type = rhydb::schema::ColumnType::INT32}
-   };
-   EXPECT_THAT(
-      [&]() { (void)parseFilter("age", schema); },
-      ThrowsMessage<IllegalQueryException>(
-         ::testing::HasSubstr("cannot be used directly as a filter predicate")
-      )
-   );
-}
-
 TEST(AstToQueryConvertToFilter, unknownColumnReferenceThrows) {
    EXPECT_THAT(
       []() { (void)parseFilter("missing"); },

--- a/src/rhydb/query_engine/scalar_expressions/comparison_bool.test.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/comparison_bool.test.cpp
@@ -138,6 +138,27 @@ const QueryTestScenario ORDERING_COLUMN_ON_RIGHT_REJECTED = {
       "The comparison operators <,>,<=,>= are not supported for boolean column 'boolField'"
 };
 
+const QueryTestScenario BARE_BOOL_FILTER = {
+   .name = "BOOL_BARE_FILTER",
+   .query = "default.filter(boolField).project(primaryKey)",
+   .expected_query_result = nlohmann::json::parse(R"([{"primaryKey":"id_true"}])")
+};
+
+const QueryTestScenario NEGATED_BARE_BOOL_FILTER = {
+   .name = "BOOL_NEGATED_BARE_FILTER",
+   .query = "default.filter(!boolField).project(primaryKey)",
+   .expected_query_result =
+      nlohmann::json::parse(R"([{"primaryKey":"id_false"},{"primaryKey":"id_null"}])")
+};
+
+const QueryTestScenario BARE_NON_BOOL_FILTER_REJECTED = {
+   .name = "BOOL_BARE_NON_BOOL_FILTER_REJECTED",
+   .query = "default.filter(intField).project(primaryKey)",
+   .expected_error_message =
+      "column 'intField' has type INT32 and cannot be used directly as a filter predicate; only "
+      "boolean columns can. Use a comparison such as `intField = ...` instead, at 1:16"
+};
+
 }  // namespace
 
 QUERY_TEST(
@@ -156,6 +177,9 @@ QUERY_TEST(
       LESS_EQUAL_REJECTED,
       GREATER_THAN_REJECTED,
       GREATER_EQUAL_REJECTED,
-      ORDERING_COLUMN_ON_RIGHT_REJECTED
+      ORDERING_COLUMN_ON_RIGHT_REJECTED,
+      BARE_BOOL_FILTER,
+      NEGATED_BARE_BOOL_FILTER,
+      BARE_NON_BOOL_FILTER_REJECTED
    )
 );

--- a/src/rhydb/query_engine/scalar_expressions/comparison_bool.test.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/comparison_bool.test.cpp
@@ -155,8 +155,7 @@ const QueryTestScenario BARE_NON_BOOL_FILTER_REJECTED = {
    .name = "BOOL_BARE_NON_BOOL_FILTER_REJECTED",
    .query = "default.filter(intField).project(primaryKey)",
    .expected_error_message =
-      "column 'intField' has type INT32 and cannot be used directly as a filter predicate; only "
-      "boolean columns can. Use a comparison such as `intField = ...` instead, at 1:16"
+      "The column 'intField' is not of type bool and cannot be used directly as a filter predicate"
 };
 
 }  // namespace

--- a/src/rhydb/query_engine/scalar_expressions/field_ref.cpp
+++ b/src/rhydb/query_engine/scalar_expressions/field_ref.cpp
@@ -5,8 +5,11 @@
 #include <utility>
 #include <vector>
 
-#include "rhydb/common/panic.h"
+#include "rhydb/query_engine/copy_on_write_bitmap.h"
+#include "rhydb/query_engine/filter/operators/index_scan.h"
 #include "rhydb/query_engine/filter/operators/operator.h"
+#include "rhydb/query_engine/illegal_query_exception.h"
+#include "rhydb/storage/column/bool_column.h"
 
 namespace rhydb::query_engine::scalar_expressions {
 
@@ -28,10 +31,16 @@ std::unique_ptr<ScalarExpression> FieldRef::rewrite(
    return std::make_unique<FieldRef>(column);
 }
 
-std::unique_ptr<filter::operators::Operator> FieldRef::compile(const storage::Table& /*table*/
-) const {
-   // A column reference is a scalar value, not a filter predicate.
-   SILO_UNIMPLEMENTED();
+std::unique_ptr<filter::operators::Operator> FieldRef::compile(const storage::Table& table) const {
+   CHECK_RHYDB_QUERY(
+      table.columns.bool_columns.contains(column.name),
+      "The column '{}' is not of type bool and cannot be used directly as a filter predicate",
+      column.name
+   );
+   const auto& bool_column = table.columns.bool_columns.at(column.name);
+   return std::make_unique<filter::operators::IndexScan>(
+      CopyOnWriteBitmap{&bool_column.true_bitmap}, table.row_layout
+   );
 }
 
 }  // namespace rhydb::query_engine::scalar_expressions

--- a/src/rhydb/query_engine/scalar_expressions/field_ref.h
+++ b/src/rhydb/query_engine/scalar_expressions/field_ref.h
@@ -12,8 +12,9 @@ namespace rhydb::query_engine::scalar_expressions {
 
 /// References an existing column by name. As a scalar expression it evaluates to
 /// that column's value per row, e.g. `y := age`; its type() is the referenced
-/// column's type. It is not a filter predicate, so it cannot be compile()d into a
-/// filter operator.
+/// column's type. As a filter predicate it is only valid for boolean columns
+/// (e.g. `filter(isHuman)`), where compile() selects the rows whose value is
+/// `true`; compiling a non-boolean reference is rejected.
 class FieldRef : public ScalarExpression {
   public:
    schema::ColumnIdentifier column;

--- a/src/rhydb/query_engine/scalar_expressions/field_ref.h
+++ b/src/rhydb/query_engine/scalar_expressions/field_ref.h
@@ -12,9 +12,7 @@ namespace rhydb::query_engine::scalar_expressions {
 
 /// References an existing column by name. As a scalar expression it evaluates to
 /// that column's value per row, e.g. `y := age`; its type() is the referenced
-/// column's type. As a filter predicate it is only valid for boolean columns
-/// (e.g. `filter(isHuman)`), where compile() selects the rows whose value is
-/// `true`; compiling a non-boolean reference is rejected.
+/// column's type.
 class FieldRef : public ScalarExpression {
   public:
    schema::ColumnIdentifier column;


### PR DESCRIPTION
resolves #1378

### Summary

A boolean column can now be used directly as a filter predicate: `default.filter(isHuman)` (equivalent to `isHuman = true`) and `default.filter(!isHuman)`. Previously a bare column reference was only valid in `map()`/scalar contexts.

- **`filter(boolColumn)`** — a bare boolean `FieldRef` compiles to the column's `true` bitmap. `!boolColumn` is a set complement, so null rows are kept (matching `!(boolColumn = true)`), not SQL three-valued logic.
- **Non-boolean bare reference is rejected** at `FieldRef::compile()` (e.g. `filter(intField)`); use an explicit comparison instead.

## PR Checklist

- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
