### PR TITLE
feat: add `a[i]` square-bracket notation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ CMake auto-scans `src/` and `app/src/` directories. The Makefile maintains `.src
 
 ### Formatting (clang-format 19)
 - 3-space indent, 100-char column limit, Chromium brace style, `#pragma once`
+- Trailing commas: add a trailing comma after the last element in multi-line braced initializers / aggregate initializations (keeps diffs minimal when appending fields).
 
 ### Include order
 ```cpp

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -502,8 +502,11 @@ cannot be used as a filter predicate and are instead used as `map()` assignments
 
 Extracts the single character of a string `column` at the 1-based `position`, returning it as a string. `position` must be greater than 0. If `position` is past the end of the value, the result is an empty string `""` (a `null` value yields `null`). This is not a boolean predicate, so it cannot be used in `.filter(...)`; use it inside [`map()`](#mapexpressions).
 
+The square-bracket notation `column[position]` is shorthand for `column.at(position)`.
+
 ```
 default.map({second_char := primary_key.at(2)})
+default.map({second_char := primary_key[2]})
 ```
 
 ### `isoWeek(column)`

--- a/src/rhydb/query_engine/operators/map_node.test.cpp
+++ b/src/rhydb/query_engine/operators/map_node.test.cpp
@@ -122,6 +122,15 @@ const QueryTestScenario MAP_AT_SCENARIO = {
    )
 };
 
+// The square-bracket notation `col[i]` is shorthand for `col.at(i)`
+const QueryTestScenario MAP_AT_BRACKET_SCENARIO = {
+   .name = "MAP_AT_BRACKET",
+   .query = "default.map({second := primaryKey[4]}).project({primaryKey, second})",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"second", "0"}}, {{"primaryKey", "id_1"}, {"second", "1"}}}
+   )
+};
+
 // When the position is past the end of the string, `at` yields an empty string
 // rather than failing. id_0's str_value "short" has only 5 characters, so at(8) is
 // out of bounds and produces ""; id_1's "longlonglong" has a character at 8 ("g").
@@ -366,6 +375,7 @@ QUERY_TEST(
       MAP_INT64_SCENARIO,
       MAP_FIELD_REF_SCENARIO,
       MAP_AT_SCENARIO,
+      MAP_AT_BRACKET_SCENARIO,
       MAP_AT_OUT_OF_BOUNDS_SCENARIO,
       MAP_AT_SEQUENCE_FIRST_SCENARIO,
       MAP_AT_SEQUENCE_INNER_SCENARIO,

--- a/src/rhydb/query_engine/operators/map_node.test.cpp
+++ b/src/rhydb/query_engine/operators/map_node.test.cpp
@@ -128,7 +128,7 @@ const QueryTestScenario MAP_AT_BRACKET_SCENARIO = {
    .query = "default.map({second := primaryKey[4]}).project({primaryKey, second})",
    .expected_query_result = nlohmann::json(
       {{{"primaryKey", "id_0"}, {"second", "0"}}, {{"primaryKey", "id_1"}, {"second", "1"}}}
-   )
+   ),
 };
 
 // When the position is past the end of the string, `at` yields an empty string

--- a/src/rhydb/query_engine/saneql/lexer.cpp
+++ b/src/rhydb/query_engine/saneql/lexer.cpp
@@ -214,6 +214,12 @@ Token Lexer::nextToken() {
       case '}':
          advance();
          return makeToken(TokenType::RIGHT_BRACE, start);
+      case '[':
+         advance();
+         return makeToken(TokenType::LEFT_BRACKET, start);
+      case ']':
+         advance();
+         return makeToken(TokenType::RIGHT_BRACKET, start);
       case '!':
          advance();
          return makeToken(TokenType::NOT, start);

--- a/src/rhydb/query_engine/saneql/lexer.test.cpp
+++ b/src/rhydb/query_engine/saneql/lexer.test.cpp
@@ -151,6 +151,28 @@ TEST(SaneQLLexer, tokenizesPunctuation) {
    EXPECT_EQ(tokens[7].type, TokenType::COLON_EQUALS);
 }
 
+TEST(SaneQLLexer, tokenizesBrackets) {
+   Lexer lexer("[ ]");
+   auto tokens = lexer.tokenizeAll();
+   ASSERT_EQ(tokens.size(), 3);
+   EXPECT_EQ(tokens[0].type, TokenType::LEFT_BRACKET);
+   EXPECT_EQ(tokens[1].type, TokenType::RIGHT_BRACKET);
+   EXPECT_EQ(tokens[2].type, TokenType::END_OF_FILE);
+}
+
+TEST(SaneQLLexer, tokenizesBracketIndexing) {
+   Lexer lexer("a[3]");
+   auto tokens = lexer.tokenizeAll();
+   ASSERT_EQ(tokens.size(), 5);
+   EXPECT_EQ(tokens[0].type, TokenType::IDENTIFIER);
+   EXPECT_EQ(tokens[0].getStringValue(), "a");
+   EXPECT_EQ(tokens[1].type, TokenType::LEFT_BRACKET);
+   EXPECT_EQ(tokens[2].type, TokenType::INT_LITERAL);
+   EXPECT_EQ(tokens[2].getIntValue(), 3);
+   EXPECT_EQ(tokens[3].type, TokenType::RIGHT_BRACKET);
+   EXPECT_EQ(tokens[4].type, TokenType::END_OF_FILE);
+}
+
 TEST(SaneQLLexer, tokenizesMethodCallChain) {
    Lexer lexer("default.filter(country = 'USA').groupBy({count:=count()})");
    auto tokens = lexer.tokenizeAll();

--- a/src/rhydb/query_engine/saneql/parser.cpp
+++ b/src/rhydb/query_engine/saneql/parser.cpp
@@ -200,6 +200,23 @@ ast::ExpressionPtr Parser::parsePostfixExpr() {
                method_name.location
             );
          }
+      } else if (check(TokenType::LEFT_BRACKET)) {
+         const SourceLocation loc = current().location;
+         advance();
+         auto index = parseExpression();
+         expect(TokenType::RIGHT_BRACKET);
+         // Desugar a[i] to at(a, i): receiver becomes first positional argument
+         std::vector<ast::PositionalArgument> pos_args;
+         pos_args.push_back(ast::PositionalArgument{.value = std::move(expr), .location = loc});
+         pos_args.push_back(ast::PositionalArgument{.value = std::move(index), .location = loc});
+         expr = ast::makeExpr(
+            ast::FunctionCall{
+               .function_name = "at",
+               .positional_arguments = std::move(pos_args),
+               .named_arguments = {}
+            },
+            loc
+         );
       } else if (check(TokenType::DOUBLE_COLON)) {
          const SourceLocation loc = current().location;
          advance();

--- a/src/rhydb/query_engine/saneql/parser.cpp
+++ b/src/rhydb/query_engine/saneql/parser.cpp
@@ -213,7 +213,7 @@ ast::ExpressionPtr Parser::parsePostfixExpr() {
             ast::FunctionCall{
                .function_name = "at",
                .positional_arguments = std::move(pos_args),
-               .named_arguments = {}
+               .named_arguments = {},
             },
             loc
          );

--- a/src/rhydb/query_engine/saneql/parser.test.cpp
+++ b/src/rhydb/query_engine/saneql/parser.test.cpp
@@ -636,6 +636,51 @@ TEST(SaneQLParser, parsesTypeCastChaining) {
    EXPECT_EQ(expr->toString(), "a::t1::t2");
 }
 
+TEST(SaneQLParser, parsesBracketIndexAsAtCall) {
+   // a[3] is sugar for a.at(3): desugared to at(a, 3)
+   Parser parser("a[3]");
+   auto expr = parser.parse();
+   ASSERT_TRUE(std::holds_alternative<ast::FunctionCall>(expr->value));
+   const auto& call = std::get<ast::FunctionCall>(expr->value);
+   EXPECT_EQ(call.function_name, "at");
+   ASSERT_EQ(call.positional_arguments.size(), 2);
+   EXPECT_EQ(call.positional_arguments[0].value->toString(), "a");
+   EXPECT_EQ(call.positional_arguments[1].value->toString(), "3");
+   ASSERT_TRUE(call.named_arguments.empty());
+   EXPECT_EQ(expr->toString(), "at(a, 3)");
+}
+
+TEST(SaneQLParser, parsesBracketIndexEqualsDotAt) {
+   // a[3] and a.at(3) produce identical ASTs
+   Parser bracket_parser("a[3]");
+   Parser dot_parser("a.at(3)");
+   EXPECT_EQ(bracket_parser.parse()->toString(), dot_parser.parse()->toString());
+}
+
+TEST(SaneQLParser, parsesChainedBracketIndex) {
+   // a[1][2] desugars to at(at(a, 1), 2)
+   Parser parser("a[1][2]");
+   auto expr = parser.parse();
+   EXPECT_EQ(expr->toString(), "at(at(a, 1), 2)");
+}
+
+TEST(SaneQLParser, parsesBracketIndexOnMethodCall) {
+   // Bracket indexing chains with method calls and other postfix ops
+   Parser parser("a.b()[0]");
+   auto expr = parser.parse();
+   EXPECT_EQ(expr->toString(), "at(b(a), 0)");
+}
+
+TEST(SaneQLParser, throwsOnUnclosedBracket) {
+   EXPECT_THAT(
+      []() {
+         Parser parser("a[3");
+         (void)parser.parse();
+      },
+      ThrowsMessage<ParseException>(::testing::HasSubstr("Expected RightBracket but got Eof"))
+   );
+}
+
 TEST(SaneQLParser, parsesNamedArgInMethodCall) {
    Parser parser("a.f(x:=1)");
    auto expr = parser.parse();

--- a/src/rhydb/query_engine/saneql/parser.test.cpp
+++ b/src/rhydb/query_engine/saneql/parser.test.cpp
@@ -664,6 +664,26 @@ TEST(SaneQLParser, parsesChainedBracketIndex) {
    EXPECT_EQ(expr->toString(), "at(at(a, 1), 2)");
 }
 
+TEST(SaneQLParser, throwsOnEmptyBracket) {
+   EXPECT_THAT(
+      []() {
+         Parser parser("a[]");
+         (void)parser.parse();
+      },
+      ThrowsMessage<ParseException>(::testing::HasSubstr("Unexpected token RightBracket"))
+   );
+}
+
+TEST(SaneQLParser, throwsOnMultipleIndices) {
+   EXPECT_THAT(
+      []() {
+         Parser parser("a[3, 4]");
+         (void)parser.parse();
+      },
+      ThrowsMessage<ParseException>(::testing::HasSubstr("Expected RightBracket but got Comma"))
+   );
+}
+
 TEST(SaneQLParser, parsesBracketIndexOnMethodCall) {
    // Bracket indexing chains with method calls and other postfix ops
    Parser parser("a.b()[0]");

--- a/src/rhydb/query_engine/saneql/token.cpp
+++ b/src/rhydb/query_engine/saneql/token.cpp
@@ -52,6 +52,10 @@ std::string tokenTypeToString(TokenType type) {
          return "LeftBrace";
       case TokenType::RIGHT_BRACE:
          return "RightBrace";
+      case TokenType::LEFT_BRACKET:
+         return "LeftBracket";
+      case TokenType::RIGHT_BRACKET:
+         return "RightBracket";
       case TokenType::COMMA:
          return "Comma";
       case TokenType::END_OF_FILE:

--- a/src/rhydb/query_engine/saneql/token.h
+++ b/src/rhydb/query_engine/saneql/token.h
@@ -32,6 +32,8 @@ enum class TokenType : uint8_t {
    RIGHT_PAREN,
    LEFT_BRACE,
    RIGHT_BRACE,
+   LEFT_BRACKET,
+   RIGHT_BRACKET,
    COMMA,
    END_OF_FILE
 };


### PR DESCRIPTION
resolves #1432

### Summary

Adds `a[i]` square-bracket indexing to SaneQL as shorthand for `a.at(i)`, so users can write `primary_key[2]` instead of `primary_key.at(2)`.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
