### PR TITLE
ci: also provide mac binary in ci and as release artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,6 +606,48 @@ jobs:
           name: wheel-macos-${{ matrix.arch }}
           path: wheelhouse/*.whl
 
+      - name: Package rhydb binary for release
+        run: |
+          set -euo pipefail
+
+          # `make build-wheels` (run above) builds build/Release/rhydb as a
+          # prerequisite, so the native macOS binary already exists here.
+          mkdir -p artifacts
+          cd artifacts
+
+          binary="rhydb-macos-${{ matrix.arch }}"
+          cp ../build/Release/rhydb "./$binary"
+          chmod +x "./$binary"
+
+          # Deprecation compatibility: the released binary was renamed silo -> rhydb.
+          # Keep publishing an identical silo-named copy during the deprecation
+          # period so existing consumers that download `silo-macos-<arch>` do not
+          # break. Remove this once the deprecation period ends.
+          legacy_binary="silo-macos-${{ matrix.arch }}"
+          cp "./$binary" "./$legacy_binary"
+
+          for b in "$binary" "$legacy_binary"; do
+            echo "Verifying $b ..."
+            [ -x "$b" ] || { echo "  ✗ FAILED: File does not exist or is not executable"; exit 1; }
+            file "$b" | grep -q "Mach-O" || { echo "  ✗ FAILED: File is not a Mach-O binary"; exit 1; }
+            echo "✓ Verified: $b"
+
+            shasum -a 256 "$b" > "$b.sha256sum"
+            # Create tar archive so that the file is executable when downloaded from GitHub Releases
+            tar -czf "$b.tar.gz" "$b"
+          done
+
+          echo "Files in artifacts/ after packaging:"
+          ls -alh .
+
+      - name: Upload rhydb binary as workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: binary-macos-${{ matrix.arch }}
+          path: |
+            artifacts/*.tar.gz
+            artifacts/*.sha256sum
+
       - name: Determine release version
         run: |
           git fetch origin 'refs/tags/*:refs/tags/*'
@@ -620,6 +662,18 @@ jobs:
         with:
           files: wheelhouse/*.whl
           tag_name: v${{ env.SILO_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload rhydb binary to GitHub release
+        if: env.SILO_VERSION != ''
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            artifacts/*.tar.gz
+            artifacts/*.sha256sum
+          tag_name: v${{ env.SILO_VERSION }}
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1526 

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This adds another CI step that produces binaries for MacOS as artifact on every pull request. Also uploads them on every release

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted or there is an issue to do so.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
