### PR TITLE
fix(query_engine): orderby produces internal server error when result is empty

### DIFF
--- a/src/rhydb/query_engine/operators/mutations_node.test.cpp
+++ b/src/rhydb/query_engine/operators/mutations_node.test.cpp
@@ -77,6 +77,19 @@ const QueryTestScenario MUTATIONS_MIN_PROPORTION_EXCLUDES_ALL = {
    .expected_query_result = nlohmann::json::array(),
 };
 
+// Regression for #1530: orderBy on an empty mutations result must return empty, not crash.
+const QueryTestScenario MUTATIONS_EMPTY_ORDER_BY_PROPORTION = {
+   .name = "MUTATIONS_EMPTY_ORDER_BY_PROPORTION",
+   .query = "default.mutations(minProportion:=0.6).orderBy({proportion})",
+   .expected_query_result = nlohmann::json::array(),
+};
+
+const QueryTestScenario MUTATIONS_EMPTY_ORDER_BY_PROPORTION_WITH_LIMIT = {
+   .name = "MUTATIONS_EMPTY_ORDER_BY_PROPORTION_WITH_LIMIT",
+   .query = "default.mutations(minProportion:=0.6).orderBy({proportion}).limit(5)",
+   .expected_query_result = nlohmann::json::array(),
+};
+
 const QueryTestScenario MUTATIONS_SEQUENCE_NAMES_SELECTS = {
    .name = "MUTATIONS_SEQUENCE_NAMES_SELECTS",
    .query =
@@ -194,6 +207,8 @@ QUERY_TEST(
       MUTATIONS_ALL_FIELDS,
       MUTATIONS_MIN_PROPORTION_KEEPS_SUBSET,
       MUTATIONS_MIN_PROPORTION_EXCLUDES_ALL,
+      MUTATIONS_EMPTY_ORDER_BY_PROPORTION,
+      MUTATIONS_EMPTY_ORDER_BY_PROPORTION_WITH_LIMIT,
       MUTATIONS_SEQUENCE_NAMES_SELECTS,
       MUTATIONS_WITH_INPUT_FILTER,
       MUTATIONS_FIELDS_NARROWED,

--- a/src/rhydb/query_engine/operators/order_by_with_limit_node.cpp
+++ b/src/rhydb/query_engine/operators/order_by_with_limit_node.cpp
@@ -69,29 +69,30 @@ std::vector<arrow::compute::SortKey> buildSortKeys(
    return sort_keys;
 }
 
-arrow::Result<arrow::acero::ExecNode*> addSelectKAndLimitNodes(
+// Fully sorts the input via `order_by_sink`, re-sources the sorted stream, and keeps the
+// `offset + limit` window with a `FetchNode`.
+//
+// Arrow's `select_k_sink` shares the same accumulate-then-`Take` machinery as `order_by_sink` (its
+// top-k index step aside), so it offers no memory advantage here, yet it crashes on empty input:
+// `SelectKUnstable` on a zero-row table returns an unset `Datum` that the subsequent `Take`
+// dereferences, terminating the process (issue #1530). `order_by_sink` handles empty input
+// correctly, exactly like `OrderByNode`.
+arrow::Result<arrow::acero::ExecNode*> addSortAndLimitNodes(
    arrow::acero::ExecPlan& plan,
    arrow::acero::ExecNode* top_node,
    const arrow::Ordering& ordering,
-   const std::vector<arrow::compute::SortKey>& sort_keys,
    const std::vector<std::shared_ptr<arrow::Field>>& output_fields,
    uint32_t offset,
    uint32_t limit
 ) {
-   // select_k returns the `k` smallest rows in sorted order. To honor an offset we select the whole
-   // window that starts at row 0 and covers up to `offset + limit`, then skip the offset below.
-   const int64_t select_k = static_cast<int64_t>(offset) + static_cast<int64_t>(limit);
-
    arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> generator;
    ARROW_ASSIGN_OR_RAISE(
       top_node,
       arrow::acero::MakeExecNode(
-         "select_k_sink",
+         "order_by_sink",
          &plan,
          {top_node},
-         arrow::acero::SelectKSinkNodeOptions{
-            arrow::compute::SelectKOptions{select_k, sort_keys}, &generator
-         }
+         arrow::acero::OrderBySinkNodeOptions{arrow::SortOptions{ordering}, &generator}
       )
    );
    top_node->SetLabel("order by with limit");
@@ -108,21 +109,15 @@ arrow::Result<arrow::acero::ExecNode*> addSelectKAndLimitNodes(
       )
    );
 
-   // select_k already caps the output at the window size; only a non-zero offset still needs a
-   // fetch to skip the leading rows. The fetch runs before the random-hash column is projected out,
-   // while the stream still carries the ordering the fetch requires.
-   if (offset > 0) {
-      ARROW_ASSIGN_OR_RAISE(
-         top_node,
-         arrow::acero::MakeExecNode(
-            std::string{arrow::acero::FetchNodeOptions::kName},
-            &plan,
-            {top_node},
-            arrow::acero::FetchNodeOptions(offset, limit)
-         )
-      );
-   }
-   return top_node;
+   // Unlike `select_k`, the full sort keeps every row, so the `offset + limit` window is always
+   // applied here. The fetch runs before the random-hash column is projected out, while the stream
+   // still carries the ordering the fetch requires.
+   return arrow::acero::MakeExecNode(
+      std::string{arrow::acero::FetchNodeOptions::kName},
+      &plan,
+      {top_node},
+      arrow::acero::FetchNodeOptions(offset, limit)
+   );
 }
 
 }  // namespace
@@ -138,15 +133,13 @@ arrow::Result<arrow::acero::ExecNode*> OrderByWithLimitNode::addToExecPlan(
 
    ARROW_ASSIGN_OR_RAISE(auto* top_node, child->addToExecPlan(plan, tables, query_options));
 
-   const std::vector<arrow::compute::SortKey> sort_keys =
-      buildSortKeys(fields, randomize_seed.has_value());
-   const arrow::Ordering ordering{sort_keys};
+   const arrow::Ordering ordering{buildSortKeys(fields, randomize_seed.has_value())};
 
    if (randomize_seed.has_value()) {
       ARROW_ASSIGN_OR_RAISE(top_node, addRandomizeColumn(plan, top_node, randomize_seed.value()));
    }
 
-   // The batches produced by select_k still carry the random-hash column (when randomizing), so the
+   // The batches produced by the sort still carry the random-hash column (when randomizing), so the
    // re-source schema must include it; `removeRandomizeColumn` projects it back out afterwards.
    auto output_fields = exec_node::columnsToArrowSchema(getOutputSchema())->fields();
    if (randomize_seed.has_value()) {
@@ -157,9 +150,7 @@ arrow::Result<arrow::acero::ExecNode*> OrderByWithLimitNode::addToExecPlan(
 
    ARROW_ASSIGN_OR_RAISE(
       top_node,
-      addSelectKAndLimitNodes(
-         plan, top_node, ordering, sort_keys, output_fields, offset.value_or(0), limit
-      )
+      addSortAndLimitNodes(plan, top_node, ordering, output_fields, offset.value_or(0), limit)
    );
 
    if (randomize_seed.has_value()) {

--- a/src/rhydb/query_engine/operators/order_by_with_limit_node.cpp
+++ b/src/rhydb/query_engine/operators/order_by_with_limit_node.cpp
@@ -40,24 +40,19 @@ std::vector<schema::ColumnIdentifier> OrderByWithLimitNode::getOutputSchema() co
    return child->getOutputSchema();
 }
 
-arrow::Result<arrow::acero::ExecNode*> OrderByWithLimitNode::addToExecPlan(
-   arrow::acero::ExecPlan& plan,
-   const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
-   const config::QueryOptions& query_options
-) const {
-   // The rewrite pass only produces this node when there is something to order by: sort fields, a
-   // randomize seed, or both.
-   SILO_ASSERT(!fields.empty() || randomize_seed.has_value());
+namespace {
 
-   ARROW_ASSIGN_OR_RAISE(auto* top_node, child->addToExecPlan(plan, tables, query_options));
-
+std::vector<arrow::compute::SortKey> buildSortKeys(
+   const std::vector<OrderByField>& fields,
+   bool has_randomize_seed
+) {
    using arrow::compute::NullPlacement;
    using arrow::compute::SortOrder;
 
    // Build the sort keys exactly as OrderByNode does, so a rewritten query orders identically to
    // the `order_by | limit` it replaces. Nulls sort as the smallest element.
    std::vector<arrow::compute::SortKey> sort_keys;
-   sort_keys.reserve(fields.size() + (randomize_seed.has_value() ? 1 : 0));
+   sort_keys.reserve(fields.size() + (has_randomize_seed ? 1 : 0));
    for (const auto& order_by_field : fields) {
       const auto sort_order =
          order_by_field.ascending ? SortOrder::Ascending : SortOrder::Descending;
@@ -68,19 +63,24 @@ arrow::Result<arrow::acero::ExecNode*> OrderByWithLimitNode::addToExecPlan(
    // A randomize seed adds the per-row random hash as the lowest-priority (tie-breaking) sort key,
    // matching OrderByNode; with no explicit fields it becomes the sole key, yielding a random
    // order.
-   if (randomize_seed.has_value()) {
+   if (has_randomize_seed) {
       sort_keys.emplace_back(RANDOMIZE_HASH_FIELD_NAME);
    }
+   return sort_keys;
+}
 
+arrow::Result<arrow::acero::ExecNode*> addSelectKAndLimitNodes(
+   arrow::acero::ExecPlan& plan,
+   arrow::acero::ExecNode* top_node,
+   const arrow::Ordering& ordering,
+   const std::vector<arrow::compute::SortKey>& sort_keys,
+   const std::vector<std::shared_ptr<arrow::Field>>& output_fields,
+   uint32_t offset,
+   uint32_t limit
+) {
    // select_k returns the `k` smallest rows in sorted order. To honor an offset we select the whole
    // window that starts at row 0 and covers up to `offset + limit`, then skip the offset below.
-   const int64_t select_k = static_cast<int64_t>(offset.value_or(0)) + static_cast<int64_t>(limit);
-
-   const arrow::Ordering ordering{sort_keys};
-
-   if (randomize_seed.has_value()) {
-      ARROW_ASSIGN_OR_RAISE(top_node, addRandomizeColumn(plan, top_node, randomize_seed.value()));
-   }
+   const int64_t select_k = static_cast<int64_t>(offset) + static_cast<int64_t>(limit);
 
    arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> generator;
    ARROW_ASSIGN_OR_RAISE(
@@ -96,14 +96,6 @@ arrow::Result<arrow::acero::ExecNode*> OrderByWithLimitNode::addToExecPlan(
    );
    top_node->SetLabel("order by with limit");
 
-   // The batches produced by select_k still carry the random-hash column (when randomizing), so the
-   // re-source schema must include it; `removeRandomizeColumn` projects it back out afterwards.
-   auto output_fields = exec_node::columnsToArrowSchema(getOutputSchema())->fields();
-   if (randomize_seed.has_value()) {
-      output_fields.emplace_back(
-         std::make_shared<arrow::Field>(RANDOMIZE_HASH_FIELD_NAME, arrow::uint64())
-      );
-   }
    ARROW_ASSIGN_OR_RAISE(
       top_node,
       arrow::acero::MakeExecNode(
@@ -119,17 +111,56 @@ arrow::Result<arrow::acero::ExecNode*> OrderByWithLimitNode::addToExecPlan(
    // select_k already caps the output at the window size; only a non-zero offset still needs a
    // fetch to skip the leading rows. The fetch runs before the random-hash column is projected out,
    // while the stream still carries the ordering the fetch requires.
-   if (offset.value_or(0) > 0) {
+   if (offset > 0) {
       ARROW_ASSIGN_OR_RAISE(
          top_node,
          arrow::acero::MakeExecNode(
             std::string{arrow::acero::FetchNodeOptions::kName},
             &plan,
             {top_node},
-            arrow::acero::FetchNodeOptions(offset.value(), limit)
+            arrow::acero::FetchNodeOptions(offset, limit)
          )
       );
    }
+   return top_node;
+}
+
+}  // namespace
+
+arrow::Result<arrow::acero::ExecNode*> OrderByWithLimitNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
+   const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
+   const config::QueryOptions& query_options
+) const {
+   // The rewrite pass only produces this node when there is something to order by: sort fields, a
+   // randomize seed, or both.
+   SILO_ASSERT(!fields.empty() || randomize_seed.has_value());
+
+   ARROW_ASSIGN_OR_RAISE(auto* top_node, child->addToExecPlan(plan, tables, query_options));
+
+   const std::vector<arrow::compute::SortKey> sort_keys =
+      buildSortKeys(fields, randomize_seed.has_value());
+   const arrow::Ordering ordering{sort_keys};
+
+   if (randomize_seed.has_value()) {
+      ARROW_ASSIGN_OR_RAISE(top_node, addRandomizeColumn(plan, top_node, randomize_seed.value()));
+   }
+
+   // The batches produced by select_k still carry the random-hash column (when randomizing), so the
+   // re-source schema must include it; `removeRandomizeColumn` projects it back out afterwards.
+   auto output_fields = exec_node::columnsToArrowSchema(getOutputSchema())->fields();
+   if (randomize_seed.has_value()) {
+      output_fields.emplace_back(
+         std::make_shared<arrow::Field>(RANDOMIZE_HASH_FIELD_NAME, arrow::uint64())
+      );
+   }
+
+   ARROW_ASSIGN_OR_RAISE(
+      top_node,
+      addSelectKAndLimitNodes(
+         plan, top_node, ordering, sort_keys, output_fields, offset.value_or(0), limit
+      )
+   );
 
    if (randomize_seed.has_value()) {
       ARROW_ASSIGN_OR_RAISE(top_node, removeRandomizeColumn(plan, top_node));

--- a/src/rhydb/query_engine/operators/order_by_with_limit_node.test.cpp
+++ b/src/rhydb/query_engine/operators/order_by_with_limit_node.test.cpp
@@ -101,10 +101,24 @@ const QueryTestScenario LIMIT_LARGER_THAN_INPUT_SCENARIO = {
    )
 };
 
+// An empty input must not crash the sort+limit path; it returns no rows (regression for #1530).
+const QueryTestScenario EMPTY_INPUT_SCENARIO = {
+   .name = "ORDER_BY_WITH_LIMIT_EMPTY_INPUT",
+   .query =
+      "default.filter(int_value = 999).project({primaryKey, int_value}).orderBy({int_value.asc()})"
+      ".limit(3)",
+   .expected_query_result = nlohmann::json::array()
+};
+
 }  // namespace
 
 QUERY_TEST(
    OrderByWithLimitNodeTest,
    TEST_DATA,
-   ::testing::Values(ASC_LIMIT_SCENARIO, DESC_LIMIT_SCENARIO, LIMIT_LARGER_THAN_INPUT_SCENARIO)
+   ::testing::Values(
+      ASC_LIMIT_SCENARIO,
+      DESC_LIMIT_SCENARIO,
+      LIMIT_LARGER_THAN_INPUT_SCENARIO,
+      EMPTY_INPUT_SCENARIO
+   )
 );


### PR DESCRIPTION
resolves #1530

### AI Summary

`orderBy(...).limit(n)` queries that produced an empty result crashed RhyDB with an internal server error (e.g. `aminoAcidMutations` with a filter matching no rows). The fused order-by-with-limit node used Arrow's `select_k`, whose empty-input handling returns an unset `Datum` that the following `Take` dereferences, terminating the process.

- **Replace `select_k` with a full sort + fetch** — `OrderByWithLimitNode` now emits `order_by_sink` followed by a `FetchNode` for the `offset + limit` window. Both Arrow sinks fully materialize and `Take`, so there is no memory regression, and `order_by_sink` handles empty input correctly (like `OrderByNode`).
- **Refactor first (separate commit)** — extracted sort-key and plan-node construction into helpers to keep `addToExecPlan()` under the cognitive-complexity limit; no behavior change.

Key fact that made the chosen fix clearly best: `select_k_sink` and `order_by_sink` are the **same Acero node** — both accumulate everything then `Take`. So `select_k` was never memory-bounded top-k here; it only saved a `log n / log k` factor on one CPU phase, while shipping a `std::terminate`.

<details>
<summary>Other fix options considered</summary>

**1. Guard node before the `select_k` sink** — insert something between child and `select_k` so it never sees 0 rows. *Impossible:* `DoFinish()` always runs; a 0-row batch (or zero batches) still yields a 0-row table → same unset `Datum` → `Take` crash. Dropping empty batches doesn't help.

**2. Custom buffering top-k sink** — keep `select_k` semantics via our own sink→buffer→source: accumulate child batches, call `SelectKUnstable` only when `rows > 0`, else emit empty. *Viable but costly:* ~60–100 lines of concurrency-adjacent code reimplementing Arrow's `FromRecordBatches`/`SelectKUnstable`/`Take` (Future composition, memory pool, threading) plus edge-case tests. Only justified if profiling later proves the top-k CPU win matters.

**3. Full sort + fetch — chosen.** Swap `select_k_sink` → `order_by_sink` + `FetchNode`. No memory regression, handles empty correctly.

**4. Wrap/patch Arrow's `SelectKUnstable`** — intercept the meta-function to return empty indices on 0 rows. *Can't reach it:* the crash is inside `OrderBySinkNode::DoFinish` (anonymous namespace, not overridable); `SinkNode` isn't subclassable either. We can't patch vendored Arrow.

**5. Drop the rewrite entirely (max-YAGNI)** — delete `SelectKRewritePass` + `OrderByWithLimitNode` and let `orderBy` + `limit` run as two nodes (that non-fused path already works on empty). Behaviorally identical to option 3's result, but throws away the node as a seam and its tests. We kept the node so a *correct* custom top-k (option 2) can be reintroduced later behind a benchmark.

**6. Upgrade / patch Arrow upstream** — newer Arrow or a conan patch fixing the empty-input `Datum`. Out of scope; higher risk/coupling than a local fix.

</details>

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
