### PR TITLE
fix(rhydb): implement custom arrow::acero node for selectK

### DIFF
--- a/src/rhydb/query_engine/exec_node/select_k.cpp
+++ b/src/rhydb/query_engine/exec_node/select_k.cpp
@@ -1,0 +1,238 @@
+#include "rhydb/query_engine/exec_node/select_k.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/acero/options.h>
+#include <arrow/acero/query_context.h>
+#include <arrow/acero/util.h>
+#include <arrow/compute/api_vector.h>
+#include <arrow/compute/exec.h>
+#include <arrow/compute/ordering.h>
+#include <arrow/datum.h>
+#include <arrow/record_batch.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+#include <arrow/table.h>
+
+#include "rhydb/common/panic.h"
+
+namespace rhydb::query_engine::exec_node {
+
+namespace {
+
+constexpr std::string_view SELECT_K_FACTORY_NAME = "rhydb_select_k";
+
+// Carries the sort order and output window from `addSelectKNode` into the node factory.
+struct SelectKNodeOptions : public arrow::acero::ExecNodeOptions {
+   SelectKNodeOptions(arrow::Ordering ordering, int64_t offset, int64_t limit)
+       : ordering(std::move(ordering)),
+         offset(offset),
+         limit(limit) {}
+
+   arrow::Ordering ordering;
+   int64_t offset;
+   int64_t limit;
+};
+
+// A select-k Acero node
+// Closely following the implementation of the acero-native SelectK-node:
+// https://github.com/apache/arrow/blob/397b3d0023030f6c6bc69d214ea7b27a687256f8/cpp/src/arrow/acero/order_by_impl.cc
+class SelectK : public arrow::acero::ExecNode {
+  public:
+   SelectK(
+      arrow::acero::ExecPlan* plan,
+      std::vector<arrow::acero::ExecNode*> inputs,
+      std::shared_ptr<arrow::Schema> output_schema,
+      arrow::Ordering ordering,
+      int64_t offset,
+      int64_t limit
+   )
+       : ExecNode(plan, std::move(inputs), {"input"}, std::move(output_schema)),
+         ordering_(std::move(ordering)),
+         offset_(offset),
+         limit_(limit),
+         k_(offset + limit) {}
+
+   static arrow::Result<arrow::acero::ExecNode*> make(
+      arrow::acero::ExecPlan* plan,
+      std::vector<arrow::acero::ExecNode*> inputs,
+      const arrow::acero::ExecNodeOptions& options
+   ) {
+      if (inputs.size() != 1) {
+         return arrow::Status::Invalid(
+            "rhydb_select_k requires exactly one input, got ", inputs.size()
+         );
+      }
+      const auto& select_k_options = static_cast<const SelectKNodeOptions&>(options);
+      std::shared_ptr<arrow::Schema> output_schema = inputs[0]->output_schema();
+      return plan->EmplaceNode<SelectK>(
+         plan,
+         std::move(inputs),
+         std::move(output_schema),
+         select_k_options.ordering,
+         select_k_options.offset,
+         select_k_options.limit
+      );
+   }
+
+   [[nodiscard]] const char* kind_name() const override { return "SelectK"; }
+
+   [[nodiscard]] const arrow::Ordering& ordering() const override { return ordering_; }
+
+   arrow::Status StartProducing() override { return arrow::Status::OK(); }
+
+   void PauseProducing(arrow::acero::ExecNode* /*output*/, int32_t counter) override {
+      inputs_[0]->PauseProducing(this, counter);
+   }
+
+   void ResumeProducing(arrow::acero::ExecNode* /*output*/, int32_t counter) override {
+      inputs_[0]->ResumeProducing(this, counter);
+   }
+
+   arrow::Status StopProducingImpl() override { return arrow::Status::OK(); }
+
+   arrow::Status InputReceived(arrow::acero::ExecNode* /*input*/, arrow::ExecBatch batch) override {
+      ARROW_ASSIGN_OR_RAISE(auto record_batch, batch.ToRecordBatch(output_schema_));
+      {
+         std::lock_guard<std::mutex> lock(mutex_);
+         batches_.push_back(std::move(record_batch));
+      }
+      // Every batch is buffered before Increment(), so when the counter reports completion the
+      // whole input is available to select from.
+      if (counter_.Increment()) {
+         return doFinish();
+      }
+      return arrow::Status::OK();
+   }
+
+   arrow::Status InputFinished(arrow::acero::ExecNode* /*input*/, int total_batches) override {
+      // Like Arrow's OrderByNode we cannot forward InputFinished eagerly: cutting the window
+      // changes the batch count, so downstream learns it only from doFinish().
+      if (counter_.SetTotal(total_batches)) {
+         return doFinish();
+      }
+      return arrow::Status::OK();
+   }
+
+  protected:
+   [[nodiscard]] std::string ToStringExtra(int /*indent*/) const override {
+      std::stringstream stream;
+      stream << "ordering=" << ordering_.ToString() << " offset=" << offset_ << " limit=" << limit_;
+      return stream.str();
+   }
+
+  private:
+   // All input has been consumed: materialize it, run the heap-based top-k over the whole table,
+   // cut the [offset, offset + limit) window
+   arrow::Status doFinish() {
+      std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+      {
+         std::lock_guard<std::mutex> lock(mutex_);
+         batches = std::move(batches_);
+      }
+      ARROW_ASSIGN_OR_RAISE(auto table, arrow::Table::FromRecordBatches(output_schema_, batches));
+
+      arrow::compute::ExecContext* ctx = plan_->query_context()->exec_context();
+      std::shared_ptr<arrow::Table> selected;
+      // Manually check for num_rows == 0 until https://github.com/apache/arrow/issues/51210 is
+      // fixed
+      if (table->num_rows() == 0) {
+         selected = std::move(table);
+      } else {
+         const arrow::compute::SelectKOptions options{k_, ordering_.sort_keys()};
+         ARROW_ASSIGN_OR_RAISE(
+            auto indices, arrow::compute::SelectKUnstable(arrow::Datum{table}, options, ctx)
+         );
+         ARROW_ASSIGN_OR_RAISE(
+            auto taken,
+            arrow::compute::Take(
+               arrow::Datum{table},
+               arrow::Datum{indices},
+               arrow::compute::TakeOptions::NoBoundsCheck(),
+               ctx
+            )
+         );
+         selected = taken.table();
+      }
+
+      // select_k returns the smallest `offset + limit` rows in sorted order; drop the leading
+      // `offset` of them to land on the [offset, offset + limit) window.
+      const int64_t rows = selected->num_rows();
+      const int64_t window_offset = std::min(offset_, rows);
+      const int64_t window_length = std::min(limit_, rows - window_offset);
+      auto window = selected->Slice(window_offset, window_length);
+
+      arrow::TableBatchReader reader(*window);
+      reader.set_chunksize(arrow::acero::ExecPlan::kMaxBatchSize);
+      int batch_index = 0;
+      while (true) {
+         ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::RecordBatch> next, reader.Next());
+         if (next == nullptr) {
+            return output_->InputFinished(this, batch_index);
+         }
+         const int index = batch_index++;
+         plan_->query_context()->ScheduleTask(
+            [this, batch = std::move(next), index]() -> arrow::Status {
+               arrow::ExecBatch exec_batch(*batch);
+               exec_batch.index = index;
+               return output_->InputReceived(this, std::move(exec_batch));
+            },
+            "SelectK::ProcessBatch"
+         );
+      }
+   }
+
+   arrow::acero::AtomicCounter counter_;
+   arrow::Ordering ordering_;
+   int64_t offset_;
+   int64_t limit_;
+   int64_t k_;
+   std::mutex mutex_;
+   // Every input row, buffered until all input arrives (no pruning). Guarded by `mutex_`.
+   std::vector<std::shared_ptr<arrow::RecordBatch>> batches_;
+};
+
+// Register the factory with Acero's default registry exactly once per process.
+void registerSelectKFactory() {
+   static std::once_flag registered;
+   std::call_once(registered, []() {
+      const arrow::Status status = arrow::acero::default_exec_factory_registry()->AddFactory(
+         std::string{SELECT_K_FACTORY_NAME}, SelectK::make
+      );
+      RHYDB_ASSERT(status.ok());
+   });
+}
+
+}  // namespace
+
+arrow::Result<arrow::acero::ExecNode*> addSelectKNode(
+   arrow::acero::ExecPlan& plan,
+   arrow::acero::ExecNode* input_node,
+   const arrow::Ordering& ordering,
+   uint32_t offset,
+   uint32_t limit
+) {
+   registerSelectKFactory();
+   ARROW_ASSIGN_OR_RAISE(
+      auto* node,
+      arrow::acero::MakeExecNode(
+         std::string{SELECT_K_FACTORY_NAME},
+         &plan,
+         {input_node},
+         SelectKNodeOptions{ordering, static_cast<int64_t>(offset), static_cast<int64_t>(limit)}
+      )
+   );
+   node->SetLabel("select_k with limit");
+   return node;
+}
+
+}  // namespace rhydb::query_engine::exec_node

--- a/src/rhydb/query_engine/exec_node/select_k.h
+++ b/src/rhydb/query_engine/exec_node/select_k.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/compute/ordering.h>
+#include <arrow/result.h>
+
+namespace rhydb::query_engine::exec_node {
+
+/// Appends a select-k Acero node on top of `input_node` and returns it.
+///
+/// The node (a custom `arrow::acero::ExecNode` registered as `rhydb_select_k`) buffers the whole
+/// input stream, selects the `offset + limit` smallest rows (by `ordering`) with a heap-based
+/// `select_k`, and emits the `[offset, offset + limit)` window in sorted order.
+arrow::Result<arrow::acero::ExecNode*> addSelectKNode(
+   arrow::acero::ExecPlan& plan,
+   arrow::acero::ExecNode* input_node,
+   const arrow::Ordering& ordering,
+   uint32_t offset,
+   uint32_t limit
+);
+
+}  // namespace rhydb::query_engine::exec_node

--- a/src/rhydb/query_engine/operators/mutations_node.test.cpp
+++ b/src/rhydb/query_engine/operators/mutations_node.test.cpp
@@ -77,6 +77,19 @@ const QueryTestScenario MUTATIONS_MIN_PROPORTION_EXCLUDES_ALL = {
    .expected_query_result = nlohmann::json::array(),
 };
 
+// Regression for #1530: orderBy on an empty mutations result must return empty, not crash.
+const QueryTestScenario MUTATIONS_EMPTY_ORDER_BY_PROPORTION = {
+   .name = "MUTATIONS_EMPTY_ORDER_BY_PROPORTION",
+   .query = "default.mutations(minProportion:=0.6).orderBy({proportion})",
+   .expected_query_result = nlohmann::json::array(),
+};
+
+const QueryTestScenario MUTATIONS_EMPTY_ORDER_BY_PROPORTION_WITH_LIMIT = {
+   .name = "MUTATIONS_EMPTY_ORDER_BY_PROPORTION_WITH_LIMIT",
+   .query = "default.mutations(minProportion:=0.6).orderBy({proportion}).limit(5)",
+   .expected_query_result = nlohmann::json::array(),
+};
+
 const QueryTestScenario MUTATIONS_SEQUENCE_NAMES_SELECTS = {
    .name = "MUTATIONS_SEQUENCE_NAMES_SELECTS",
    .query =
@@ -194,6 +207,8 @@ QUERY_TEST(
       MUTATIONS_ALL_FIELDS,
       MUTATIONS_MIN_PROPORTION_KEEPS_SUBSET,
       MUTATIONS_MIN_PROPORTION_EXCLUDES_ALL,
+      MUTATIONS_EMPTY_ORDER_BY_PROPORTION,
+      MUTATIONS_EMPTY_ORDER_BY_PROPORTION_WITH_LIMIT,
       MUTATIONS_SEQUENCE_NAMES_SELECTS,
       MUTATIONS_WITH_INPUT_FILTER,
       MUTATIONS_FIELDS_NARROWED,

--- a/src/rhydb/query_engine/operators/order_by_with_limit_node.cpp
+++ b/src/rhydb/query_engine/operators/order_by_with_limit_node.cpp
@@ -8,15 +8,12 @@
 #include <vector>
 
 #include <arrow/acero/exec_plan.h>
-#include <arrow/acero/options.h>
 #include <arrow/compute/api.h>
 #include <arrow/compute/ordering.h>
-#include <arrow/type.h>
-#include <arrow/util/async_generator_fwd.h>
 #include <nlohmann/json.hpp>
 
 #include "rhydb/common/panic.h"
-#include "rhydb/query_engine/exec_node/arrow_util.h"
+#include "rhydb/query_engine/exec_node/select_k.h"
 #include "rhydb/query_engine/operators/order_by_randomize.h"
 #include "rhydb/schema/database_schema.h"
 #include "rhydb/storage/table.h"
@@ -40,6 +37,37 @@ std::vector<schema::ColumnIdentifier> OrderByWithLimitNode::getOutputSchema() co
    return child->getOutputSchema();
 }
 
+namespace {
+
+std::vector<arrow::compute::SortKey> buildSortKeys(
+   const std::vector<OrderByField>& fields,
+   bool has_randomize_seed
+) {
+   using arrow::compute::NullPlacement;
+   using arrow::compute::SortOrder;
+
+   // Build the sort keys exactly as OrderByNode does, so a rewritten query orders identically to
+   // the `order_by | limit` it replaces. Nulls sort as the smallest element.
+   std::vector<arrow::compute::SortKey> sort_keys;
+   sort_keys.reserve(fields.size() + (has_randomize_seed ? 1 : 0));
+   for (const auto& order_by_field : fields) {
+      const auto sort_order =
+         order_by_field.ascending ? SortOrder::Ascending : SortOrder::Descending;
+      const auto null_placement =
+         order_by_field.ascending ? NullPlacement::AtStart : NullPlacement::AtEnd;
+      sort_keys.emplace_back(order_by_field.field.name, sort_order, null_placement);
+   }
+   // A randomize seed adds the per-row random hash as the lowest-priority (tie-breaking) sort key,
+   // matching OrderByNode; with no explicit fields it becomes the sole key, yielding a random
+   // order.
+   if (has_randomize_seed) {
+      sort_keys.emplace_back(RANDOMIZE_HASH_FIELD_NAME);
+   }
+   return sort_keys;
+}
+
+}  // namespace
+
 arrow::Result<arrow::acero::ExecNode*> OrderByWithLimitNode::addToExecPlan(
    arrow::acero::ExecPlan& plan,
    const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
@@ -51,85 +79,17 @@ arrow::Result<arrow::acero::ExecNode*> OrderByWithLimitNode::addToExecPlan(
 
    ARROW_ASSIGN_OR_RAISE(auto* top_node, child->addToExecPlan(plan, tables, query_options));
 
-   using arrow::compute::NullPlacement;
-   using arrow::compute::SortOrder;
-
-   // Build the sort keys exactly as OrderByNode does, so a rewritten query orders identically to
-   // the `order_by | limit` it replaces. Nulls sort as the smallest element.
-   std::vector<arrow::compute::SortKey> sort_keys;
-   sort_keys.reserve(fields.size() + (randomize_seed.has_value() ? 1 : 0));
-   for (const auto& order_by_field : fields) {
-      const auto sort_order =
-         order_by_field.ascending ? SortOrder::Ascending : SortOrder::Descending;
-      const auto null_placement =
-         order_by_field.ascending ? NullPlacement::AtStart : NullPlacement::AtEnd;
-      sort_keys.emplace_back(order_by_field.field.name, sort_order, null_placement);
-   }
-   // A randomize seed adds the per-row random hash as the lowest-priority (tie-breaking) sort key,
-   // matching OrderByNode; with no explicit fields it becomes the sole key, yielding a random
-   // order.
-   if (randomize_seed.has_value()) {
-      sort_keys.emplace_back(RANDOMIZE_HASH_FIELD_NAME);
-   }
-
-   // select_k returns the `k` smallest rows in sorted order. To honor an offset we select the whole
-   // window that starts at row 0 and covers up to `offset + limit`, then skip the offset below.
-   const int64_t select_k = static_cast<int64_t>(offset.value_or(0)) + static_cast<int64_t>(limit);
-
-   const arrow::Ordering ordering{sort_keys};
+   const arrow::Ordering ordering{buildSortKeys(fields, randomize_seed.has_value())};
 
    if (randomize_seed.has_value()) {
       ARROW_ASSIGN_OR_RAISE(top_node, addRandomizeColumn(plan, top_node, randomize_seed.value()));
    }
 
-   arrow::AsyncGenerator<std::optional<arrow::ExecBatch>> generator;
+   // The top-k stage preserves its input columns, so when randomizing its output still carries the
+   // random-hash column; `removeRandomizeColumn` projects it back out afterwards.
    ARROW_ASSIGN_OR_RAISE(
-      top_node,
-      arrow::acero::MakeExecNode(
-         "select_k_sink",
-         &plan,
-         {top_node},
-         arrow::acero::SelectKSinkNodeOptions{
-            arrow::compute::SelectKOptions{select_k, sort_keys}, &generator
-         }
-      )
+      top_node, exec_node::addSelectKNode(plan, top_node, ordering, offset.value_or(0), limit)
    );
-   top_node->SetLabel("order by with limit");
-
-   // The batches produced by select_k still carry the random-hash column (when randomizing), so the
-   // re-source schema must include it; `removeRandomizeColumn` projects it back out afterwards.
-   auto output_fields = exec_node::columnsToArrowSchema(getOutputSchema())->fields();
-   if (randomize_seed.has_value()) {
-      output_fields.emplace_back(
-         std::make_shared<arrow::Field>(RANDOMIZE_HASH_FIELD_NAME, arrow::uint64())
-      );
-   }
-   ARROW_ASSIGN_OR_RAISE(
-      top_node,
-      arrow::acero::MakeExecNode(
-         "source",
-         &plan,
-         {},
-         arrow::acero::SourceNodeOptions{
-            arrow::schema(output_fields), std::move(generator), ordering
-         }
-      )
-   );
-
-   // select_k already caps the output at the window size; only a non-zero offset still needs a
-   // fetch to skip the leading rows. The fetch runs before the random-hash column is projected out,
-   // while the stream still carries the ordering the fetch requires.
-   if (offset.value_or(0) > 0) {
-      ARROW_ASSIGN_OR_RAISE(
-         top_node,
-         arrow::acero::MakeExecNode(
-            std::string{arrow::acero::FetchNodeOptions::kName},
-            &plan,
-            {top_node},
-            arrow::acero::FetchNodeOptions(offset.value(), limit)
-         )
-      );
-   }
 
    if (randomize_seed.has_value()) {
       ARROW_ASSIGN_OR_RAISE(top_node, removeRandomizeColumn(plan, top_node));

--- a/src/rhydb/query_engine/operators/order_by_with_limit_node.h
+++ b/src/rhydb/query_engine/operators/order_by_with_limit_node.h
@@ -17,8 +17,8 @@ namespace rhydb::query_engine::operators {
 /// Sorts output rows by the specified fields and keeps only the `offset + limit` smallest of them.
 ///
 /// This is the combined equivalent of an `OrderByNode` directly below a `FetchNode`: instead of
-/// sorting the entire input and then discarding all but a small window, it uses Arrow's `select_k`
-/// (top-k) implementation, which only ever keeps the `offset + limit` best rows seen so far. The
+/// sorting the entire input and then discarding all but a small window, it runs a heap-based
+/// select-k stage (see `addSelectKNode`) that selects the `offset + limit` best rows. The
 /// `SelectKRewritePass` rewrites `Fetch(OrderBy(...))` into this node.
 ///
 /// Like `OrderByNode`, a `randomize_seed` orders rows by a per-row random hash (as an extra,

--- a/src/rhydb/query_engine/operators/order_by_with_limit_node.test.cpp
+++ b/src/rhydb/query_engine/operators/order_by_with_limit_node.test.cpp
@@ -101,10 +101,40 @@ const QueryTestScenario LIMIT_LARGER_THAN_INPUT_SCENARIO = {
    )
 };
 
+// Same query with multiple batches
+const QueryTestScenario MULTI_BATCH_SCENARIO = {
+   .name = "ORDER_BY_WITH_LIMIT_MULTI_BATCH",
+   .query =
+      "default.project({primaryKey, int_value, date}).orderBy({int_value.asc(), "
+      "date.asc()}).limit(3)",
+   .expected_query_result = nlohmann::json(
+      {{{"primaryKey", "id_0"}, {"int_value", nullptr}, {"date", nullptr}},
+       {{"primaryKey", "id_1"}, {"int_value", nullptr}, {"date", "2023-01-01"}},
+       {{"primaryKey", "id_2"}, {"int_value", 1}, {"date", nullptr}}}
+   ),
+   .query_options = rhydb::config::QueryOptions{.materialization_cutoff = 2}
+};
+
+// An empty input must not crash the sort+limit path (See
+// https://github.com/apache/arrow/issues/51210)
+const QueryTestScenario EMPTY_INPUT_SCENARIO = {
+   .name = "ORDER_BY_WITH_LIMIT_EMPTY_INPUT",
+   .query =
+      "default.filter(int_value = 999).project({primaryKey, int_value}).orderBy({int_value.asc()})"
+      ".limit(3)",
+   .expected_query_result = nlohmann::json::array()
+};
+
 }  // namespace
 
 QUERY_TEST(
    OrderByWithLimitNodeTest,
    TEST_DATA,
-   ::testing::Values(ASC_LIMIT_SCENARIO, DESC_LIMIT_SCENARIO, LIMIT_LARGER_THAN_INPUT_SCENARIO)
+   ::testing::Values(
+      ASC_LIMIT_SCENARIO,
+      DESC_LIMIT_SCENARIO,
+      LIMIT_LARGER_THAN_INPUT_SCENARIO,
+      MULTI_BATCH_SCENARIO,
+      EMPTY_INPUT_SCENARIO
+   )
 );


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1530

### Summary
<!-- Add a few sentences describing the main changes introduced in this PR. -->
<!-- Only relevant if the corresponding issue does not already describe enough. -->

This implements a custom selectK node implementation, which does not have the same bug as `arrow::acero`'s provided node.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [X] All necessary documentation has been adapted or there is an issue to do so.
- [X] The implemented feature is covered by an appropriate test.
