### PR TITLE
docs: mention `make full-clean` in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ Documentation (for devs and users) in `documentation/`.
 make build/Debug/rhydb             # Debug build (includes ASAN)
 make build/Release/rhydb           # Release build (includes mimalloc on Linux)
 
-make clean                         # Clean build artifacts
+make clean                         # Clean generated outputs/logs/deps (keeps build/)
+make full-clean                    # clean + remove build/ (forces full reconfigure + rebuild)
 
 # Test
 make test                          # Build and run C++ unit tests


### PR DESCRIPTION
### Summary
My agent kept complaining about stale build caches. I think telling it about the existence of `make full-clean` will help.

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
~~- [ ] The implemented feature is covered by an appropriate test.~~
