### PR TITLE
feat(query_engine): add `tables()` function to list all tables

### DIFF
--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -518,8 +518,7 @@ tables()
 {"tableName": "myTable"}
 ```
 
-`tables()` produces an ordinary relation, so operators such as `project`, `map`, `orderBy` and
-`limit` can be chained after it.
+`tables()` produces an ordinary relation, so operators such as `filter` and `limit` can be chained after it.
 
 ### `transitiveClosure(input, from, to [, includeVertices:=bool])`
 

--- a/documentation/query_documentation.md
+++ b/documentation/query_documentation.md
@@ -499,6 +499,28 @@ so operators such as `project`, `map`, `orderBy` and `limit` can be chained afte
 When a sequence column is read into a pipeline it is decompressed to a string before `schema()` observes it,
 so nucleotide and amino acid sequences cannot be distinguished from ordinary strings at this point.
 
+### `tables()`
+
+Lists all tables in the database. It takes no arguments and is called as a top-level function
+(not chained onto a table).
+
+```
+tables()
+```
+
+**Output:** one row per table, with a single column:
+
+| Field       | Type   | Description        |
+|-------------|--------|--------------------|
+| `tableName` | string | Name of the table  |
+
+```json
+{"tableName": "myTable"}
+```
+
+`tables()` produces an ordinary relation, so operators such as `project`, `map`, `orderBy` and
+`limit` can be chained after it.
+
 ### `transitiveClosure(input, from, to [, includeVertices:=bool])`
 
 Computes the transitive closure of a directed relation. The `input` is any relation-producing

--- a/src/rhydb/database.test.cpp
+++ b/src/rhydb/database.test.cpp
@@ -347,6 +347,26 @@ int64_t countInTableWhere(
 }
 }  // namespace
 
+TEST(DatabaseTablesQueryTest, listsAllTablesSortedByName) {
+   rhydb::Database database;
+   database.createTable(TableName{"source"}, makeValueColumnSchema());
+   database.createTable(TableName{"archive"}, makeValueColumnSchema());
+   database.createTable(TableName{"backup"}, makeValueColumnSchema());
+
+   auto query_plan = rhydb::query_engine::Planner::planSaneqlQuery(
+      "tables()", database.tables, rhydb::config::QueryOptions{}, "tables_query"
+   );
+
+   ASSERT_EQ(
+      rhydb::test::executeQueryToJsonArray(query_plan),
+      nlohmann::json::array({
+         {{"tableName", "archive"}},
+         {{"tableName", "backup"}},
+         {{"tableName", "source"}},
+      })
+   );
+}
+
 TEST(DatabaseInsertQueryTest, copiesFilteredRowsFromOneTableIntoAnother) {
    rhydb::Database database;
    database.createTable(TableName{"source"}, makeValueColumnSchema());

--- a/src/rhydb/database.test.cpp
+++ b/src/rhydb/database.test.cpp
@@ -347,26 +347,6 @@ int64_t countInTableWhere(
 }
 }  // namespace
 
-TEST(DatabaseTablesQueryTest, listsAllTablesSortedByName) {
-   rhydb::Database database;
-   database.createTable(TableName{"source"}, makeValueColumnSchema());
-   database.createTable(TableName{"archive"}, makeValueColumnSchema());
-   database.createTable(TableName{"backup"}, makeValueColumnSchema());
-
-   auto query_plan = rhydb::query_engine::Planner::planSaneqlQuery(
-      "tables()", database.tables, rhydb::config::QueryOptions{}, "tables_query"
-   );
-
-   ASSERT_EQ(
-      rhydb::test::executeQueryToJsonArray(query_plan),
-      nlohmann::json::array({
-         {{"tableName", "archive"}},
-         {{"tableName", "backup"}},
-         {{"tableName", "source"}},
-      })
-   );
-}
-
 TEST(DatabaseInsertQueryTest, copiesFilteredRowsFromOneTableIntoAnother) {
    rhydb::Database database;
    database.createTable(TableName{"source"}, makeValueColumnSchema());

--- a/src/rhydb/query_engine/operator_visitor.h
+++ b/src/rhydb/query_engine/operator_visitor.h
@@ -19,6 +19,7 @@
 #include "rhydb/query_engine/operators/project_node.h"
 #include "rhydb/query_engine/operators/schema_node.h"
 #include "rhydb/query_engine/operators/table_scan_node.h"
+#include "rhydb/query_engine/operators/tables_node.h"
 #include "rhydb/query_engine/operators/transitive_closure_node.h"
 #include "rhydb/query_engine/operators/union_all_node.h"
 #include "rhydb/query_engine/operators/unresolved_insertions_node.h"
@@ -89,6 +90,8 @@ decltype(auto) visit(QueryNode& node, Func&& func) {
          return std::forward<Func>(func)(static_cast<JoinNode&>(node));
       case NodeKind::SCHEMA:
          return std::forward<Func>(func)(static_cast<SchemaNode&>(node));
+      case NodeKind::TABLES_LIST:
+         return std::forward<Func>(func)(static_cast<TablesNode&>(node));
       case NodeKind::BITMAP_AGGREGATION:
          return std::forward<Func>(func)(static_cast<BitmapAggregationNode&>(node));
       case NodeKind::TRANSITIVE_CLOSURE:

--- a/src/rhydb/query_engine/operators/query_node.cpp
+++ b/src/rhydb/query_engine/operators/query_node.cpp
@@ -60,6 +60,8 @@ std::string_view nodeKindToString(NodeKind kind) {
          return "Join";
       case NodeKind::SCHEMA:
          return "Schema";
+      case NodeKind::TABLES_LIST:
+         return "TablesList";
       case NodeKind::BITMAP_AGGREGATION:
          return "BitmapAggregation";
       case NodeKind::TRANSITIVE_CLOSURE:

--- a/src/rhydb/query_engine/operators/query_node.h
+++ b/src/rhydb/query_engine/operators/query_node.h
@@ -40,6 +40,7 @@ enum class NodeKind : uint8_t {
    UNION_ALL,
    JOIN,
    SCHEMA,
+   TABLES_LIST,
    BITMAP_AGGREGATION,
    TRANSITIVE_CLOSURE,
 };

--- a/src/rhydb/query_engine/operators/tables_node.cpp
+++ b/src/rhydb/query_engine/operators/tables_node.cpp
@@ -15,16 +15,22 @@
 
 namespace rhydb::query_engine::operators {
 
-std::vector<schema::ColumnIdentifier> TablesNode::getOutputSchema() const {
+using config::QueryOptions;
+using schema::ColumnIdentifier;
+using schema::ColumnType;
+using schema::TableName;
+using storage::Table;
+
+std::vector<ColumnIdentifier> TablesNode::getOutputSchema() const {
    return {
-      {.name = std::string{TABLE_NAME_COLUMN}, .type = schema::ColumnType::STRING},
+      {.name = std::string{TABLE_NAME_COLUMN}, .type = ColumnType::STRING},
    };
 }
 
 arrow::Result<arrow::acero::ExecNode*> TablesNode::addToExecPlan(
    arrow::acero::ExecPlan& plan,
-   const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
-   const config::QueryOptions& /*query_options*/
+   const std::map<TableName, std::shared_ptr<Table>>& tables,
+   const QueryOptions& /*query_options*/
 ) const {
    arrow::StringBuilder table_name_builder{};
    for (const auto& [table_name, _] : tables) {

--- a/src/rhydb/query_engine/operators/tables_node.cpp
+++ b/src/rhydb/query_engine/operators/tables_node.cpp
@@ -1,0 +1,49 @@
+#include "rhydb/query_engine/operators/tables_node.h"
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include <arrow/acero/exec_plan.h>
+#include <arrow/acero/options.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <nlohmann/json.hpp>
+
+#include "rhydb/query_engine/exec_node/arrow_util.h"
+#include "rhydb/schema/database_schema.h"
+
+namespace rhydb::query_engine::operators {
+
+std::vector<schema::ColumnIdentifier> TablesNode::getOutputSchema() const {
+   return {
+      {.name = std::string{TABLE_NAME_COLUMN}, .type = schema::ColumnType::STRING},
+   };
+}
+
+arrow::Result<arrow::acero::ExecNode*> TablesNode::addToExecPlan(
+   arrow::acero::ExecPlan& plan,
+   const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
+   const config::QueryOptions& /*query_options*/
+) const {
+   arrow::StringBuilder table_name_builder{};
+   for (const auto& [table_name, _] : tables) {
+      ARROW_RETURN_NOT_OK(table_name_builder.Append(table_name.getName()));
+   }
+   std::shared_ptr<arrow::Array> table_name_array;
+   ARROW_ASSIGN_OR_RAISE(table_name_array, table_name_builder.Finish());
+
+   const auto arrow_schema = exec_node::columnsToArrowSchema(getOutputSchema());
+   const auto table = arrow::Table::Make(arrow_schema, {table_name_array});
+
+   const arrow::acero::TableSourceNodeOptions options{table};
+   return arrow::acero::MakeExecNode("table_source", &plan, {}, options);
+}
+
+nlohmann::json TablesNode::toJson() const {
+   return {
+      {"type", nodeKindToString(kind())},
+   };
+}
+
+}  // namespace rhydb::query_engine::operators

--- a/src/rhydb/query_engine/operators/tables_node.h
+++ b/src/rhydb/query_engine/operators/tables_node.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include <arrow/result.h>
+
+#include "rhydb/query_engine/operators/query_node.h"
+#include "rhydb/schema/database_schema.h"
+#include "rhydb/storage/table.h"
+
+namespace rhydb::query_engine::operators {
+
+/// Source-type node that lists all tables in the database as data rows, one row
+/// per table. It takes no input; the table names are read from the database's
+/// table map at execution time.
+class TablesNode final : public QueryNode {
+  public:
+   static constexpr std::string_view TABLE_NAME_COLUMN = "tableName";
+
+   TablesNode() = default;
+
+   [[nodiscard]] std::vector<schema::ColumnIdentifier> getOutputSchema() const override;
+
+   [[nodiscard]] arrow::Result<arrow::acero::ExecNode*> addToExecPlan(
+      arrow::acero::ExecPlan& plan,
+      const std::map<schema::TableName, std::shared_ptr<storage::Table>>& tables,
+      const config::QueryOptions& query_options
+   ) const override;
+
+   [[nodiscard]] NodeKind kind() const override { return NodeKind::TABLES_LIST; }
+
+   [[nodiscard]] nlohmann::json toJson() const override;
+};
+
+}  // namespace rhydb::query_engine::operators

--- a/src/rhydb/query_engine/operators/tables_node.test.cpp
+++ b/src/rhydb/query_engine/operators/tables_node.test.cpp
@@ -1,0 +1,70 @@
+#include <nlohmann/json.hpp>
+
+#include "rhydb/test/query_fixture.test.h"
+
+namespace {
+using rhydb::ReferenceGenomes;
+using rhydb::test::QueryTestData;
+using rhydb::test::QueryTestScenario;
+
+const std::vector<nlohmann::json> DATA = {
+   {{"primaryKey", "id_0"},
+    {"country", "CH"},
+    {"segment1", nullptr},
+    {"gene1", nullptr},
+    {"unaligned_segment1", nullptr}},
+   {{"primaryKey", "id_1"},
+    {"country", "DE"},
+    {"segment1", nullptr},
+    {"gene1", nullptr},
+    {"unaligned_segment1", nullptr}},
+};
+
+const auto DATABASE_CONFIG =
+   R"(
+schema:
+  instanceName: "dummy name"
+  metadata:
+    - name: "primaryKey"
+      type: "string"
+    - name: "country"
+      type: "string"
+  primaryKey: "primaryKey"
+)";
+
+const auto REFERENCE_GENOMES = ReferenceGenomes{
+   {{"segment1", "ACGT"}},
+   {{"gene1", "*"}},
+};
+
+const QueryTestData TEST_DATA{
+   .ndjson_input_data = DATA,
+   .database_config = DATABASE_CONFIG,
+   .reference_genomes = REFERENCE_GENOMES
+};
+
+const QueryTestScenario TABLES_SCENARIO = {
+   .name = "TABLES",
+   .query = "tables()",
+   .expected_query_result = nlohmann::json({{{"tableName", "default"}}}),
+};
+
+const QueryTestScenario TABLES_SCHEMA_SCENARIO = {
+   .name = "TABLES_SCHEMA",
+   .query = "tables().schema()",
+   .expected_query_result = nlohmann::json({{{"fieldName", "tableName"}, {"type", "STRING"}}}),
+};
+
+const QueryTestScenario TABLES_EXTRA_ARG_ERROR_SCENARIO = {
+   .name = "TABLES_EXTRA_ARG_ERROR",
+   .query = "tables(default)",
+   .expected_error_message = "tables() received too many positional arguments",
+};
+
+}  // namespace
+
+QUERY_TEST(
+   TablesTest,
+   TEST_DATA,
+   ::testing::Values(TABLES_SCENARIO, TABLES_SCHEMA_SCENARIO, TABLES_EXTRA_ARG_ERROR_SCENARIO)
+);

--- a/src/rhydb/query_engine/operators/tables_node.test.cpp
+++ b/src/rhydb/query_engine/operators/tables_node.test.cpp
@@ -1,5 +1,13 @@
+#include <map>
+#include <memory>
+
+#include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
+#include "rhydb/database.h"
+#include "rhydb/query_engine/planner.h"
+#include "rhydb/schema/database_schema.h"
+#include "rhydb/storage/column/string_column.h"
 #include "rhydb/test/query_fixture.test.h"
 
 namespace {
@@ -68,3 +76,54 @@ QUERY_TEST(
    TEST_DATA,
    ::testing::Values(TABLES_SCENARIO, TABLES_SCHEMA_SCENARIO, TABLES_EXTRA_ARG_ERROR_SCENARIO)
 );
+
+namespace {
+using rhydb::Database;
+using rhydb::config::QueryOptions;
+using rhydb::query_engine::Planner;
+using rhydb::schema::ColumnIdentifier;
+using rhydb::schema::ColumnType;
+using rhydb::schema::TableName;
+using rhydb::schema::TableSchema;
+using rhydb::storage::column::ColumnMetadata;
+using rhydb::storage::column::StringColumnMetadata;
+
+std::shared_ptr<TableSchema> makeMinimalSchema() {
+   const ColumnIdentifier key{.name = "key", .type = ColumnType::STRING};
+   std::map<ColumnIdentifier, std::shared_ptr<ColumnMetadata>> column_metadata{
+      {key, std::make_shared<StringColumnMetadata>(key.name)},
+   };
+   return std::make_shared<TableSchema>(std::move(column_metadata), key);
+}
+}  // namespace
+
+TEST(TablesNodeMultiTableTest, listsAndFiltersMultipleTables) {
+   Database database;
+   database.createTable(TableName{"source"}, makeMinimalSchema());
+   database.createTable(TableName{"archive"}, makeMinimalSchema());
+   database.createTable(TableName{"backup"}, makeMinimalSchema());
+
+   auto query_plan =
+      Planner::planSaneqlQuery("tables()", database.tables, QueryOptions{}, "tables_query");
+   ASSERT_EQ(
+      rhydb::test::executeQueryToJsonArray(query_plan),
+      nlohmann::json::array({
+         {{"tableName", "archive"}},
+         {{"tableName", "backup"}},
+         {{"tableName", "source"}},
+      })
+   );
+
+   auto filtered_plan = Planner::planSaneqlQuery(
+      "tables().filter(tableName='backup')",
+      database.tables,
+      QueryOptions{},
+      "filtered_tables_query"
+   );
+   ASSERT_EQ(
+      rhydb::test::executeQueryToJsonArray(filtered_plan),
+      nlohmann::json::array({
+         {{"tableName", "backup"}},
+      })
+   );
+}

--- a/src/rhydb/query_engine/operators/tables_node.test.cpp
+++ b/src/rhydb/query_engine/operators/tables_node.test.cpp
@@ -1,5 +1,6 @@
 #include <map>
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
@@ -126,4 +127,12 @@ TEST(TablesNodeMultiTableTest, listsAndFiltersMultipleTables) {
          {{"tableName", "backup"}},
       })
    );
+}
+
+TEST(TablesNodeMultiTableTest, listsNoTablesForEmptyDatabase) {
+   Database database;
+
+   auto query_plan =
+      Planner::planSaneqlQuery("tables()", database.tables, QueryOptions{}, "empty_tables_query");
+   ASSERT_EQ(rhydb::test::executeQueryToJsonArray(query_plan), nlohmann::json::array());
 }

--- a/src/rhydb/query_engine/saneql/ast_to_query.cpp
+++ b/src/rhydb/query_engine/saneql/ast_to_query.cpp
@@ -26,6 +26,7 @@
 #include "rhydb/query_engine/operators/project_node.h"
 #include "rhydb/query_engine/operators/schema_node.h"
 #include "rhydb/query_engine/operators/table_scan_node.h"
+#include "rhydb/query_engine/operators/tables_node.h"
 #include "rhydb/query_engine/operators/transitive_closure_node.h"
 #include "rhydb/query_engine/operators/union_all_node.h"
 #include "rhydb/query_engine/operators/unresolved_insertions_node.h"
@@ -1041,6 +1042,14 @@ operators::QueryNodePtr handleSchema(
    return std::make_unique<operators::SchemaNode>(std::move(child));
 }
 
+operators::QueryNodePtr handleTables(
+   const BoundArguments& /*args*/,
+   const Tables& /*tables*/,
+   const ChildConverter& /*convert_child*/
+) {
+   return std::make_unique<operators::TablesNode>();
+}
+
 // NOLINTNEXTLINE(misc-no-recursion)
 operators::QueryNodePtr handleGroupBy(
    const BoundArguments& args,
@@ -1634,6 +1643,8 @@ FunctionRegistry::FunctionRegistry() {
    registerFunction("filter", {{pos("input"), pos("predicate")}}, handleFilter);
 
    registerFunction("schema", {{pos("input")}}, handleSchema);
+
+   registerFunction("tables", {{}}, handleTables);
 
    registerFunction(
       "groupBy", {{pos("input"), pos("aggregates"), pos("columns", false)}}, handleGroupBy


### PR DESCRIPTION
resolves #1460

### Summary
Adds a SaneQL `tables()` function that returns the names of all tables in the database, one row per table.

It is a source function (takes no input, not chained onto a table). The result is a single-column relation ordered alphabetically by table name, so operators like `project`, `orderBy` and `limit` can be chained after it.

```
tables()
→ {"tableName": "default"}
```

## PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted or there is an issue to do so.
- [x] The implemented feature is covered by an appropriate test.
